### PR TITLE
[ 機能追加 ] HTTP API に新規ペイン作成エンドポイント (/api/new-pane) を追加 ＋ 信頼確認・waiting 判定の不具合修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 不具合修正 ] 2 つ目以降のターミナルで信頼確認プロンプトが自動承認されず待機状態のままになる不具合を修正（Claude Code の新 UI 文言 "Enter to confirm" にも対応）
+- [ 不具合修正 ] Claude Code フッターの "bypass permissions on" 表示によってターミナルが入力待ち状態として誤判定される不具合を修正
 - [ 機能追加 ] HTTP API に `POST /api/new-pane` エンドポイントを追加（新規ペインを作成して termId を返す）
 - [ 不具合修正 ] Claude の初期化が 4 秒以内に終わらない場合に initialCommand（起動時自動実行コマンド）が無視されてしまう不具合を、Claude のプロンプト（`? for shortcuts`）検知方式に変更して修正
 - [ 不具合修正 ] 新規ディレクトリで起動した際の信頼確認プロンプト（`Do you trust the files in this folder?`）で待機して initialCommand が送信されない不具合を修正（Enter を自動送信して承認）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] HTTP API に `POST /api/new-pane` エンドポイントを追加（新規ペインを作成して termId を返す）
 - [ 不具合修正 ] Claude の初期化が 4 秒以内に終わらない場合に initialCommand（起動時自動実行コマンド）が無視されてしまう不具合を、Claude のプロンプト（`? for shortcuts`）検知方式に変更して修正
 - [ 不具合修正 ] 新規ディレクトリで起動した際の信頼確認プロンプト（`Do you trust the files in this folder?`）で待機して initialCommand が送信されない不具合を修正（Enter を自動送信して承認）
 - [ 仕様変更 ] アプリ名を claude-terminals から vk-terminals に変更

--- a/README.md
+++ b/README.md
@@ -146,6 +146,21 @@ curl -s -X POST http://127.0.0.1:13847/api/send \
 
 送信成功時、対象ペインに「🤖 自動入力」バッジが3秒間表示されます。
 
+#### `POST /api/new-pane`
+
+新規ペインを作成し、作成されたターミナルの `termId` を返します。フォーカス中のペインを水平分割して新規ペインを生成します。
+
+```bash
+curl -s -X POST http://127.0.0.1:13847/api/new-pane
+# => {"ok":true,"termId":"3"}
+```
+
+レスポンス:
+
+- 成功時: `{"ok": true, "termId": "<新規ターミナルID>"}`
+- ウィンドウが利用できない: `503 {"error": "window not available"}`
+- タイムアウト（15秒）: `504 {"error": "timeout waiting for new pane"}`
+
 ### 状態ファイル
 
 `~/.vk-terminals/states.json` に2秒ごとに全ターミナルの状態が書き出されます。HTTP API と同じ内容です。アプリ終了時に自動削除されます。

--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ curl -s -X POST http://127.0.0.1:13847/api/new-pane
 
 レスポンス:
 
-- 成功時: `{"ok": true, "termId": "<新規ターミナルID>"}`
+- 成功時: `200 {"ok": true, "termId": "<新規ターミナルID>"}`
 - ウィンドウが利用できない: `503 {"error": "window not available"}`
 - タイムアウト（15秒）: `504 {"error": "timeout waiting for new pane"}`
+- renderer 側でペイン作成に失敗（既存ペインなし／分割失敗など）: `500 {"error": "<renderer からのエラーメッセージ>"}`
 
 ### 状態ファイル
 

--- a/main.js
+++ b/main.js
@@ -193,62 +193,67 @@ ipcMain.handle('terminal:create', (event, cwd) => {
     env: { ...process.env, TERM_PROGRAM: 'VKTerminals' },
   });
 
-  // initialCommand 送信用のプロンプト検知フック（最初の 1 ターミナルのみ）
-  const shouldWatchForPrompt = !firstTerminalCreated;
+  // initialCommand は最初の 1 ターミナルのみ送信
+  const isFirstTerminal = !firstTerminalCreated;
+  if (isFirstTerminal) firstTerminalCreated = true;
+
   let promptWatcher = null;
-  // ターミナル終了時にクリアできるよう、タイムアウト ID を外側スコープで保持する
   let promptWatcherTimeoutId = null;
-  if (shouldWatchForPrompt) {
-    firstTerminalCreated = true;
-    const config = loadUserConfig();
-    if (config.initialCommand) {
-      let sent = false;
-      let trustHandled = false;
-      let buffer = '';
-      // Claude Code が入力受付状態になったことを検知するパターン
-      // バージョンにより文言が揺れるため複数表現に対応
-      const READY_PATTERN = /\?\s*for\s*shortcuts|\?\s*to\s*show\s*shortcuts|for\s*shortcuts|Welcome to Claude|Try\s*["']?\/help|Bypass(ing)?\s*Permissions|accept edits/i;
-      // 新規ディレクトリで起動した際の信頼確認プロンプト（デフォルトで Yes が選択されているので Enter で承認）
-      // Claude Code のバージョンによって文言が揺れるため、複数表現に対応
-      // 例: "Do you trust the files in this folder?" / "Do you trust this folder?" / 選択肢の "Yes, I trust this folder"
-      const TRUST_PATTERN = /Do you trust.{0,40}folder|Yes,\s*I\s*trust\s*(the\s*files\s*in\s*)?this\s*folder/i;
-      // Claude の起動には通常 2〜4 秒程度。READY_PATTERN が検知できなくてもフォールバック送信する
-      const WATCH_TIMEOUT_MS = 10000;
 
-      const sendInitialCommand = (reason) => {
-        if (sent) return;
-        sent = true;
-        if (ptys.has(id)) {
-          ptyProcess.write(config.initialCommand + '\r');
-          console.log(`${LOG_PREFIX} initialCommand sent (${reason})`);
-        }
-      };
+  // ANSI エスケープを除去するユーティリティ
+  const stripAnsi = (data) => data
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1b\]\d+;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
 
+  // 信頼確認プロンプトの検知パターン（全ターミナル共通）
+  // 「Enter to confirm」が出た時点でメニュー描画済みなので、そこで \r を送る
+  // 旧UI: "Do you trust the files in this folder?" / "Yes, I trust this folder"
+  // 新UI: "Quick safety check..." → "Enter to confirm · Esc to cancel"
+  const TRUST_PATTERN = /Enter to confirm|Do you trust.{0,40}folder|Yes,\s*I\s*trust\s*(the\s*files\s*in\s*)?this\s*folder/i;
+
+  // Claude Code が入力受付状態になったことを検知するパターン
+  const READY_PATTERN = /\?\s*for\s*shortcuts|\?\s*to\s*show\s*shortcuts|for\s*shortcuts|Welcome to Claude|Try\s*["']?\/help|Bypass(ing)?\s*Permissions|accept edits/i;
+
+  const WATCH_TIMEOUT_MS = 10000;
+
+  {
+    const config = isFirstTerminal ? loadUserConfig() : {};
+    let sent = false;
+    let trustHandled = false;
+    let buffer = '';
+
+    const sendInitialCommand = (reason) => {
+      if (sent || !config.initialCommand) return;
+      sent = true;
+      if (ptys.has(id)) {
+        ptyProcess.write(config.initialCommand + '\r');
+        console.log(`${LOG_PREFIX} initialCommand sent (${reason})`);
+      }
+    };
+
+    if (isFirstTerminal && config.initialCommand) {
       promptWatcherTimeoutId = setTimeout(() => {
         if (!sent) {
           console.warn(`${LOG_PREFIX} Claude ready prompt not detected within ${WATCH_TIMEOUT_MS}ms, sending initialCommand as fallback`);
           sendInitialCommand('timeout fallback');
         }
       }, WATCH_TIMEOUT_MS);
+    }
 
-      promptWatcher = (data) => {
-        if (sent) return;
-        // ANSI エスケープ（CSI / OSC）を除去してから末尾 4KB だけ保持
-        // 標準 CSI: ESC[ + パラメータ(0x30-0x3F) + 中間バイト(0x20-0x2F) + 最終バイト(0x40-0x7E)
-        // 英字終端に限定すると ESC[1~ のような非英字終端が残るため最終バイト全体を許容する
-        const stripped = data
-          .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
-          .replace(/\x1b\]\d+;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
-        buffer = (buffer + stripped).slice(-4096);
+    promptWatcher = (data) => {
+      const stripped = stripAnsi(data);
+      buffer = (buffer + stripped).slice(-4096);
 
-        // 信頼確認プロンプトが出ていたら Enter を送って承認（1回だけ）
-        if (!trustHandled && TRUST_PATTERN.test(buffer)) {
-          trustHandled = true;
-          buffer = '';
-          if (ptys.has(id)) {
-            ptyProcess.write('\r');
-          }
-          // 信頼承認後は Claude の起動に時間がかかるため、タイムアウトをリセット
+      // 信頼確認プロンプト → Enter で承認（全ターミナル共通）
+      if (!trustHandled && TRUST_PATTERN.test(buffer)) {
+        trustHandled = true;
+        buffer = '';
+        console.log(`${LOG_PREFIX} trust prompt detected, sending Enter (terminal ${id})`);
+        if (ptys.has(id)) {
+          ptyProcess.write('\r');
+        }
+        // 信頼承認後はタイムアウトをリセット（initialCommand 待ち継続）
+        if (isFirstTerminal && config.initialCommand && !sent) {
           clearTimeout(promptWatcherTimeoutId);
           promptWatcherTimeoutId = setTimeout(() => {
             if (!sent) {
@@ -256,16 +261,17 @@ ipcMain.handle('terminal:create', (event, cwd) => {
               sendInitialCommand('timeout fallback after trust');
             }
           }, WATCH_TIMEOUT_MS);
-          return;
         }
+        return;
+      }
 
-        if (READY_PATTERN.test(buffer)) {
-          clearTimeout(promptWatcherTimeoutId);
-          promptWatcherTimeoutId = null;
-          sendInitialCommand('ready detected');
-        }
-      };
-    }
+      // initialCommand 送信（最初のターミナルのみ）
+      if (isFirstTerminal && !sent && READY_PATTERN.test(buffer)) {
+        clearTimeout(promptWatcherTimeoutId);
+        promptWatcherTimeoutId = null;
+        sendInitialCommand('ready detected');
+      }
+    };
   }
 
   ptyProcess.onData((data) => {

--- a/main.js
+++ b/main.js
@@ -13,6 +13,9 @@ const ptys = new Map();
 let nextId = 1;
 let firstTerminalCreated = false;
 
+// /api/new-pane の HTTP レスポンスを待つコールバックキュー
+const pendingNewPaneCallbacks = [];
+
 // ─── Terminal state & HTTP API ───────────────────────────────────────────────
 const API_PORT = 13847;
 const DATA_DIR = path.join(os.homedir(), '.vk-terminals');
@@ -316,6 +319,12 @@ ipcMain.on('terminal:kill', (event, id) => {
   }
 });
 
+// renderer が新規ペインを作成し終えたら HTTP レスポンスを返す
+ipcMain.on('terminal:new-pane-created', (event, result) => {
+  const resolve = pendingNewPaneCallbacks.shift();
+  if (resolve) resolve(result);
+});
+
 // ─── State reporting from renderer ───────────────────────────────────────────
 // データディレクトリを確保
 fs.mkdirSync(DATA_DIR, { recursive: true });
@@ -387,6 +396,37 @@ function startHttpApi() {
           res.end(JSON.stringify({ error: 'invalid JSON' }));
         }
       });
+      return;
+    }
+
+    // POST /api/new-pane  — 新規ペインを作成して termId を返す
+    if (req.method === 'POST' && url.pathname === '/api/new-pane') {
+      if (!win || win.isDestroyed()) {
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'window not available' }));
+        return;
+      }
+      let resolve;
+      const timeoutId = setTimeout(() => {
+        const idx = pendingNewPaneCallbacks.indexOf(resolve);
+        if (idx !== -1) {
+          pendingNewPaneCallbacks.splice(idx, 1);
+          res.writeHead(504, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'timeout waiting for new pane' }));
+        }
+      }, 15000);
+      resolve = (result) => {
+        clearTimeout(timeoutId);
+        if (result.error) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: result.error }));
+        } else {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, termId: result.termId }));
+        }
+      };
+      pendingNewPaneCallbacks.push(resolve);
+      win.webContents.send('terminal:request-new-pane');
       return;
     }
 

--- a/main.js
+++ b/main.js
@@ -13,8 +13,10 @@ const ptys = new Map();
 let nextId = 1;
 let firstTerminalCreated = false;
 
-// /api/new-pane の HTTP レスポンスを待つコールバックキュー
-const pendingNewPaneCallbacks = [];
+// /api/new-pane の HTTP レスポンスを待つコールバック（requestId → resolver）
+// 並行リクエストでも取り違えが起きないように requestId で相関付ける
+const pendingNewPaneCallbacks = new Map();
+let nextNewPaneRequestId = 1;
 
 // ─── Terminal state & HTTP API ───────────────────────────────────────────────
 const API_PORT = 13847;
@@ -326,9 +328,13 @@ ipcMain.on('terminal:kill', (event, id) => {
 });
 
 // renderer が新規ペインを作成し終えたら HTTP レスポンスを返す
-ipcMain.on('terminal:new-pane-created', (event, result) => {
-  const resolve = pendingNewPaneCallbacks.shift();
-  if (resolve) resolve(result);
+ipcMain.on('terminal:new-pane-created', (event, payload = {}) => {
+  const { requestId, ...result } = payload;
+  if (!requestId) return;
+  const resolve = pendingNewPaneCallbacks.get(requestId);
+  if (!resolve) return;
+  pendingNewPaneCallbacks.delete(requestId);
+  resolve(result);
 });
 
 // ─── State reporting from renderer ───────────────────────────────────────────
@@ -412,16 +418,15 @@ function startHttpApi() {
         res.end(JSON.stringify({ error: 'window not available' }));
         return;
       }
-      let resolve;
+      const requestId = String(nextNewPaneRequestId++);
       const timeoutId = setTimeout(() => {
-        const idx = pendingNewPaneCallbacks.indexOf(resolve);
-        if (idx !== -1) {
-          pendingNewPaneCallbacks.splice(idx, 1);
+        if (pendingNewPaneCallbacks.has(requestId)) {
+          pendingNewPaneCallbacks.delete(requestId);
           res.writeHead(504, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'timeout waiting for new pane' }));
         }
       }, 15000);
-      resolve = (result) => {
+      const resolve = (result) => {
         clearTimeout(timeoutId);
         if (result.error) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -431,8 +436,8 @@ function startHttpApi() {
           res.end(JSON.stringify({ ok: true, termId: result.termId }));
         }
       };
-      pendingNewPaneCallbacks.push(resolve);
-      win.webContents.send('terminal:request-new-pane');
+      pendingNewPaneCallbacks.set(requestId, resolve);
+      win.webContents.send('terminal:request-new-pane', { requestId });
       return;
     }
 

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -594,18 +594,24 @@ setInterval(() => {
 }, 2000);
 
 // ─── New pane request from HTTP API ──────────────────────────────────────────
-ipcRenderer.on('terminal:request-new-pane', async () => {
+ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
+  const { requestId } = payload;
+  const reply = (result) => ipcRenderer.send('terminal:new-pane-created', { requestId, ...result });
   const targetPaneId = focusedPaneId || (tree ? getAllLeafIds(tree)[0] : null);
   if (!targetPaneId) {
-    ipcRenderer.send('terminal:new-pane-created', { error: 'no pane available' });
+    reply({ error: 'no pane available' });
     return;
   }
-  const result = await splitPane(targetPaneId, 'h');
-  if (!result || !result.termId) {
-    ipcRenderer.send('terminal:new-pane-created', { error: 'split failed or termId unavailable' });
-    return;
+  try {
+    const result = await splitPane(targetPaneId, 'h');
+    if (!result || !result.termId) {
+      reply({ error: 'split failed or termId unavailable' });
+      return;
+    }
+    reply({ termId: result.termId });
+  } catch (e) {
+    reply({ error: e?.message || 'failed to create pane' });
   }
-  ipcRenderer.send('terminal:new-pane-created', { termId: result.termId });
 });
 
 // ─── Auto-input notification from main (HTTP API経由の入力時) ─────────────────

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -590,6 +590,19 @@ setInterval(() => {
   ipcRenderer.send('terminal:report-states', states);
 }, 2000);
 
+// ─── New pane request from HTTP API ──────────────────────────────────────────
+ipcRenderer.on('terminal:request-new-pane', async () => {
+  const targetPaneId = focusedPaneId || (tree ? getAllLeafIds(tree)[0] : null);
+  if (!targetPaneId) {
+    ipcRenderer.send('terminal:new-pane-created', { error: 'no pane available' });
+    return;
+  }
+  await splitPane(targetPaneId, 'h');
+  // splitPane は新しいペインにフォーカスを移すので focusedPaneId が新ペイン
+  const termId = terminals[focusedPaneId]?.termId;
+  ipcRenderer.send('terminal:new-pane-created', { termId });
+});
+
 // ─── Auto-input notification from main (HTTP API経由の入力時) ─────────────────
 ipcRenderer.on('terminal:auto-input', (event, termId) => {
   const paneId = Object.keys(terminals).find(k => terminals[k]?.termId === termId);

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -51,7 +51,7 @@ const WAITING_PATTERNS = [
   /\[\s*A\s*\]llow/i,
   /\[\s*D\s*\]eny/i,
   /approve.*\(y\/n\)/i,
-  /permission/i,
+  // NOTE: /permission/i は削除 — Claude Code の UI フッター "bypass permissions on" に誤反応するため
 ];
 
 function stripAnsi(str) {
@@ -233,7 +233,7 @@ function getAllLeafIds(node) {
 // ─── Pane actions ─────────────────────────────────────────────────────────────
 async function splitPane(paneId, direction) {
   const node = findNode(tree, paneId);
-  if (!node) return;
+  if (!node) return null;
 
   const newPaneId = newId();
   // Inherit cwd from current pane if available
@@ -254,6 +254,9 @@ async function splitPane(paneId, direction) {
     fitTerminal(newPaneId);
     focusPane(newPaneId);
   });
+
+  // 新ペインの情報を返す（focusedPaneId の更新を待たずに確定値を返す）
+  return { paneId: newPaneId, termId: terminals[newPaneId]?.termId };
 }
 
 function closePane(paneId) {
@@ -597,10 +600,12 @@ ipcRenderer.on('terminal:request-new-pane', async () => {
     ipcRenderer.send('terminal:new-pane-created', { error: 'no pane available' });
     return;
   }
-  await splitPane(targetPaneId, 'h');
-  // splitPane は新しいペインにフォーカスを移すので focusedPaneId が新ペイン
-  const termId = terminals[focusedPaneId]?.termId;
-  ipcRenderer.send('terminal:new-pane-created', { termId });
+  const result = await splitPane(targetPaneId, 'h');
+  if (!result || !result.termId) {
+    ipcRenderer.send('terminal:new-pane-created', { error: 'split failed or termId unavailable' });
+    return;
+  }
+  ipcRenderer.send('terminal:new-pane-created', { termId: result.termId });
 });
 
 // ─── Auto-input notification from main (HTTP API経由の入力時) ─────────────────


### PR DESCRIPTION
## 概要

このPRは以下の3点をまとめて対応します。

### 1. HTTP API に `POST /api/new-pane` を追加（機能追加）

- 外部から新規ペインを作成して `termId` を取得できるエンドポイントを追加
- フォーカス中のペインを水平分割して新規ペインを生成し、作成された `termId` をレスポンスで返す
- ウィンドウが利用できない場合は `503`、15 秒以内に作成できなかった場合は `504` を返す
- `splitPane` が新規ペインの `{ paneId, termId }` を返すよう変更し、`focusedPaneId` の状態に依存せず確実に termId を返却できるように改善

これにより、外部スクリプトや Claude Code 連携から「新しいターミナルを開く → そのターミナルにコマンドを送る」という連続操作が可能になります。

### 2. 2つ目以降のターミナルでの信頼確認プロンプト自動承認を修正（不具合修正）

- 従来、信頼確認プロンプト（"Do you trust the files in this folder?"）の自動承認は **最初のターミナル & initialCommand 設定時のみ** 動作していたため、2 つ目以降のペインを開いた際は手動で Enter を押す必要があった
- 検知ロジックを全ターミナル共通に切り出し、initialCommand 未設定でも全ペインで自動承認されるように修正
- `TRUST_PATTERN` に `"Enter to confirm"` を追加し、Claude Code の新 UI（`Quick safety check...` → `Enter to confirm · Esc to cancel`）にも対応

### 3. waiting 状態の誤判定を修正（不具合修正）

- `WAITING_PATTERNS` から `/permission/i` を削除
- Claude Code のフッターに常時表示される `"bypass permissions on"` という文字列に誤反応し、ペインが常に「入力待ち（waiting）」として判定されてしまう不具合を解消

## 変更ファイル

- `main.js` — `/api/new-pane` エンドポイント追加、信頼確認プロンプト処理を全ターミナル共通に切り出し、TRUST_PATTERN 拡張
- `renderer/app.js` — `terminal:request-new-pane` IPC ハンドラ追加、`splitPane` の戻り値追加、`/permission/i` 除去
- `README.md` — `/api/new-pane` のドキュメントを追記
- `CHANGELOG.md` — 機能追加・不具合修正 3 項目を追記

## 確認手順

### 前提条件
- vk-terminals を起動した状態
- HTTP API がデフォルトポート `13847` で待ち受けている

### 手順1: `/api/new-pane` の動作確認

1. vk-terminals を起動する
2. 別ターミナルで以下を実行する
   \`\`\`bash
   curl -s -X POST http://127.0.0.1:13847/api/new-pane
   \`\`\`
   → ✓ レスポンスとして \`{\"ok\":true,\"termId\":\"<数字>\"}\` が返る
   → ✓ vk-terminals のウィンドウ上で、フォーカス中のペインが水平分割されて新規ペインが作成される
3. 返ってきた \`termId\` を使ってコマンドを送信する
   \`\`\`bash
   curl -s -X POST http://127.0.0.1:13847/api/send \\
     -H 'Content-Type: application/json' \\
     -d '{\"termId\": \"<返ってきたID>\", \"input\": \"echo hello\\r\"}'
   \`\`\`
   → ✓ 新規作成されたペインに \`echo hello\` が入力・実行される
4. \`curl -s http://127.0.0.1:13847/api/states | python3 -m json.tool\` を実行する
   → ✓ 新規ペインが \`terminals\` に含まれている

### 手順2: 信頼確認プロンプトの自動承認（全ターミナル）

#### Before（修正前の挙動）
1. まだ開いた事のないディレクトリで新規ペインを開く（2 つ目以降のペイン、または initialCommand 未設定）
2. Claude Code を起動する
   → ✗ "Do you trust the files in this folder?" もしくは "Enter to confirm · Esc to cancel" で待機したまま、自動で Enter が送信されない

#### After（修正後）
1. まだ開いた事のないディレクトリで 1 つ目のペインを開き、Claude Code を起動する
   → ✓ 信頼確認プロンプトに対して自動で Enter が送信され、Claude Code が起動する
2. **続けて 2 つ目以降のペインを別の新規ディレクトリで開く**
   → ✓ こちらも自動で Enter が送信される（従来は手動 Enter が必要だった）
3. 新 UI（"Quick safety check..." → "Enter to confirm · Esc to cancel"）が出るバージョンの Claude Code でも同様に確認する
   → ✓ 自動承認される
4. 既に信頼済みのディレクトリで Claude Code を起動する
   → ✓ プロンプトが出ないので何も送信されない（デグレ確認）

### 手順3: waiting 誤判定の修正確認

#### Before（修正前の挙動）
1. ペインで Claude Code を起動し、入力待ちでない状態で放置する（フッターに "bypass permissions on" が表示されている状態）
   → ✗ タブ／ペインが常に「入力待ち（waiting）」表示になる

#### After（修正後）
1. ペインで Claude Code を起動し、入力待ちでない状態で放置する
   → ✓ waiting 表示にならない
2. Claude Code が実際に権限確認プロンプト（`[Y]es` / `[N]o` 等）を出した状態にする
   → ✓ waiting 表示になる（既存パターンによる検知は引き続き動作）
3. \`curl -s http://127.0.0.1:13847/api/states\` を実行して \`waiting\` フィールドの値を確認する
   → ✓ 通常時 \`false\`、プロンプト時 \`true\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 新しいHTTP APIエンドポイント POST /api/new-pane を追加。新しいターミナルペインを作成し、成功時に termId を返します。

* **バグ修正**
  * trust/confirmation プロンプトの自動承認が次の端末で動作しない問題を修正（追加表記も考慮）。
  * Claude Code のフッター表記による「待機」誤検出を改善。

* **ドキュメント**
  * README に API の挙動とエラーケース（ウィンドウ利用不可/タイムアウト/レンダー側失敗など）を追記。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/11)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->