### PR TITLE
[ 仕様変更 ] claude-terminals → vk-terminals にリネーム

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-- [ 機能追加 ] 各ターミナルの状態を `~/.claude/terminal-states.json` に定期書き出しする機能を追加
+- [ 仕様変更 ] アプリ名を claude-terminals から vk-terminals に変更
+- [ 仕様変更 ] 設定・データディレクトリを `~/.vk-terminals/` に変更（旧パス `~/.claude/terminals-config.json` も後方互換で読み込み）
+- [ 機能追加 ] 各ターミナルの状態を `~/.vk-terminals/states.json` に定期書き出しする機能を追加
 - [ 機能追加 ] ローカル HTTP API（port 13847）を追加し、外部からターミナルの状態取得・コマンド送信が可能に
 
 ## 1.3.0
@@ -15,4 +17,4 @@
 - [ デザイン不具合修正 ] ボタンのサイズ・文字サイズ・色を調整
 
 ## 1.0.0
-- [ 機能追加 ] 起動時に自動実行するコマンドをユーザー設定ファイル（`~/.claude/terminals-config.json` または `config.json`）で指定できる機能を追加
+- [ 機能追加 ] 起動時に自動実行するコマンドをユーザー設定ファイル（`~/.vk-terminals/config.json` または `config.json`）で指定できる機能を追加

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-terminals
+# vk-terminals
 
 複数のターミナルを並べて表示できる Electron 製デスクトップアプリです。
 起動すると自動的に `claude` コマンドが実行されます。
@@ -56,7 +56,7 @@ npm start
 
 設定ファイルを以下のいずれかのパスに配置してください（上が優先）：
 
-1. `~/.claude/terminals-config.json` — ユーザー固有設定（推奨）
+1. `~/.vk-terminals/config.json` — ユーザー固有設定（推奨）
 2. `config.json`（リポジトリ直下）— ローカル設定（`.gitignore` 対象）
 
 `config.example.json` をコピーして編集してください：
@@ -64,10 +64,11 @@ npm start
 ```bash
 cp config.example.json config.json
 # または
-cp config.example.json ~/.claude/terminals-config.json
+mkdir -p ~/.vk-terminals
+cp config.example.json ~/.vk-terminals/config.json
 ```
 
-設定例（`config.json` / `~/.claude/terminals-config.json`）：
+設定例：
 
 ```json
 {
@@ -76,6 +77,8 @@ cp config.example.json ~/.claude/terminals-config.json
 ```
 
 `initialCommand` を省略または空にすると、自動実行は行われません。
+
+> **移行メモ**: 旧パス `~/.claude/terminals-config.json` も後方互換として読み込まれます。
 
 ## HTTP API（外部連携用）
 
@@ -145,7 +148,7 @@ curl -s -X POST http://127.0.0.1:13847/api/send \
 
 ### 状態ファイル
 
-`~/.claude-terminals/states.json` に2秒ごとに全ターミナルの状態が書き出されます。HTTP API と同じ内容です。アプリ終了時に自動削除されます。
+`~/.vk-terminals/states.json` に2秒ごとに全ターミナルの状態が書き出されます。HTTP API と同じ内容です。アプリ終了時に自動削除されます。
 
 ## 技術スタック
 

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ let firstTerminalCreated = false;
 const API_PORT = 13847;
 const DATA_DIR = path.join(os.homedir(), '.vk-terminals');
 const STATE_FILE = path.join(DATA_DIR, 'states.json');
+const LOG_PREFIX = '[vk-terminals]';
 let cachedStates = {};  // renderer から受け取った状態キャッシュ
 let httpServer = null;
 
@@ -43,7 +44,7 @@ function loadUserConfig() {
         const raw = fs.readFileSync(configPath, 'utf8');
         return JSON.parse(raw);
       } catch (e) {
-        console.error(`[vk-terminals] Failed to parse config: ${configPath}`, e);
+        console.error(`${LOG_PREFIX} Failed to parse config: ${configPath}`, e);
       }
     }
   }
@@ -103,7 +104,7 @@ async function checkAndUpdate() {
       'git', ['status', '--porcelain'], opts
     );
     if (statusOut.trim().length > 0) {
-      console.warn('[vk-terminals] Working tree is dirty, skipping pull.');
+      console.warn(`${LOG_PREFIX} Working tree is dirty, skipping pull.`);
       return;
     }
 
@@ -127,7 +128,7 @@ async function checkAndUpdate() {
     }
   } catch (e) {
     // ネットワーク不通などは無視
-    console.error('[vk-terminals] Update check failed:', e.message);
+    console.error(`${LOG_PREFIX} Update check failed:`, e.message);
   }
 }
 
@@ -326,14 +327,14 @@ function startHttpApi() {
   });
 
   httpServer.listen(API_PORT, '127.0.0.1', () => {
-    console.log(`[vk-terminals] API server listening on http://127.0.0.1:${API_PORT}`);
+    console.log(`${LOG_PREFIX} API server listening on http://127.0.0.1:${API_PORT}`);
   });
 
   httpServer.on('error', (e) => {
     if (e.code === 'EADDRINUSE') {
-      console.warn(`[vk-terminals] Port ${API_PORT} in use, API server disabled.`);
+      console.warn(`${LOG_PREFIX} Port ${API_PORT} in use, API server disabled.`);
     } else {
-      console.error('[vk-terminals] API server error:', e);
+      console.error(`${LOG_PREFIX} API server error:`, e);
     }
   });
 }

--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ let firstTerminalCreated = false;
 
 // ─── Terminal state & HTTP API ───────────────────────────────────────────────
 const API_PORT = 13847;
-const DATA_DIR = path.join(os.homedir(), '.claude-terminals');
+const DATA_DIR = path.join(os.homedir(), '.vk-terminals');
 const STATE_FILE = path.join(DATA_DIR, 'states.json');
 let cachedStates = {};  // renderer から受け取った状態キャッシュ
 let httpServer = null;
@@ -23,16 +23,18 @@ let httpServer = null;
 /**
  * ユーザー設定を読み込む。
  * 読み込み順:
- *   1. ~/.claude/terminals-config.json（ユーザー固有設定）
+ *   1. ~/.vk-terminals/config.json（ユーザー固有設定）
  *   2. {appDir}/config.json（リポジトリローカル設定）
+ *   3. ~/.claude/terminals-config.json（後方互換）
  * どちらも存在しない場合は空オブジェクトを返す。
  *
  * @returns {{ initialCommand?: string }} 設定オブジェクト
  */
 function loadUserConfig() {
   const candidates = [
-    path.join(os.homedir(), '.claude', 'terminals-config.json'),
+    path.join(DATA_DIR, 'config.json'),
     path.join(__dirname, 'config.json'),
+    path.join(os.homedir(), '.claude', 'terminals-config.json'), // 後方互換
   ];
 
   for (const configPath of candidates) {
@@ -41,7 +43,7 @@ function loadUserConfig() {
         const raw = fs.readFileSync(configPath, 'utf8');
         return JSON.parse(raw);
       } catch (e) {
-        console.error(`[claude-terminals] Failed to parse config: ${configPath}`, e);
+        console.error(`[vk-terminals] Failed to parse config: ${configPath}`, e);
       }
     }
   }
@@ -101,7 +103,7 @@ async function checkAndUpdate() {
       'git', ['status', '--porcelain'], opts
     );
     if (statusOut.trim().length > 0) {
-      console.warn('[claude-terminals] Working tree is dirty, skipping pull.');
+      console.warn('[vk-terminals] Working tree is dirty, skipping pull.');
       return;
     }
 
@@ -111,7 +113,7 @@ async function checkAndUpdate() {
     const { response } = await dialog.showMessageBox({
       type: 'info',
       title: 'アップデート完了',
-      message: `Terminals を ${currentTag} → ${latestTag} に更新しました。`,
+      message: `VK Terminals を ${currentTag} → ${latestTag} に更新しました。`,
       detail: '変更を反映するにはアプリを再起動してください。',
       buttons: ['今すぐ再起動', 'あとで'],
       defaultId: 0,
@@ -125,7 +127,7 @@ async function checkAndUpdate() {
     }
   } catch (e) {
     // ネットワーク不通などは無視
-    console.error('[claude-terminals] Update check failed:', e.message);
+    console.error('[vk-terminals] Update check failed:', e.message);
   }
 }
 
@@ -150,7 +152,7 @@ function createWindow() {
     titleBarStyle: 'hiddenInset',
     trafficLightPosition: { x: 16, y: 12 },
     backgroundColor: '#0d1117',
-    title: 'Terminals',
+    title: 'VK Terminals',
   });
 
   win.loadFile('renderer/index.html');
@@ -184,7 +186,7 @@ ipcMain.handle('terminal:create', (event, cwd) => {
     cols: 80,
     rows: 24,
     cwd: resolvedCwd,
-    env: { ...process.env, TERM_PROGRAM: 'ClaudeTerminals' },
+    env: { ...process.env, TERM_PROGRAM: 'VKTerminals' },
   });
 
   ptyProcess.onData((data) => {
@@ -324,14 +326,14 @@ function startHttpApi() {
   });
 
   httpServer.listen(API_PORT, '127.0.0.1', () => {
-    console.log(`[claude-terminals] API server listening on http://127.0.0.1:${API_PORT}`);
+    console.log(`[vk-terminals] API server listening on http://127.0.0.1:${API_PORT}`);
   });
 
   httpServer.on('error', (e) => {
     if (e.code === 'EADDRINUSE') {
-      console.warn(`[claude-terminals] Port ${API_PORT} in use, API server disabled.`);
+      console.warn(`[vk-terminals] Port ${API_PORT} in use, API server disabled.`);
     } else {
-      console.error('[claude-terminals] API server error:', e);
+      console.error('[vk-terminals] API server error:', e);
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-terminals",
+  "name": "vk-terminals",
   "version": "1.3.0",
   "description": "複数ターミナルを並べて表示するデスクトップアプリ",
   "main": "main.js",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -2,13 +2,13 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>Terminals</title>
+  <title>VK Terminals</title>
   <link rel="stylesheet" href="../node_modules/@xterm/xterm/css/xterm.css">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="titlebar">
-    <span class="app-title">Terminals</span>
+    <span class="app-title">VK Terminals</span>
   </div>
   <div id="root"></div>
   <script src="app.js"></script>


### PR DESCRIPTION
## 概要

- アプリ名を `claude-terminals` から `vk-terminals` に変更
- 設定・データディレクトリを `~/.vk-terminals/` に統一
- 旧設定パス `~/.claude/terminals-config.json` は後方互換として引き続き読み込み

## 背景

アプリ自体は Claude に依存しておらず、名称が誤解を招く。また macOS の Terminal.app との混同も避けるため、Vektor 製であることが明確な `vk-terminals` に変更。

## 変更一覧

| 対象 | Before | After |
|---|---|---|
| package.json name | `claude-terminals` | `vk-terminals` |
| ウィンドウタイトル | `Terminals` | `VK Terminals` |
| TERM_PROGRAM | `ClaudeTerminals` | `VKTerminals` |
| ログプレフィックス | `[claude-terminals]` | `[vk-terminals]` |
| ユーザー設定 | `~/.claude/terminals-config.json` | `~/.vk-terminals/config.json` |
| データディレクトリ | `~/.claude-terminals/` | `~/.vk-terminals/` |

## 確認手順

### 前提条件
- `npm install` 済み

### 手順

1. `npm start` でアプリを起動する
   → ✓ ウィンドウタイトルが「VK Terminals」になっている
   → ✓ タイトルバーに「VK Terminals」と表示されている
2. コンソール出力を確認する
   → ✓ ログプレフィックスが `[vk-terminals]` になっている
3. `ls ~/.vk-terminals/` を確認する
   → ✓ `states.json` が作成されている
4. `~/.vk-terminals/config.json` に `{"initialCommand": "echo test"}` を配置して再起動する
   → ✓ 設定が読み込まれる
5. 手順4のファイルを削除し、`~/.claude/terminals-config.json`（旧パス）に同内容を配置して再起動する
   → ✓ 後方互換で設定が読み込まれる
6. `curl -s http://127.0.0.1:13847/api/health` を実行する
   → ✓ `{"ok":true}` が返る（HTTP API は変更なく動作）

### デグレ確認

1. ペインの分割・閉じる・リサイズが正常に動作すること
2. 待機検出（⚠ 待機中バッジ）が従来通り機能すること

## 備考

このPRマージ後、GitHub リポジトリ名を `vektor-inc/claude-terminals` → `vektor-inc/vk-terminals` に変更予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * アプリ名を「claude-terminals」から「vk-terminals」に変更しました
  * 実行時表示（ウィンドウタイトル、ログ等）とパッケージ名を新名称に更新しました
* **Documentation**
  * ユーザ設定/状態の推奨ディレクトリを`~/.vk-terminals/`に更新（既存の`~/.claude/terminals-config.json`は後方互換で読み取り継続）
  * 定期保存される状態ファイルのパス表記を更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->