### PR TITLE
[ 不具合修正 ] initialCommand の送信タイミング検知と信頼確認プロンプト対応を改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 不具合修正 ] Claude の初期化が 4 秒以内に終わらない場合に initialCommand（起動時自動実行コマンド）が無視されてしまう不具合を、Claude のプロンプト（`? for shortcuts`）検知方式に変更して修正
+- [ 不具合修正 ] 新規ディレクトリで起動した際の信頼確認プロンプト（`Do you trust the files in this folder?`）で待機して initialCommand が送信されない不具合を修正（Enter を自動送信して承認）
 - [ 仕様変更 ] アプリ名を claude-terminals から vk-terminals に変更
 - [ 仕様変更 ] 設定・データディレクトリを `~/.vk-terminals/` に変更（旧パス `~/.claude/terminals-config.json` も後方互換で読み込み）
 - [ 機能追加 ] 各ターミナルの状態を `~/.vk-terminals/states.json` に定期書き出しする機能を追加

--- a/main.js
+++ b/main.js
@@ -231,8 +231,10 @@ ipcMain.handle('terminal:create', (event, cwd) => {
       promptWatcher = (data) => {
         if (sent) return;
         // ANSI エスケープ（CSI / OSC）を除去してから末尾 4KB だけ保持
+        // 標準 CSI: ESC[ + パラメータ(0x30-0x3F) + 中間バイト(0x20-0x2F) + 最終バイト(0x40-0x7E)
+        // 英字終端に限定すると ESC[1~ のような非英字終端が残るため最終バイト全体を許容する
         const stripped = data
-          .replace(/\x1b\[[\d;?]*[a-zA-Z]/g, '')
+          .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
           .replace(/\x1b\]\d+;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
         buffer = (buffer + stripped).slice(-4096);
 

--- a/main.js
+++ b/main.js
@@ -190,7 +190,78 @@ ipcMain.handle('terminal:create', (event, cwd) => {
     env: { ...process.env, TERM_PROGRAM: 'VKTerminals' },
   });
 
+  // initialCommand 送信用のプロンプト検知フック（最初の 1 ターミナルのみ）
+  const shouldWatchForPrompt = !firstTerminalCreated;
+  let promptWatcher = null;
+  if (shouldWatchForPrompt) {
+    firstTerminalCreated = true;
+    const config = loadUserConfig();
+    if (config.initialCommand) {
+      let sent = false;
+      let trustHandled = false;
+      let buffer = '';
+      // Claude Code が入力受付状態になったことを検知するパターン
+      // バージョンにより文言が揺れるため複数表現に対応
+      const READY_PATTERN = /\?\s*for\s*shortcuts|\?\s*to\s*show\s*shortcuts|for\s*shortcuts|Welcome to Claude|Try\s*["']?\/help|Bypass(ing)?\s*Permissions|accept edits|cwd:/i;
+      // 新規ディレクトリで起動した際の信頼確認プロンプト（デフォルトで Yes が選択されているので Enter で承認）
+      // Claude Code のバージョンによって文言が揺れるため、複数表現に対応
+      // 例: "Do you trust the files in this folder?" / "Do you trust this folder?" / 選択肢の "Yes, I trust this folder"
+      const TRUST_PATTERN = /Do you trust.{0,40}folder|Yes,\s*I\s*trust\s*(the\s*files\s*in\s*)?this\s*folder/i;
+      // Claude の起動には通常 2〜4 秒程度。READY_PATTERN が検知できなくてもフォールバック送信する
+      const WATCH_TIMEOUT_MS = 10000;
+
+      const sendInitialCommand = (reason) => {
+        if (sent) return;
+        sent = true;
+        if (ptys.has(id)) {
+          ptyProcess.write(config.initialCommand + '\r');
+          console.log(`${LOG_PREFIX} initialCommand sent (${reason})`);
+        }
+      };
+
+      let timeoutId = setTimeout(() => {
+        if (!sent) {
+          console.warn(`${LOG_PREFIX} Claude ready prompt not detected within ${WATCH_TIMEOUT_MS}ms, sending initialCommand as fallback`);
+          sendInitialCommand('timeout fallback');
+        }
+      }, WATCH_TIMEOUT_MS);
+
+      promptWatcher = (data) => {
+        if (sent) return;
+        // ANSI エスケープ（CSI / OSC）を除去してから末尾 4KB だけ保持
+        const stripped = data
+          .replace(/\x1b\[[\d;?]*[a-zA-Z]/g, '')
+          .replace(/\x1b\]\d+;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+        buffer = (buffer + stripped).slice(-4096);
+
+        // 信頼確認プロンプトが出ていたら Enter を送って承認（1回だけ）
+        if (!trustHandled && TRUST_PATTERN.test(buffer)) {
+          trustHandled = true;
+          buffer = '';
+          if (ptys.has(id)) {
+            ptyProcess.write('\r');
+          }
+          // 信頼承認後は Claude の起動に時間がかかるため、タイムアウトをリセット
+          clearTimeout(timeoutId);
+          timeoutId = setTimeout(() => {
+            if (!sent) {
+              console.warn(`${LOG_PREFIX} Claude ready prompt not detected after trust confirmation, sending initialCommand as fallback`);
+              sendInitialCommand('timeout fallback after trust');
+            }
+          }, WATCH_TIMEOUT_MS);
+          return;
+        }
+
+        if (READY_PATTERN.test(buffer)) {
+          clearTimeout(timeoutId);
+          sendInitialCommand('ready detected');
+        }
+      };
+    }
+  }
+
   ptyProcess.onData((data) => {
+    if (promptWatcher) promptWatcher(data);
     if (win && !win.isDestroyed()) {
       win.webContents.send('terminal:data', id, data);
     }
@@ -211,19 +282,6 @@ ipcMain.handle('terminal:create', (event, cwd) => {
       ptyProcess.write('claude\r');
     }
   }, 200);
-
-  // 起動後に initialCommand を実行する（最初の1回のみ）
-  if (!firstTerminalCreated) {
-    firstTerminalCreated = true;
-    const config = loadUserConfig();
-    if (config.initialCommand) {
-      setTimeout(() => {
-        if (ptys.has(id)) {
-          ptyProcess.write(config.initialCommand + '\r');
-        }
-      }, 4000);
-    }
-  }
 
   return { id, cwd: resolvedCwd };
 });

--- a/main.js
+++ b/main.js
@@ -193,6 +193,8 @@ ipcMain.handle('terminal:create', (event, cwd) => {
   // initialCommand 送信用のプロンプト検知フック（最初の 1 ターミナルのみ）
   const shouldWatchForPrompt = !firstTerminalCreated;
   let promptWatcher = null;
+  // ターミナル終了時にクリアできるよう、タイムアウト ID を外側スコープで保持する
+  let promptWatcherTimeoutId = null;
   if (shouldWatchForPrompt) {
     firstTerminalCreated = true;
     const config = loadUserConfig();
@@ -202,7 +204,7 @@ ipcMain.handle('terminal:create', (event, cwd) => {
       let buffer = '';
       // Claude Code が入力受付状態になったことを検知するパターン
       // バージョンにより文言が揺れるため複数表現に対応
-      const READY_PATTERN = /\?\s*for\s*shortcuts|\?\s*to\s*show\s*shortcuts|for\s*shortcuts|Welcome to Claude|Try\s*["']?\/help|Bypass(ing)?\s*Permissions|accept edits|cwd:/i;
+      const READY_PATTERN = /\?\s*for\s*shortcuts|\?\s*to\s*show\s*shortcuts|for\s*shortcuts|Welcome to Claude|Try\s*["']?\/help|Bypass(ing)?\s*Permissions|accept edits/i;
       // 新規ディレクトリで起動した際の信頼確認プロンプト（デフォルトで Yes が選択されているので Enter で承認）
       // Claude Code のバージョンによって文言が揺れるため、複数表現に対応
       // 例: "Do you trust the files in this folder?" / "Do you trust this folder?" / 選択肢の "Yes, I trust this folder"
@@ -219,7 +221,7 @@ ipcMain.handle('terminal:create', (event, cwd) => {
         }
       };
 
-      let timeoutId = setTimeout(() => {
+      promptWatcherTimeoutId = setTimeout(() => {
         if (!sent) {
           console.warn(`${LOG_PREFIX} Claude ready prompt not detected within ${WATCH_TIMEOUT_MS}ms, sending initialCommand as fallback`);
           sendInitialCommand('timeout fallback');
@@ -242,8 +244,8 @@ ipcMain.handle('terminal:create', (event, cwd) => {
             ptyProcess.write('\r');
           }
           // 信頼承認後は Claude の起動に時間がかかるため、タイムアウトをリセット
-          clearTimeout(timeoutId);
-          timeoutId = setTimeout(() => {
+          clearTimeout(promptWatcherTimeoutId);
+          promptWatcherTimeoutId = setTimeout(() => {
             if (!sent) {
               console.warn(`${LOG_PREFIX} Claude ready prompt not detected after trust confirmation, sending initialCommand as fallback`);
               sendInitialCommand('timeout fallback after trust');
@@ -253,7 +255,8 @@ ipcMain.handle('terminal:create', (event, cwd) => {
         }
 
         if (READY_PATTERN.test(buffer)) {
-          clearTimeout(timeoutId);
+          clearTimeout(promptWatcherTimeoutId);
+          promptWatcherTimeoutId = null;
           sendInitialCommand('ready detected');
         }
       };
@@ -268,6 +271,11 @@ ipcMain.handle('terminal:create', (event, cwd) => {
   });
 
   ptyProcess.onExit(() => {
+    // ターミナル終了時に未発火のタイムアウトが残らないようクリアする
+    if (promptWatcherTimeoutId) {
+      clearTimeout(promptWatcherTimeoutId);
+      promptWatcherTimeoutId = null;
+    }
     ptys.delete(id);
     if (win && !win.isDestroyed()) {
       win.webContents.send('terminal:exit', id);


### PR DESCRIPTION
## 概要

`config.json` の `initialCommand`（起動時自動実行コマンド）が送信されない、または送信されるまで時間がかかる不具合を修正します。

### 変更内容

- **4 秒固定タイマー → プロンプト検知方式に変更**
  - Claude の初期化が 4 秒以内に終わらない環境で initialCommand が無視されてしまう問題を解消
  - Claude Code の入力受付状態（`? for shortcuts` 等）を検知してから送信
- **信頼確認プロンプト（`Do you trust the files in this folder?`）の自動承認**
  - 新規ディレクトリで起動した際に待機してしまう問題を解消
  - デフォルトで「Yes」が選択されているため Enter を自動送信
- **文言揺れへの対応**
  - Claude Code のバージョン差を吸収するため、READY/TRUST の検知パターンを複数表現に対応（例: `Yes, I trust this folder` / `Do you trust this folder?` / `Welcome to Claude` など）
- **タイムアウトフォールバックの追加**
  - 検知できない場合でも 10 秒後に initialCommand を送信
  - 信頼承認後は起動待ちのためタイムアウトをリセット

## 確認手順

### 前提条件

- `~/.vk-terminals/config.json` または `{appDir}/config.json` に `initialCommand` が設定されていること（例: `{"initialCommand": "スキルでタスク管理を呼び出して"}`）
- Claude Code CLI がインストールされていること

### 手順

#### Before（修正前の再現手順）

1. VK Terminals を起動する（`npm start`）
2. 新規ディレクトリで最初のターミナルを開く
3. 信頼確認プロンプト（`Do you trust the files in this folder?`）が表示される
   → ✗ プロンプトで止まり、`initialCommand` が送信されない

#### After（修正後の確認手順）

1. VK Terminals を起動する（`npm start`）
2. 最初のターミナルが自動で開き、`claude` コマンドが実行される
   → ✓ Claude Code の起動画面が表示される
3. 信頼確認プロンプトが表示された場合、自動で Enter が送信される
   → ✓ 自動承認されて Claude の入力画面に遷移する
4. Claude の入力画面になったら `initialCommand`（例: `スキルでタスク管理を呼び出して`）が自動入力・送信される
   → ✓ 設定されたコマンドがプロンプトに入力され、実行される
5. 2 つ目以降のターミナルを開く
   → ✓ `initialCommand` は送信されない（最初の 1 ターミナルのみ）
6. `config.json` に `initialCommand` を設定しないで起動する
   → ✓ タイマー・フォールバックとも作動せず、通常通り Claude が起動するだけ

### 備考

- 既存の 2 件の未リリース changelog（プロンプト検知方式への変更 / 信頼確認プロンプト対応）は本 PR にまとめて含まれます。
- フォールバックは 10 秒（信頼承認後はさらに 10 秒）です。READY_PATTERN が検知できない Claude Code のバージョンでもここで送信されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 起動時の自動実行コマンド(initialCommand)が確実に送信されるよう、初期化完了の検知を改善しました（プロンプト検知に基づく送信に変更、タイムアウト時のフォールバック含む）。
  * 新規ディレクトリ起動時に表示される信頼確認プロンプトで待機してしまう問題を修正し、承認（Enter）が自動送信されるようにしました。
* **ドキュメント**
  * 変更点をCHANGELOGに追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->