### PR TITLE
[ 機能追加 ] 各ペイン上部にタスクタイトル行を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] 各ペイン上部に「タスクタイトル行」を追加。OSC 0 / OSC 2 のターミナルタイトル変更（例: `printf '\033]0;ビルド中\007'`）と HTTP API（`POST /api/set-title { termId, title }`）の両方から設定可能。空のときはタイトル行を非表示にして xterm 表示領域を圧迫しない
 - [ 機能追加 ] ペインヘッダに上下左右の移動ボタン（◀ ▼ ▲ ▶）を追加。クリックで該当方向にある隣接ペインと位置を入れ替え（PTY セッションは維持・termId 紐付けも変わらない）
 - [ 機能追加 ] 起動時 CLI フラグ `--no-claude`（`--plain` も同義）を追加。指定すると新規ペインで claude を自動起動せず素のシェルとして開く（`initialCommand` も送信しない）。`additionalPanes` 設定で個別に `noClaude: true` も指定可能
 - [ 機能追加 ] HTTP API（`POST /api/new-pane`）のリクエストボディで `noClaude: true` を指定できるように変更（指定された場合、新規ペインで claude を自動起動せず素のシェルとして開く）

--- a/main.js
+++ b/main.js
@@ -469,6 +469,50 @@ function startHttpApi() {
       return;
     }
 
+    // POST /api/set-title  { termId: "1", title: "タスク名" } — ペイン上部のタスクタイトル行に表示する文字列を設定
+    //   空文字や null を指定するとタイトル行を非表示に戻す。
+    if (req.method === 'POST' && url.pathname === '/api/set-title') {
+      const MAX_BODY = 10 * 1024;
+      let body = '';
+      let aborted = false;
+      req.on('data', chunk => {
+        body += chunk;
+        if (body.length > MAX_BODY) {
+          aborted = true;
+          res.writeHead(413, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'payload too large' }));
+          req.destroy();
+        }
+      });
+      req.on('end', () => {
+        if (aborted) return;
+        try {
+          const parsed = JSON.parse(body);
+          const termId = parsed?.termId != null ? String(parsed.termId) : '';
+          if (!termId) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'termId required' }));
+            return;
+          }
+          if (!ptys.has(termId)) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: `terminal ${termId} not found` }));
+            return;
+          }
+          const title = typeof parsed?.title === 'string' ? parsed.title : '';
+          if (win && !win.isDestroyed()) {
+            win.webContents.send('terminal:title', termId, title);
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, termId, title }));
+        } catch (e) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid JSON' }));
+        }
+      });
+      return;
+    }
+
     // POST /api/new-pane  { cwd?: "/path/to/dir", noClaude?: boolean } — 新規ペインを作成して termId を返す
     //   cwd を指定すればそのディレクトリで開く。未指定なら HOME で開く。
     //   noClaude: true を指定すると、新規ペインで claude を自動起動せず素のシェルとして開く。

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -96,6 +96,15 @@ async function createTerminal(paneId, cwd, options = {}) {
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
 
+  // OSC 0 / OSC 2 のタイトル変更を購読してペイン上部のタスクタイトル行に反映する。
+  // 例: `printf '\033]0;ビルド中\007'` をシェルで実行すると "ビルド中" がここに表示される。
+  term.onTitleChange((title) => {
+    const t = terminals[paneId];
+    if (!t) return;
+    t.taskTitle = title || '';
+    updatePaneTitle(paneId);
+  });
+
   // 共通の入力送信ヘルパー（waiting バッジのクリアを含む）
   function sendTerminalInput(data) {
     ipcRenderer.send('terminal:input', termId, data);
@@ -144,6 +153,7 @@ async function createTerminal(paneId, cwd, options = {}) {
     lastLines: '',
     lastOutputTime: Date.now(),
     lastInputTime: 0,
+    taskTitle: '',
   };
 
   return paneId;
@@ -191,6 +201,17 @@ ipcRenderer.on('terminal:exit', (event, id) => {
 function updatePaneCwd(paneId, cwd) {
   const el = document.querySelector(`.pane[data-id="${paneId}"] .pane-cwd`);
   if (el) el.textContent = cwd;
+}
+
+function updatePaneTitle(paneId) {
+  const t = terminals[paneId];
+  if (!t) return;
+  const el = document.querySelector(`.pane[data-id="${paneId}"] .pane-task-title`);
+  if (!el) return;
+  const title = t.taskTitle || '';
+  el.textContent = title;
+  el.title = title;
+  el.classList.toggle('empty', title.length === 0);
 }
 
 function updatePaneStatus(paneId) {
@@ -444,10 +465,19 @@ function renderLeaf(node) {
   const cwd = t?.cwd || '~';
   const waiting = t?.waiting || false;
   const focused = node.id === focusedPaneId;
+  const taskTitle = t?.taskTitle || '';
 
   const el = document.createElement('div');
   el.className = 'pane' + (focused ? ' focused' : '') + (waiting ? ' waiting' : '');
   el.dataset.id = node.id;
+
+  // タスクタイトル行（OSC 0/2 または POST /api/set-title で設定された文字列を表示）。
+  // 空のときは .empty クラスで非表示にし、xterm の表示領域を圧迫しない。
+  const taskTitleEl = document.createElement('div');
+  taskTitleEl.className = 'pane-task-title' + (taskTitle ? '' : ' empty');
+  taskTitleEl.textContent = taskTitle;
+  if (taskTitle) taskTitleEl.title = taskTitle;
+  el.appendChild(taskTitleEl);
 
   const header = document.createElement('div');
   header.className = 'pane-header';
@@ -712,6 +742,7 @@ setInterval(() => {
       lastOutputTime: t.lastOutputTime,
       lastInputTime: t.lastInputTime,
       lastLines: t.lastLines,
+      taskTitle: t.taskTitle || '',
     };
   }
   ipcRenderer.send('terminal:report-states', states);
@@ -740,6 +771,14 @@ ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
   } catch (e) {
     reply({ error: e?.message || 'failed to create pane' });
   }
+});
+
+// ─── Title update from main (HTTP API POST /api/set-title) ──────────────────
+ipcRenderer.on('terminal:title', (event, termId, title) => {
+  const paneId = Object.keys(terminals).find(k => terminals[k]?.termId === termId);
+  if (!paneId) return;
+  terminals[paneId].taskTitle = title || '';
+  updatePaneTitle(paneId);
 });
 
 // ─── Auto-input notification from main (HTTP API経由の入力時) ─────────────────

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -122,6 +122,33 @@ html, body {
   }
 }
 
+/* ─── Pane task title (上部固定のタスク表示行) ─────────────────────────────── */
+.pane-task-title {
+  display: flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 10px;
+  background: #1c2128;
+  border-bottom: 1px solid #21262d;
+  color: #adbac7;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.pane-task-title.empty {
+  display: none;
+}
+
+.pane.focused .pane-task-title {
+  color: #e6edf3;
+  background: #22282f;
+}
+
 /* ─── Pane header ──────────────────────────────────────────────────────────── */
 .pane-header {
   display: flex;


### PR DESCRIPTION
## Summary

- ペイン上部に「現在何のタスクをやっているか」を示すタイトル行を追加
- OSC 0 / OSC 2 のターミナルタイトル変更（例: `printf '\033]0;ビルド中\007'`）と HTTP API（`POST /api/set-title { termId, title }`）の両方から設定可能
- タイトルが空のときは行ごと非表示にして xterm の表示領域を圧迫しない

## 背景

ペインをたくさん開いたとき、それぞれのペインの中で何の作業をしているのか分かりにくくなる問題への対応。

確認した結果、Claude Code 自身が OSC 2 で現在のタスク内容（例: `"⠐ Call task management in skill"`）を自動的に出力しているため、追加設定なしでも各ペインで Claude が動いている作業内容がタイトル行に自動表示される。

外部（task-queue など）からも `POST /api/set-title` でタイトルを上書きできるため、issue タイトルなど任意の文字列に差し替えることも可能。

## 使い方

\`\`\`bash
# ペイン内のシェルから直接（標準的）
printf '\033]0;vk-blocks-pro: build 修正\007'

# 外部スクリプト / 他ターミナルから（HTTP API）
curl -X POST http://127.0.0.1:13847/api/set-title \\
  -H 'Content-Type: application/json' \\
  -d '{\"termId\":\"1\",\"title\":\"vk-blocks-pro: build 修正\"}'

# クリア
printf '\033]0;\007'
\`\`\`

## 実装メモ

- \`main.js\`: \`POST /api/set-title\` を追加。受信した title を renderer に IPC (\`terminal:title\`) で転送
- \`renderer/app.js\`:
  - xterm.js の \`onTitleChange\` を購読し OSC 由来の変更を捕捉
  - HTTP API 経由の IPC も同じハンドラに合流させ、\`terminals[paneId].taskTitle\` に格納
  - \`renderLeaf\` で \`.pane-task-title\` を \`.pane-header\` の上に挿入
  - states.json レポートにも taskTitle を含める
- \`renderer/style.css\`: \`.pane-task-title\` のスタイル定義（22px、省略表示、focus 時に色変化）

## Test plan

- [ ] \`npm start\` で起動し、ペイン上部にタイトル行が表示されることを確認
- [ ] Claude Code が動いているペインで作業内容がタイトル行に自動表示される（OSC 2 経由）
- [ ] \`printf '\\033]0;テスト\\007'\` を実行してタイトル行が "テスト" になる
- [ ] \`curl -X POST http://127.0.0.1:13847/api/set-title -d '{\"termId\":\"1\",\"title\":\"hello\"}'\` でタイトルが "hello" になる
- [ ] \`printf '\\033]0;\\007'\` でタイトル行が消える（行ごと非表示）
- [ ] フォーカス切り替え時にタイトル文字色が変化する
- [ ] 長いタイトルが省略（\`...\`）表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**New Features**
* 各ペイン上部にタスクタイトル行を追加。ターミナルのタイトル変更に対応し、自動的に表示更新されます。
* タイトルが空の場合は非表示になり、ターミナル表示領域を効率的に活用できます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/21)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->