### PR TITLE
[ 機能追加 ] Shift+Enter で改行を送信できる機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+- [ 機能追加 ] Shift+Enter で改行を送信できる機能を追加（Claude Code の keybindings.json 対応）
+
 ## 1.1.0
 
 - [ 機能追加 ] 起動時に新バージョン（git タグ）があるか確認し、あれば自動で `git pull` して再起動を促す機能を追加

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-terminals",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "複数ターミナルを並べて表示するデスクトップアプリ",
   "main": "main.js",
   "scripts": {

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -94,12 +94,22 @@ async function createTerminal(paneId, cwd) {
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
 
+  // 共通の入力送信ヘルパー（waiting バッジのクリアを含む）
+  function sendTerminalInput(data) {
+    ipcRenderer.send('terminal:input', termId, data);
+    if (terminals[paneId]?.waiting) {
+      terminals[paneId].waiting = false;
+      terminals[paneId].lastLines = '';
+      updatePaneStatus(paneId);
+    }
+  }
+
   // Shift+Enter を改行として送信（Claude Code の keybindings.json 対応）
   term.attachCustomKeyEventHandler((ev) => {
     if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
       if (ev.type === 'keydown') {
         // CSI u エンコーディングで Shift+Enter を送信
-        ipcRenderer.send('terminal:input', termId, '\x1b[13;2u');
+        sendTerminalInput('\x1b[13;2u');
       }
       return false; // keydown / keypress 両方でデフォルト処理を抑止
     }
@@ -112,13 +122,7 @@ async function createTerminal(paneId, cwd) {
 
   // Input: terminal -> pty
   term.onData((data) => {
-    ipcRenderer.send('terminal:input', termId, data);
-    // Clear waiting on any keystroke
-    if (terminals[paneId]?.waiting) {
-      terminals[paneId].waiting = false;
-      terminals[paneId].lastLines = '';
-      updatePaneStatus(paneId);
-    }
+    sendTerminalInput(data);
   });
 
   const shortCwd = formatCwd(initialCwd);

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -94,6 +94,18 @@ async function createTerminal(paneId, cwd) {
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
 
+  // Shift+Enter を改行として送信（Claude Code の keybindings.json 対応）
+  term.attachCustomKeyEventHandler((ev) => {
+    if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+      if (ev.type === 'keydown') {
+        // CSI u エンコーディングで Shift+Enter を送信
+        ipcRenderer.send('terminal:input', termId, '\x1b[13;2u');
+      }
+      return false; // keydown / keypress 両方でデフォルト処理を抑止
+    }
+    return true;
+  });
+
   const element = document.createElement('div');
   element.className = 'term-viewport';
   // NOTE: term.open(element) is called later, after element is attached to DOM


### PR DESCRIPTION
## 概要

- Shift+Enter を押した際に CSI u エンコーディング（`\x1b[13;2u`）で改行を送信する機能を追加
- Claude Code の keybindings.json で Shift+Enter を改行に設定している場合に対応

## 確認手順

### 前提条件
- Claude Code の `~/.claude/keybindings.json` で Shift+Enter が改行に設定されていること

### 手順
1. `npm start` でアプリを起動する
2. いずれかのターミナルペインで Claude Code を起動する（`claude` コマンド）
3. プロンプト入力欄で Shift+Enter を押す
   → ✓ 改行が入力される（送信されない）
4. Enter を押す
   → ✓ 通常通り送信される
5. Shift+Enter を使わずに通常のコマンド（例: `ls`）を入力して Enter を押す
   → ✓ 既存の動作に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift+Enter で改行を送信できるようになりました。Claude Code のキーバインド設定に対応しています。

* **Chores**
  * パッケージバージョンを 1.2.0 に更新しました。

* **Documentation**
  * バージョン 1.2.0 用のチェンジログ項目を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->