### PR TITLE
[ 不具合修正 ] /api/set-title のタイトルが OSC 0/2 で上書きされる不具合を修正

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -98,6 +98,8 @@ async function createTerminal(paneId, cwd, options = {}) {
 
   // OSC 0 / OSC 2 のタイトル変更を購読してペイン上部のタスクタイトル行に反映する。
   // 例: `printf '\033]0;ビルド中\007'` をシェルで実行すると "ビルド中" がここに表示される。
+  // ここで書き込むのは OSC 由来の taskTitle のみ。API（POST /api/set-title）由来の
+  // apiTitle が設定されている間はそちらが優先表示される（updatePaneTitle 参照）。
   term.onTitleChange((title) => {
     const t = terminals[paneId];
     if (!t) return;
@@ -153,7 +155,13 @@ async function createTerminal(paneId, cwd, options = {}) {
     lastLines: '',
     lastOutputTime: Date.now(),
     lastInputTime: 0,
+    // taskTitle: xterm の OSC 0/2 由来のタイトル（claude TUI 等が継続的に発行する）
+    // apiTitle:  HTTP API（POST /api/set-title）で明示的にセットされたタイトル
+    // 表示時は apiTitle を優先し、空のときに taskTitle へフォールバックする。
+    // これにより task-queue 等が指定した issue タイトルが OSC 由来の文字列で
+    // 上書きされなくなる（issue #22）。
     taskTitle: '',
+    apiTitle: '',
   };
 
   return paneId;
@@ -203,12 +211,20 @@ function updatePaneCwd(paneId, cwd) {
   if (el) el.textContent = cwd;
 }
 
+// API（POST /api/set-title）由来のタイトルを最優先で表示し、未設定なら OSC 0/2 由来の
+// taskTitle にフォールバックする。空文字を API に送れば apiTitle がクリアされ、OSC
+// タイトルがそのまま見えるようになる（後方互換）。
+function getDisplayTitle(t) {
+  if (!t) return '';
+  return t.apiTitle || t.taskTitle || '';
+}
+
 function updatePaneTitle(paneId) {
   const t = terminals[paneId];
   if (!t) return;
   const el = document.querySelector(`.pane[data-id="${paneId}"] .pane-task-title`);
   if (!el) return;
-  const title = t.taskTitle || '';
+  const title = getDisplayTitle(t);
   el.textContent = title;
   el.title = title;
   el.classList.toggle('empty', title.length === 0);
@@ -615,7 +631,8 @@ function renderLeaf(node, parentDirection) {
   const cwd = t?.cwd || '~';
   const waiting = t?.waiting || false;
   const focused = node.id === focusedPaneId;
-  const taskTitle = t?.taskTitle || '';
+  // apiTitle（API 由来）優先、無ければ taskTitle（OSC 由来）にフォールバック。
+  const taskTitle = getDisplayTitle(t);
   const collapsed = !!node.collapsed;
   // 親 split が split-v（上下分割）の場合のみ折り畳みボタンを表示する。
   // 親 split-h（横並び）の場合は折り畳むと縦のストリップになるが、今回はスコープ外。
@@ -942,7 +959,12 @@ setInterval(() => {
       lastOutputTime: t.lastOutputTime,
       lastInputTime: t.lastInputTime,
       lastLines: t.lastLines,
+      // taskTitle: OSC 0/2 由来のタイトル（後方互換のため既存キーを維持）
+      // apiTitle:  POST /api/set-title 由来のタイトル（issue #22 で分離）
+      // displayTitle: 実際にペイン上部に表示している値（apiTitle || taskTitle）
       taskTitle: t.taskTitle || '',
+      apiTitle: t.apiTitle || '',
+      displayTitle: getDisplayTitle(t),
       collapsed: !!(leaf && leaf.collapsed),
     };
   }
@@ -975,10 +997,13 @@ ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
 });
 
 // ─── Title update from main (HTTP API POST /api/set-title) ──────────────────
+// API 由来のタイトルは apiTitle に保存し、OSC 由来の taskTitle とは別フィールドで管理する。
+// これにより claude TUI が継続的に発行する OSC 0/2 で API 設定タイトルが上書きされない。
+// 空文字を送ると apiTitle がクリアされ、OSC 由来の taskTitle にフォールバックする。
 ipcRenderer.on('terminal:title', (event, termId, title) => {
   const paneId = Object.keys(terminals).find(k => terminals[k]?.termId === termId);
   if (!paneId) return;
-  terminals[paneId].taskTitle = title || '';
+  terminals[paneId].apiTitle = title || '';
   updatePaneTitle(paneId);
 });
 


### PR DESCRIPTION
## 概要

vk-terminals の HTTP API `POST /api/set-title` で設定したタスクタイトルが、xterm の `term.onTitleChange`（OSC 0/2）由来のタイトルで即座に上書きされてしまう不具合を修正します。

claude TUI はペイン起動直後から継続的に OSC 0/2 で `✳ Claude Code` や `⠂ <要約>` といった文字列を発行するため、`/api/set-title` で issue タイトル等をセットしても直後の OSC で消えてしまい、task-queue オーケストレーターから設定したタイトルがペインに反映されない状態でした。

Closes #22

## 修正方針

`renderer/app.js` で OSC 由来のタイトルと API 由来のタイトルを別フィールドに分離します。

- `taskTitle`: 従来通り OSC 0/2（`term.onTitleChange`）で書き込まれるタイトル
- `apiTitle`: `POST /api/set-title` 経由でのみ書き込まれるタイトル（新設）
- 表示時は `apiTitle || taskTitle` の優先順で出すため、API でセットした値が OSC で上書きされない
- `/api/set-title` に空文字を送ると `apiTitle` がクリアされ OSC 由来の `taskTitle` にフォールバック（後方互換）
- `~/.vk-terminals/states.json` への書き出しには `taskTitle`（既存キー維持）に加えて `apiTitle` と `displayTitle`（実際の表示値）を追加

## 変更ファイル

- `renderer/app.js`
  - `terminals[paneId]` に `apiTitle` フィールドを追加
  - `getDisplayTitle()` ヘルパを新設し `apiTitle || taskTitle` を返す
  - `updatePaneTitle()` / `renderLeaf()` の表示ロジックをヘルパ経由に統一
  - IPC `terminal:title` ハンドラの書き込み先を `taskTitle` → `apiTitle` に変更
  - `terminal:report-states` のペイロードに `apiTitle` / `displayTitle` を追加

`main.js` は renderer からの states をそのまま `states.json` に書き出す実装のため変更不要です。

## CHANGELOG について

「タスクタイトル機能」自体がまだ未リリース（`CHANGELOG.md` 冒頭のバージョン番号未付与セクションに含まれる）のため、vk-agents の [changelog ルール](https://github.com/vektor-inc/vk-agents/blob/main/rules/changelog.md)「未リリース機能の不具合修正は changelog 追記不要」に従って `CHANGELOG.md` は更新しません。

## 確認手順

### 前提条件

- vk-terminals がインストール済み（`npm install && npm start` でローカル起動）
- HTTP API ポート（デフォルト `13847`）が利用可能
- ペインで claude が起動済み（OSC 0/2 でタイトル発行する状態）

### 手順

#### Before（修正前の再現手順）

1. vk-terminals をローカル起動（旧バージョン）し、ペインで claude が立ち上がっていることを確認する
2. `~/.vk-terminals/states.json` を確認し、`pane-1` の `termId` を控える（例: `1`）
3. `curl -X POST http://127.0.0.1:13847/api/set-title -H 'Content-Type: application/json' -d '{\"termId\":\"1\",\"title\":\"#22 タイトル上書きバグ\"}'` を実行する
   → ✗ ペイン上部のタスクタイトル行が一瞬「#22 タイトル上書きバグ」になるが、直後に claude の OSC 0/2 出力（例: `✳ Claude Code`）で上書きされて消える
4. `cat ~/.vk-terminals/states.json | jq '.terminals[\"pane-1\"].taskTitle'` を確認する
   → ✗ `taskTitle` が OSC 由来の文字列になっており API でセットした値は残っていない

#### After（修正後の確認手順）

1. このブランチをチェックアウトし、`npm start` で起動する
2. ペインで claude が立ち上がり、OSC 0/2 由来のタイトル（例: `✳ Claude Code`）が表示されることを確認する
3. `curl -X POST http://127.0.0.1:13847/api/set-title -H 'Content-Type: application/json' -d '{\"termId\":\"1\",\"title\":\"#22 タイトル上書きバグ\"}'` を実行する
   → ✓ ペイン上部のタスクタイトル行が「#22 タイトル上書きバグ」になる
4. claude にプロンプトを投げて OSC 0/2 タイトルが新たに発行される状態にする（例: `何かタスクを依頼` してタイトルが変化する状況を作る）
   → ✓ ペイン上部の表示は「#22 タイトル上書きバグ」のまま変わらない（OSC で上書きされない）
5. `cat ~/.vk-terminals/states.json | jq '.terminals[\"pane-1\"] | {taskTitle, apiTitle, displayTitle}'` を確認する
   → ✓ `apiTitle` が `\"#22 タイトル上書きバグ\"`、`taskTitle` は OSC 由来の文字列、`displayTitle` は `apiTitle` の値になっている
6. `curl -X POST http://127.0.0.1:13847/api/set-title -H 'Content-Type: application/json' -d '{\"termId\":\"1\",\"title\":\"\"}'` で空文字を送る
   → ✓ ペイン上部の表示が OSC 由来の `taskTitle`（例: `✳ Claude Code`）にフォールバックする
   → ✓ `states.json` でも `apiTitle` が空、`displayTitle` が `taskTitle` と同じになる
7. ペインで `printf '\033]0;手動タイトル\007'` を実行する
   → ✓ `apiTitle` が空の状態では「手動タイトル」がペインに表示される（OSC 経路のデグレなし）

### デグレ確認

- `/api/set-title` を一度も呼ばない場合、従来通り OSC 0/2 でセットしたタイトル（`printf '\033]0;ビルド中\007'` 等）がペインに表示される
- 既存の `states.json` の `taskTitle` キーは互換のため残してあり、外部スクリプトが `taskTitle` を読んでいる場合でも壊れない

## スクリーンショット

純粋なロジック修正（タイトル文字列の優先順位）であり、表示する文字列は条件次第で「OSC 由来」または「API 由来」のいずれかになるだけで UI レイアウトの変更はないため省略します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * ペインのタイトル表示を改善しました。API経由で設定したタイトルを優先表示し、未設定時はターミナルの既定タイトルにフォールバックします。
  * 表示用のタイトル情報を明確化し、状態報告にAPIタイトルと表示用タイトルを含めるよう拡張しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/24)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->