### PR TITLE
[ その他 ] stripAnsi を utils/stripAnsi.js に共通化（用途別関数で分離）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ その他 ] `main.js` と `renderer/app.js` に重複していた `stripAnsi` を `utils/stripAnsi.js` に共通化（用途別に表示用 `stripAnsiForDisplay` とパターンマッチング用 `stripAnsiForPattern` の 2 関数をエクスポート。正規表現は両方の意図を維持したまま据え置き）
 - [ 機能追加 ] ペイン上部のヘッダ左側に動作ステータスインジケータ（🟢 実行中／🟡 入力待ち）を追加。PTY 出力中は緑、入力待ち（既存の WAITING_PATTERNS ヒット時）は黄、それ以外は非表示。`states.json` および `GET /api/states` のレスポンスに `status` フィールド（`'idle' | 'running' | 'waiting'`）を追加（既存 `waiting` フィールドは後方互換のため維持）
 - [ 仕様変更 ] 旧 `.waiting-badge`（⚠ 待機中）を新ステータスインジケータに統合して削除。入力待ち表示は `🟡 入力待ち` バッジに一本化（`.pane.waiting` 枠の点滅アニメーションは引き続き動作）
 - [ 機能追加 ] 上下分割されたペインを折り畳めるように変更。ヘッダの ▾ ボタン（折り畳み中は ▴）で展開・折り畳みを切り替え。折り畳み中はタスクタイトル行とヘッダのみ表示し、xterm 領域を隠して兄弟ペインを広げる（PTY プロセスは生存し続けるため、出力や waiting バッジは継続）

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const http = require('http');
 const { execFile } = require('child_process');
 const { promisify } = require('util');
+const { stripAnsiForPattern } = require('./utils/stripAnsi');
 const execFileAsync = promisify(execFile);
 
 let win;
@@ -211,11 +212,6 @@ ipcMain.handle('terminal:create', (event, cwd, options = {}) => {
   let promptWatcher = null;
   let promptWatcherTimeoutId = null;
 
-  // ANSI エスケープを除去するユーティリティ
-  const stripAnsi = (data) => data
-    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
-    .replace(/\x1b\]\d+;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
-
   // 信頼確認プロンプトの検知パターン（全ターミナル共通）
   // 「Enter to confirm」が出た時点でメニュー描画済みなので、そこで \r を送る
   // 旧UI: "Do you trust the files in this folder?" / "Yes, I trust this folder"
@@ -253,7 +249,7 @@ ipcMain.handle('terminal:create', (event, cwd, options = {}) => {
     }
 
     promptWatcher = (data) => {
-      const stripped = stripAnsi(data);
+      const stripped = stripAnsiForPattern(data);
       buffer = (buffer + stripped).slice(-4096);
 
       // 信頼確認プロンプト → Enter で承認（全ターミナル共通）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -2,6 +2,7 @@
 const { ipcRenderer, shell } = require('electron');
 const { Terminal } = require('@xterm/xterm');
 const { FitAddon } = require('@xterm/addon-fit');
+const { stripAnsiForDisplay } = require('../utils/stripAnsi');
 
 // ─── State ────────────────────────────────────────────────────────────────────
 let tree = null;       // Layout tree root
@@ -69,18 +70,10 @@ const WAITING_PATTERNS = [
   // NOTE: /permission/i は削除 — Claude Code の UI フッター "bypass permissions on" に誤反応するため
 ];
 
-function stripAnsi(str) {
-  return str
-    .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
-    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
-    .replace(/\x1b[^[\]]/g, '')
-    .replace(/\r/g, '\n');  // \r を \n に変換して行バッファに乗せる
-}
-
 function checkWaiting(paneId) {
   const t = terminals[paneId];
   if (!t) return;
-  const clean = stripAnsi(t.lastLines);
+  const clean = stripAnsiForDisplay(t.lastLines);
   const waiting = WAITING_PATTERNS.some(p => p.test(clean));
   if (waiting !== t.waiting) {
     t.waiting = waiting;
@@ -269,7 +262,7 @@ ipcRenderer.on('terminal:data', (event, id, data) => {
   }
 
   // Accumulate last lines for waiting detection
-  const stripped = stripAnsi(data);
+  const stripped = stripAnsiForDisplay(data);
   t.lastLines = (t.lastLines + stripped).split('\n').slice(-15).join('\n');
   t.lastOutputTime = Date.now();
   checkWaiting(paneId);

--- a/utils/stripAnsi.js
+++ b/utils/stripAnsi.js
@@ -1,0 +1,30 @@
+// ANSI エスケープシーケンス除去ユーティリティ
+//
+// 用途が「表示用」と「パターンマッチング用」で要件が異なるため、
+// 単一の関数に統合せず用途別に複数の関数をエクスポートする。
+//
+// - stripAnsiForDisplay: renderer 側（xterm 表示・WAITING_PATTERNS 判定）用。
+//   CR を LF に正規化し、ESC<single-char>（CSI/OSC 以外の単発 ESC シーケンス）も除去する。
+//   CSI は `[A-Za-z]` で終端する一般的な範囲のみを対象にする。
+//
+// - stripAnsiForPattern: main.js 側（信頼確認 / READY パターン検知）用。
+//   CR→LF 変換や ESC<single-char> 除去は不要。
+//   CSI の終端文字を非英字（`[@-~]`）まで含めて広く除去する（PR #10 対応）。
+//   OSC は `\d+;...` 形式のみを対象にする。
+
+const stripAnsiForDisplay = (str) =>
+  str
+    .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b[^[\]]/g, '')
+    .replace(/\r/g, '\n'); // \r を \n に変換して行バッファに乗せる
+
+const stripAnsiForPattern = (data) =>
+  data
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1b\]\d+;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+
+module.exports = {
+  stripAnsiForDisplay,
+  stripAnsiForPattern,
+};


### PR DESCRIPTION
## 概要

`main.js` と `renderer/app.js` に重複していた `stripAnsi` 実装を、共通モジュール `utils/stripAnsi.js` に切り出すリファクタリング。

両者の `stripAnsi` は意図的に正規表現が分かれており（表示用は CR→LF 正規化や ESC<single-char> 除去を含む、パターンマッチング用は CSI 終端を `[@-~]` まで広く許容）、単純にマージできないため **用途別に 2 関数をエクスポートする設計** にしている。正規表現は両ファイルの元実装から 1 文字も変えずに移植しており、純粋なリファクタリングで振る舞いは変わらない。

Closes #12

## 変更内容

- `utils/stripAnsi.js` を新規追加し、以下 2 関数を CommonJS でエクスポート
  - `stripAnsiForDisplay(str)` — renderer 用（xterm 表示・WAITING パターン判定）。CR→LF 正規化を含む 4 段 replace
  - `stripAnsiForPattern(data)` — main.js 用（信頼確認 / READY パターン検知）。CSI `[@-~]` + OSC `\d+;` の 2 段 replace
- `main.js` のローカル `stripAnsi` 定義（旧 215〜217 行）を削除し、`require('./utils/stripAnsi')` 経由で `stripAnsiForPattern` を利用
- `renderer/app.js` のローカル `stripAnsi` 定義（旧 72〜78 行）を削除し、`require('../utils/stripAnsi')` 経由で `stripAnsiForDisplay` を利用（renderer は `nodeIntegration: true` / `contextIsolation: false` のため `require` 利用可）
- `CHANGELOG.md` 冒頭未リリース欄に追記

## 確認手順

### 前提条件

- macOS で `npm install` 済みのローカル環境
- `node` コマンドが利用可能

### 手順

#### 1. モジュールロード確認

リポジトリルートで以下を実行する。

\`\`\`bash
node -e \"const m = require('./utils/stripAnsi'); console.log(m);\"
\`\`\`

→ 以下のように 2 関数がエクスポートされていれば OK。

\`\`\`
{
  stripAnsiForDisplay: [Function: stripAnsiForDisplay],
  stripAnsiForPattern: [Function: stripAnsiForPattern]
}
\`\`\`

#### 2. 元実装との等価性確認（リファクタリング前後で振る舞いが変わらないこと）

リポジトリルートで以下を実行する。

\`\`\`bash
node -e \"
const { stripAnsiForDisplay, stripAnsiForPattern } = require('./utils/stripAnsi');
const orig_display = (str) => str
  .replace(/\\x1b\\[[0-9;?]*[A-Za-z]/g, '')
  .replace(/\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\\\\\)/g, '')
  .replace(/\\x1b[^[\\]]/g, '')
  .replace(/\\r/g, '\\n');
const orig_pattern = (data) => data
  .replace(/\\x1b\\[[0-?]*[ -/]*[@-~]/g, '')
  .replace(/\\x1b\\]\\d+;[^\\x07\\x1b]*(?:\\x07|\\x1b\\\\\\\\)/g, '');
const samples = ['\\x1b[31mhello\\x1b[0m world','\\x1b]0;title\\x07rest','line1\\rline2','\\x1b[?25hcursor','\\x1bMplain','\\x1b[10G\\x1b]0;t\\x07x'];
let ok = true;
for (const s of samples) {
  if (orig_display(s) !== stripAnsiForDisplay(s)) ok = false;
  if (orig_pattern(s) !== stripAnsiForPattern(s)) ok = false;
}
console.log(ok ? 'ALL EQUIVALENT' : 'MISMATCH');
\"
\`\`\`

→ `ALL EQUIVALENT` と出力されれば OK（元の正規表現と新モジュールの正規表現が完全等価）。

#### 3. アプリ起動確認（デグレなし）

\`\`\`bash
npm start
\`\`\`

1. ターミナルが正常に開き、claude が自動起動する
   → ✓ 信頼確認プロンプト（`Enter to confirm` / `Do you trust...`）が出た場合に自動で Enter が送信される（main.js 側の `stripAnsiForPattern` 経路）
2. claude のプロンプト表示後、`initialCommand` が自動送信される
   → ✓ `? for shortcuts` などの READY パターン検知が動く
3. claude に `[y/N]` 系の確認プロンプトを出させる（例: ファイル編集の許可など）
   → ✓ ペインヘッダに 🟡 入力待ちインジケータが表示される（renderer 側の `stripAnsiForDisplay` 経路で WAITING_PATTERNS が判定される）
4. 通常コマンド実行中
   → ✓ 🟢 実行中インジケータが表示され、出力が ANSI カラー付きで正しく表示される（xterm 側は ANSI を保持したまま `write` するため見た目への影響なし）

### デグレ確認ポイント

- 正規表現の文字列は元のままコピーしているため、表示・パターン検知ともに既存挙動と一致するはず
- `main.js` 215〜217 行のローカル `stripAnsi` 削除、`renderer/app.js` 72〜78 行のローカル `stripAnsi` 削除以外に振る舞いを変える変更は含まない

## レビュー状況

- 安藤のセキュリティレビュー: PASS（Blocker / Should なし、Nit 2 点は今回対応不要）
- UX レビュー: CSS/UI 変更なしのため省略

## 関連 issue / PR

- Closes #12
- 関連: PR #10（CSI `[@-~]` 対応） / PR #11（重複指摘の発端）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ANSI文字列処理ユーティリティを共通化し、コード重複を削減しました。ターミナル出力の表示と検知処理をそれぞれ最適化し、内部実装の効率性を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->