### PR TITLE
[ 機能追加 ] ペインヘッダに上下左右の移動ボタンを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] ペインヘッダに上下左右の移動ボタン（◀ ▼ ▲ ▶）を追加。クリックで該当方向にある隣接ペインと位置を入れ替え（PTY セッションは維持・termId 紐付けも変わらない）
 - [ 機能追加 ] 起動時 CLI フラグ `--no-claude`（`--plain` も同義）を追加。指定すると新規ペインで claude を自動起動せず素のシェルとして開く（`initialCommand` も送信しない）。`additionalPanes` 設定で個別に `noClaude: true` も指定可能
 - [ 機能追加 ] HTTP API（`POST /api/new-pane`）のリクエストボディで `noClaude: true` を指定できるように変更（指定された場合、新規ペインで claude を自動起動せず素のシェルとして開く）
 - [ 機能追加 ] HTTP API（`POST /api/new-pane`）のリクエストボディで `cwd` を指定できるように変更（指定があればそのディレクトリ、未指定ならホームディレクトリで新規ペインを開く）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -275,6 +275,12 @@ function findNeighborPane(fromPaneId, dir) {
       (dir === 'up'    && r.bottom <= fromRect.top   + 1) ||
       (dir === 'down'  && r.top    >= fromRect.bottom - 1);
     if (!inDir) continue;
+    // 直交軸でオーバーラップしているペインのみを隣接候補とする（対角線上の非隣接ペイン除外）
+    const orthOverlap =
+      (dir === 'left' || dir === 'right')
+        ? (r.top < fromRect.bottom && r.bottom > fromRect.top)
+        : (r.left < fromRect.right && r.right > fromRect.left);
+    if (!orthOverlap) continue;
     const dist = Math.hypot(cx - fromCx, cy - fromCy);
     if (dist < bestDist) {
       bestDist = dist;

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -262,28 +262,35 @@ function findNeighborPane(fromPaneId, dir) {
   const fromCx = fromRect.left + fromRect.width / 2;
   const fromCy = fromRect.top + fromRect.height / 2;
   let best = null;
-  let bestDist = Infinity;
+  // 主軸ギャップ（共有辺への近さ）を最優先、同値なら直交軸の中心ずれが小さい方を選ぶ
+  let bestGap = Infinity;
+  let bestCross = Infinity;
   for (const id of getAllLeafIds(tree)) {
     if (id === fromPaneId) continue;
     const r = getPaneRect(id);
     if (!r) continue;
     const cx = r.left + r.width / 2;
     const cy = r.top + r.height / 2;
-    const inDir =
-      (dir === 'left'  && r.right  <= fromRect.left  + 1) ||
-      (dir === 'right' && r.left   >= fromRect.right - 1) ||
-      (dir === 'up'    && r.bottom <= fromRect.top   + 1) ||
-      (dir === 'down'  && r.top    >= fromRect.bottom - 1);
-    if (!inDir) continue;
+    // dir 方向の主軸ギャップ（候補の手前辺と fromRect の対辺の隙間）
+    const axisGap =
+      dir === 'left'  ? fromRect.left - r.right  :
+      dir === 'right' ? r.left - fromRect.right  :
+      dir === 'up'    ? fromRect.top - r.bottom  :
+                        r.top - fromRect.bottom;
+    // 候補が dir 方向側に存在しない（手前 or 重なっている）場合は除外
+    if (axisGap < -1) continue;
     // 直交軸でオーバーラップしているペインのみを隣接候補とする（対角線上の非隣接ペイン除外）
     const orthOverlap =
       (dir === 'left' || dir === 'right')
         ? (r.top < fromRect.bottom && r.bottom > fromRect.top)
         : (r.left < fromRect.right && r.right > fromRect.left);
     if (!orthOverlap) continue;
-    const dist = Math.hypot(cx - fromCx, cy - fromCy);
-    if (dist < bestDist) {
-      bestDist = dist;
+    const cross = (dir === 'left' || dir === 'right')
+      ? Math.abs(cy - fromCy)
+      : Math.abs(cx - fromCx);
+    if (axisGap < bestGap || (axisGap === bestGap && cross < bestCross)) {
+      bestGap = axisGap;
+      bestCross = cross;
       best = id;
     }
   }

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -227,6 +227,21 @@ function removeNode(node, id) {
   return { ...node, first: newFirst, second: newSecond };
 }
 
+// tree 内の leaf 2つの「位置」を入れ替える（leaf.id 文字列をスワップすることで等価に実現）。
+// terminals マップは paneId キーのまま不変なので、HTTP API / states.json の termId 紐付けには影響しない。
+function swapLeavesInTree(node, idA, idB) {
+  if (node.type === 'leaf') {
+    if (node.id === idA) return { type: 'leaf', id: idB };
+    if (node.id === idB) return { type: 'leaf', id: idA };
+    return node;
+  }
+  return {
+    ...node,
+    first: swapLeavesInTree(node.first, idA, idB),
+    second: swapLeavesInTree(node.second, idA, idB),
+  };
+}
+
 function getAllLeafIds(node) {
   if (node.type === 'leaf') return [node.id];
   return [...getAllLeafIds(node.first), ...getAllLeafIds(node.second)];
@@ -237,6 +252,36 @@ function getPaneRect(paneId) {
   const rect = paneEl?.getBoundingClientRect();
   if (!rect || rect.width <= 0 || rect.height <= 0) return null;
   return rect;
+}
+
+// フォーカスペインから方向 dir にある最も近い隣接ペインを座標ベースで探す。
+// 無ければ null。dir は 'left' | 'right' | 'up' | 'down'。
+function findNeighborPane(fromPaneId, dir) {
+  const fromRect = getPaneRect(fromPaneId);
+  if (!fromRect) return null;
+  const fromCx = fromRect.left + fromRect.width / 2;
+  const fromCy = fromRect.top + fromRect.height / 2;
+  let best = null;
+  let bestDist = Infinity;
+  for (const id of getAllLeafIds(tree)) {
+    if (id === fromPaneId) continue;
+    const r = getPaneRect(id);
+    if (!r) continue;
+    const cx = r.left + r.width / 2;
+    const cy = r.top + r.height / 2;
+    const inDir =
+      (dir === 'left'  && r.right  <= fromRect.left  + 1) ||
+      (dir === 'right' && r.left   >= fromRect.right - 1) ||
+      (dir === 'up'    && r.bottom <= fromRect.top   + 1) ||
+      (dir === 'down'  && r.top    >= fromRect.bottom - 1);
+    if (!inDir) continue;
+    const dist = Math.hypot(cx - fromCx, cy - fromCy);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = id;
+    }
+  }
+  return best;
 }
 
 function findLargestVisiblePaneId() {
@@ -318,6 +363,18 @@ function closePane(paneId) {
   requestAnimationFrame(fitAll);
 }
 
+// ペインを方向 dir の隣接ペインと入れ替える。隣が無ければ何もしない。
+function movePane(paneId, dir) {
+  const target = findNeighborPane(paneId, dir);
+  if (!target) return;
+  tree = swapLeavesInTree(tree, paneId, target);
+  render();
+  requestAnimationFrame(() => {
+    fitAll();
+    focusPane(paneId);
+  });
+}
+
 function focusPane(paneId) {
   focusedPaneId = paneId;
   document.querySelectorAll('.pane').forEach(el => {
@@ -386,6 +443,10 @@ function renderLeaf(node) {
     <div class="pane-actions">
       <span class="auto-input-badge" style="display:none"></span>
       <span class="waiting-badge" style="display:${waiting ? 'flex' : 'none'}">⚠ 待機中</span>
+      <button class="btn btn-move btn-move-left" title="左へ移動">◀</button>
+      <button class="btn btn-move btn-move-down" title="下へ移動">▼</button>
+      <button class="btn btn-move btn-move-up" title="上へ移動">▲</button>
+      <button class="btn btn-move btn-move-right" title="右へ移動">▶</button>
       <button class="btn btn-split-h" title="左右に分割">⇔</button>
       <button class="btn btn-split-v" title="上下に分割">⇕</button>
       <button class="btn btn-close" title="閉じる">✕</button>
@@ -400,6 +461,22 @@ function renderLeaf(node) {
   el.appendChild(header);
   el.appendChild(termContainer);
 
+  header.querySelector('.btn-move-left').addEventListener('click', e => {
+    e.stopPropagation();
+    movePane(node.id, 'left');
+  });
+  header.querySelector('.btn-move-right').addEventListener('click', e => {
+    e.stopPropagation();
+    movePane(node.id, 'right');
+  });
+  header.querySelector('.btn-move-up').addEventListener('click', e => {
+    e.stopPropagation();
+    movePane(node.id, 'up');
+  });
+  header.querySelector('.btn-move-down').addEventListener('click', e => {
+    e.stopPropagation();
+    movePane(node.id, 'down');
+  });
   header.querySelector('.btn-split-h').addEventListener('click', e => {
     e.stopPropagation();
     splitPane(node.id, 'h');


### PR DESCRIPTION
## 概要

各ペインヘッダに **上下左右の移動ボタン（◀ ▼ ▲ ▶）** を追加しました。クリックすると、その方向にある隣接ペインと位置を入れ替えます。

PTY セッションは維持されたままで `termId` 紐付けも変わらないため、HTTP API（`/api/send` など）の宛先や `states.json` の紐付けに影響しません。

## 変更内容

- `renderer/app.js`
  - `swapLeavesInTree(node, idA, idB)` を追加し、ツリー上の 2 leaf の位置（id 文字列）をスワップ
  - `findNeighborPane(fromPaneId, dir)` を追加し、座標ベース（中心点の距離）で `left` / `right` / `up` / `down` の最近接ペインを探索
  - `movePane(paneId, dir)` を追加し、隣接ペインと位置を入れ替えてフォーカスを維持
  - `renderLeaf` のヘッダに `.btn-move-{left,down,up,right}` ボタンを追加・クリックハンドラを登録
- `CHANGELOG.md` に該当エントリを追記

設計上のポイント:

- ターミナルマップ（`terminals` Map）は `paneId` キーのまま不変。**ツリー側の leaf.id だけを入れ替える**ことで、見た目（DOM 上の位置）と PTY セッションを切り離して移動を実現しています。
- `findNeighborPane` は分割ツリー構造に依存しない座標ベース判定。複雑にネストした分割（横分割の中の縦分割など）でも、画面上で本当に「右にある」ペインを直感通りに選びます。

## 確認手順

### 前提条件
- vk-terminals アプリを起動できる状態

### 手順

#### 基本動作（左右の入れ替え）
1. アプリを起動し、ペインを左右に 2 分割する（ヘッダの ⇔ ボタン）
2. 左ペインのヘッダにある **▶ ボタン** をクリック
   → ✓ 左ペインと右ペインの位置が入れ替わる
3. 左ペインで実行中だったプロセス（claude や `top` など）が右側に移動しても**そのまま継続している**ことを確認
   → ✓ PTY セッションが切れていない（再起動されない）

#### 上下の入れ替え
4. 右ペインを上下に分割（⇕ ボタン）し、3 ペイン構成にする
5. 上段ペインの **▼ ボタン** をクリック
   → ✓ 上段と下段が入れ替わる

#### 隣接ペインが無い場合
6. 一番左のペインの **◀ ボタン** をクリック
   → ✓ 何も起きない（エラーにもならない）

#### HTTP API 紐付けが壊れないことの確認
7. ペインを 2 枚開いた状態で、片方の `termId` を確認（`curl -s http://127.0.0.1:13847/api/terminals`）
8. その `termId` を控えた状態で、移動ボタンでペインを入れ替える
9. 控えた `termId` 宛に `POST /api/send` でコマンドを送る
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/send \
     -H 'Content-Type: application/json' \
     -d '{"termId":"<控えた termId>","text":"echo moved\n"}'
   ```
   → ✓ 元々その `termId` だったペイン（移動後の位置）にコマンドが届く

#### デグレ確認
10. 既存の分割（⇔ / ⇕）、閉じる（✕）、フォーカス切替が従来通り動くことを確認
    → ✓ デグレなし

## スクリーンショット

ヘッダボタンの追加 UI 変更のため、必要であれば Before / After を追加してください（純粋な追加で既存表示には影響しません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ペインヘッダーに方向移動ボタン（◀ ▼ ▲ ▶）を追加。クリックで隣接ペインと位置を入れ替えられます。
  * 端末のセッション/IDの紐付けは維持され、画面の再描画・端末のリサイズ・フォーカスが適切に更新されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/18)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->