### PR TITLE
[ 仕様変更 ] HTTP API 経由で開く新規ペインを縦横バランスよくグリッド状に配置

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 仕様変更 ] HTTP API（`POST /api/new-pane`）経由で新規ペインを作成する際、対象ペインの長辺方向に分割するよう変更（横にだけ広がらず、縦横バランスよくグリッド状に増える挙動に）
 - [ 不具合修正 ] 2 つ目以降のターミナルで信頼確認プロンプトが自動承認されず待機状態のままになる不具合を修正（Claude Code の新 UI 文言 "Enter to confirm" にも対応）
 - [ 不具合修正 ] Claude Code フッターの "bypass permissions on" 表示によってターミナルが入力待ち状態として誤判定される不具合を修正
 - [ 機能追加 ] HTTP API に `POST /api/new-pane` エンドポイントを追加（新規ペインを作成して termId を返す）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -603,7 +603,11 @@ ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
     return;
   }
   try {
-    const result = await splitPane(targetPaneId, 'h');
+    // 対象ペインの長辺方向に分割することで、横にだけ広がらずグリッド状に増える
+    const paneEl = document.querySelector(`.pane[data-id="${targetPaneId}"]`);
+    const rect = paneEl?.getBoundingClientRect();
+    const direction = (rect && rect.height > rect.width) ? 'v' : 'h';
+    const result = await splitPane(targetPaneId, direction);
     if (!result || !result.termId) {
       reply({ error: 'split failed or termId unavailable' });
       return;


### PR DESCRIPTION
## 概要

外部 HTTP API（`POST /api/new-pane`）経由で新規ペインを開く際、これまでは常に横分割（`splitPane(targetPaneId, 'h')` のハードコード）だったため、task-queue などから連続して開くとペインが右へ右へとだけ広がり、横幅が極端に狭くなる問題がありました。

対象ペインの現在の幅・高さを `getBoundingClientRect()` で取得し、「長辺方向」に分割するよう変更しました。これにより、

- 横長のペインなら縦に切る
- 縦長のペインなら横に切る

を繰り返すため、外部から連続でペインを追加しても自然にグリッド状に配置されます。

## 変更内容

- `renderer/app.js`: HTTP API 経由の `terminal:request-new-pane` ハンドラで、対象ペインの DOM 矩形を見て `direction` を `'h' / 'v'` から自動選択
- 手動操作（キーバインド等）の `splitPane` 呼び出しには影響なし

## 確認手順

### 前提条件
- vk-terminals を起動済み（`npm start`）

### 手順

#### Before（修正前の挙動）
1. ペインが 1 つの状態で `curl -X POST http://127.0.0.1:13847/api/new-pane` を 3 回連続で叩く
   → ✗ ペインが横方向にだけ 4 つ並び、各ペインの横幅が狭くなる

#### After（修正後）
1. ペインが 1 つの状態で `curl -X POST http://127.0.0.1:13847/api/new-pane` を実行
   → ✓ 2 ペインが左右に並ぶ（横分割）
2. もう 1 回 `curl -X POST http://127.0.0.1:13847/api/new-pane` を実行
   → ✓ フォーカス側のペインが上下に分割される（縦分割。横長だった状態から長辺＝横が切られて縦方向に分かれる）
3. さらに `curl -X POST http://127.0.0.1:13847/api/new-pane` を 2〜3 回実行
   → ✓ 2×2、3×2 のようにグリッド状に増えていき、特定方向だけに広がらない
4. 手動操作（既存のペイン分割キーバインド）で h / v の分割を行う
   → ✓ 従来通り、指定した方向に分割される（手動操作には影響していないこと）

## 補足

- 表示挙動の変更ですが、各ペインの初期状態（width × height）に応じた自動判定なので、Before / After のスクリーンショットは「連続でペインを追加した時の最終的なレイアウト」で比較すると分かりやすいです。必要であれば追ってスクリーンショットを添付します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 新しいペインの作成時に、ペインのアスペクト比に基づいて分割方向を自動選択するようになりました。これにより、水平・垂直方向のバランスが取れたグリッドレイアウトが実現されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/13)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->