### PR TITLE
[ 機能追加 ] ペインのタスクタイトル行に外部リンクを指定できるように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] ペイン上部のタスクタイトル行に外部リンクを指定できるように変更。`POST /api/set-title` に `url` フィールド（任意・`http(s):` のみ・2048 文字以内）を追加し、API 由来タイトル（`apiTitle`）表示時かつ `url` が設定されているときに限り、タイトル全体を `<a>` 化（末尾に外部リンクマーク `↗` を表示）。クリックすると `shell.openExternal()` で OS の既定ブラウザを開く。`url` を省略すると従来通り URL なし表示、空文字 `""` で既存 URL をクリア。`url` のバリデーション違反は `400` を返す。`states.json` および `GET /api/states` のレスポンスに `apiUrl` フィールドを追加（後方互換のため既存フィールドは維持）
 - [ その他 ] `main.js` と `renderer/app.js` に重複していた `stripAnsi` を `utils/stripAnsi.js` に共通化（用途別に表示用 `stripAnsiForDisplay` とパターンマッチング用 `stripAnsiForPattern` の 2 関数をエクスポート。正規表現は両方の意図を維持したまま据え置き）
 - [ 機能追加 ] ペイン上部のヘッダ左側に動作ステータスインジケータ（🟢 実行中／🟡 入力待ち）を追加。PTY 出力中は緑、入力待ち（既存の WAITING_PATTERNS ヒット時）は黄、それ以外は非表示。`states.json` および `GET /api/states` のレスポンスに `status` フィールド（`'idle' | 'running' | 'waiting'`）を追加（既存 `waiting` フィールドは後方互換のため維持）
 - [ 仕様変更 ] 旧 `.waiting-badge`（⚠ 待機中）を新ステータスインジケータに統合して削除。入力待ち表示は `🟡 入力待ち` バッジに一本化（`.pane.waiting` 枠の点滅アニメーションは引き続き動作）

--- a/README.md
+++ b/README.md
@@ -166,6 +166,54 @@ curl -s -X POST http://127.0.0.1:13847/api/send \
 
 送信成功時、対象ペインに「🤖 自動入力」バッジが3秒間表示されます。
 
+#### `POST /api/set-title`
+
+指定ペイン上部の「タスクタイトル行」に表示する文字列を設定します。任意で外部リンクの URL を渡すと、タイトル全体がリンク化され、クリックで OS の既定ブラウザで開きます。
+
+```bash
+# タイトルだけ設定（リンクなし）
+curl -s -X POST http://127.0.0.1:13847/api/set-title \
+  -H 'Content-Type: application/json' \
+  -d '{"termId": "1", "title": "issue #29 対応中"}'
+
+# タイトルとリンク URL をセットで設定
+curl -s -X POST http://127.0.0.1:13847/api/set-title \
+  -H 'Content-Type: application/json' \
+  -d '{"termId": "1", "title": "issue #29", "url": "https://github.com/vektor-inc/vk-terminals/issues/29"}'
+
+# タイトルと URL をクリア（空文字で消す）
+curl -s -X POST http://127.0.0.1:13847/api/set-title \
+  -H 'Content-Type: application/json' \
+  -d '{"termId": "1", "title": "", "url": ""}'
+```
+
+リクエストボディ:
+
+- `termId`: 対象のターミナル ID（必須）
+- `title`: 表示する文字列。空文字 `""` を渡すと API 由来タイトルがクリアされ、OSC 由来タイトル（`taskTitle`）にフォールバックします。
+- `url`（任意）: タイトル全体をリンク化するための URL。`http(s):` スキームのみ許可、2048 文字以内、`new URL()` で parse 可能であることが必須。違反時は `400` を返します。空文字 `""` を渡すと既存の URL がクリアされます。省略すると URL なしになります。
+
+| 挙動 |
+|---|
+| `title` と `url` はペアで都度送る**置換セマンティクス**です（patch 形式ではありません）。`title` だけ更新したい場合も、その都度 `url` を一緒に送る必要があります（送らなければ URL なし扱いになります）。 |
+| `url` が設定されている間のみ、ペインのタイトル文字列全体が `<a>` として描画され、末尾に外部リンクマーク `↗` が付きます。クリックすると `shell.openExternal()` で OS の既定ブラウザを開きます。 |
+| OSC 0 / OSC 2 由来のタイトル（`taskTitle`）が表示されている間は URL を表示しません。API 由来のタイトル（`apiTitle`）が選択されているときだけリンク化されます。 |
+
+レスポンス例:
+
+```json
+{ "ok": true, "termId": "1", "title": "issue #29", "url": "https://github.com/vektor-inc/vk-terminals/issues/29" }
+```
+
+エラー例:
+
+- `400 {"error": "url must be http(s)"}` — `file:` などの非 http(s) スキーム
+- `400 {"error": "invalid url"}` — `new URL()` で parse 失敗
+- `400 {"error": "url too long (max 2048 chars)"}` — 2048 文字超過
+- `404 {"error": "terminal <id> not found"}` — 指定 `termId` のペインが存在しない
+
+設定された値は `GET /api/states` のレスポンス（および `~/.vk-terminals/states.json`）の各ペインオブジェクトに `apiTitle` / `apiUrl` フィールドとして含まれます。
+
 #### `POST /api/new-pane`
 
 新規ペインを作成し、作成されたターミナルの `termId` を返します。表示面積が一番大きいペインを対象に、そのペインの長辺方向へ分割して新規ペインを生成します。

--- a/README.md
+++ b/README.md
@@ -212,6 +212,28 @@ curl -s -X POST http://127.0.0.1:13847/api/set-title \
 - `400 {"error": "url too long (max 2048 chars)"}` — 2048 文字超過
 - `404 {"error": "terminal <id> not found"}` — 指定 `termId` のペインが存在しない
 
+バリデーション動作確認用のリクエスト例（リグレッション検知用）:
+
+```bash
+# 大文字スキーム（`new URL()` がプロトコルを小文字化するため http(s) 判定で弾かれる）
+curl -i -s -X POST http://127.0.0.1:13847/api/set-title \
+  -H 'Content-Type: application/json' \
+  -d '{"termId":"1","title":"x","url":"JAVASCRIPT:alert(1)"}'
+# => 400 {"error":"url must be http(s)"}
+
+# javascript: スキーム
+curl -i -s -X POST http://127.0.0.1:13847/api/set-title \
+  -H 'Content-Type: application/json' \
+  -d '{"termId":"1","title":"x","url":"javascript:alert(1)"}'
+# => 400 {"error":"url must be http(s)"}
+
+# data: スキーム
+curl -i -s -X POST http://127.0.0.1:13847/api/set-title \
+  -H 'Content-Type: application/json' \
+  -d '{"termId":"1","title":"x","url":"data:text/html,<script>alert(1)</script>"}'
+# => 400 {"error":"url must be http(s)"}
+```
+
 設定された値は `GET /api/states` のレスポンス（および `~/.vk-terminals/states.json`）の各ペインオブジェクトに `apiTitle` / `apiUrl` フィールドとして含まれます。
 
 #### `POST /api/new-pane`

--- a/main.js
+++ b/main.js
@@ -465,8 +465,13 @@ function startHttpApi() {
       return;
     }
 
-    // POST /api/set-title  { termId: "1", title: "タスク名" } — ペイン上部のタスクタイトル行に表示する文字列を設定
-    //   空文字や null を指定するとタイトル行を非表示に戻す。
+    // POST /api/set-title  { termId: "1", title: "タスク名", url?: "https://..." }
+    //   — ペイン上部のタスクタイトル行に表示する文字列を設定。
+    //   空文字や null を title に指定するとタイトル行を非表示に戻す。
+    //   url を指定するとタイトル全体をリンク化（クリックで OS の既定ブラウザで開く）。
+    //   url を省略すると URL なし扱い、空文字 "" を渡すと既存 URL をクリアする扱い。
+    //   url は http(s): スキームのみ許可・new URL() で parse 可能・2048 文字以内の制約あり。
+    //   title と url はペアで都度送る置換セマンティクス（patch ではない）。
     if (req.method === 'POST' && url.pathname === '/api/set-title') {
       const MAX_BODY = 10 * 1024;
       let body = '';
@@ -496,11 +501,47 @@ function startHttpApi() {
             return;
           }
           const title = typeof parsed?.title === 'string' ? parsed.title : '';
+
+          // url のバリデーション。
+          //   - 未指定（undefined）→ 後方互換のため URL なし扱い（空文字を送る）
+          //   - 空文字 "" → クリア扱い（renderer 側で apiUrl をクリア）
+          //   - それ以外 → 文字列必須、長さ 2048 以内、new URL() parse 必須、http(s): のみ
+          let urlValue = '';
+          if (parsed && Object.prototype.hasOwnProperty.call(parsed, 'url')) {
+            const rawUrl = parsed.url;
+            if (rawUrl === '' || rawUrl == null) {
+              urlValue = '';
+            } else if (typeof rawUrl !== 'string') {
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: 'url must be a string' }));
+              return;
+            } else if (rawUrl.length > 2048) {
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: 'url too long (max 2048 chars)' }));
+              return;
+            } else {
+              let parsedUrl;
+              try {
+                parsedUrl = new URL(rawUrl);
+              } catch (_e) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'invalid url' }));
+                return;
+              }
+              if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'url must be http(s)' }));
+                return;
+              }
+              urlValue = rawUrl;
+            }
+          }
+
           if (win && !win.isDestroyed()) {
-            win.webContents.send('terminal:title', termId, title);
+            win.webContents.send('terminal:title', termId, title, urlValue);
           }
           res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ ok: true, termId, title }));
+          res.end(JSON.stringify({ ok: true, termId, title, url: urlValue }));
         } catch (e) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'invalid JSON' }));

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -337,8 +337,10 @@ function renderTaskTitleContent(el, title, url) {
   link.href = '#'; // 実 URL は入れない（Electron の target="_blank" 経由の新 BrowserWindow 防止）
   link.setAttribute('role', 'link');
   link.setAttribute('aria-label', `${title}（外部ブラウザで開く）`);
-  // ホバー時のツールチップで URL を確認できるようにする
-  link.title = url;
+  // ホバー時のツールチップにはタイトル本文と URL の両方を改行区切りで含める。
+  // 親要素 .pane-task-title の title 属性は has-link 時に外して競合を避ける
+  // （ブラウザ実装により親子 title の優先順位が不定なため。updatePaneTitle / renderLeaf 側で制御）。
+  link.title = title ? `${title}\n${url}` : url;
 
   const labelSpan = document.createElement('span');
   labelSpan.className = 'pane-task-title-text';
@@ -385,8 +387,14 @@ function updatePaneTitle(paneId) {
   const title = getDisplayTitle(t);
   const url = getDisplayUrl(t);
   renderTaskTitleContent(el, title, url);
-  // ホバー時のツールチップは「タイトル本文」を表示（URL は <a> 側の title で別途見える）
-  el.title = title;
+  // ホバー時のツールチップは has-link 時は子 <a> 側に集約して親子競合を避ける。
+  //   - URL 無し: 親 .pane-task-title に title 属性をセット（従来挙動）
+  //   - URL 有り: 親 title 属性を削除し、<a> 側の title（タイトル + URL）のみに任せる
+  if (url) {
+    el.removeAttribute('title');
+  } else {
+    el.title = title;
+  }
   el.classList.toggle('empty', title.length === 0);
   el.classList.toggle('has-link', !!url);
 }
@@ -842,7 +850,8 @@ function renderLeaf(node, parentDirection) {
     + (taskTitle ? '' : ' empty')
     + (taskUrl ? ' has-link' : '');
   renderTaskTitleContent(taskTitleEl, taskTitle, taskUrl);
-  if (taskTitle) taskTitleEl.title = taskTitle;
+  // URL 有りのときは子 <a> 側の title 属性に集約するため、親には付けない（親子競合回避）。
+  if (taskTitle && !taskUrl) taskTitleEl.title = taskTitle;
   el.appendChild(taskTitleEl);
 
   const header = document.createElement('div');

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -225,11 +225,15 @@ async function createTerminal(paneId, cwd, options = {}) {
     lastInputTime: 0,
     // taskTitle: xterm の OSC 0/2 由来のタイトル（claude TUI 等が継続的に発行する）
     // apiTitle:  HTTP API（POST /api/set-title）で明示的にセットされたタイトル
+    // apiUrl:    HTTP API（POST /api/set-title）で渡された URL（issue #29）。
+    //            apiTitle が表示されているときのみ、タイトル全体をリンク化する。
+    //            taskTitle（OSC 由来）の表示時は URL を一切表示しない。
     // 表示時は apiTitle を優先し、空のときに taskTitle へフォールバックする。
     // これにより task-queue 等が指定した issue タイトルが OSC 由来の文字列で
     // 上書きされなくなる（issue #22）。
     taskTitle: '',
     apiTitle: '',
+    apiUrl: '',
   };
 
   return paneId;
@@ -289,15 +293,102 @@ function getDisplayTitle(t) {
   return t.apiTitle || t.taskTitle || '';
 }
 
+// 表示中のタイトルにリンクを付けるべきか判定する。
+//   - apiTitle が選ばれている（apiTitle が非空）かつ
+//   - apiUrl が設定されている（http(s) スキームは main 側で検証済み）
+// 時のみ true。OSC 由来の taskTitle 表示時はリンク化しない。
+function getDisplayUrl(t) {
+  if (!t) return '';
+  if (!t.apiTitle) return '';
+  return t.apiUrl || '';
+}
+
+// http(s): スキームのチェック（renderer 側の二段構えバリデーション）。
+// main 側で検証済みでも shell.openExternal 直前に念のため再チェックする。
+function isSafeExternalUrl(url) {
+  if (typeof url !== 'string' || !url) return false;
+  if (url.length > 2048) return false;
+  try {
+    const u = new URL(url);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch (_e) {
+    return false;
+  }
+}
+
+// .pane-task-title 要素の中身を、URL の有無に応じて
+// プレーンテキスト or <a>（外部リンクマーク付き）で再構築する。
+//   - URL 無し: テキストノードのみ（従来通り、見た目は完全互換）
+//   - URL 有り: <a role="link" href="#"> + <span>title</span> + <span aria-hidden>↗</span>
+// href には URL を直接入れない（Electron の <a target="_blank"> が新 BrowserWindow を
+// 開く危険挙動を回避するため）。クリック時は preventDefault → shell.openExternal で
+// OS の既定ブラウザを開く。
+function renderTaskTitleContent(el, title, url) {
+  // 既存の子要素を全消去（innerHTML は使わずに DOM API で組み立てる）
+  while (el.firstChild) el.removeChild(el.firstChild);
+
+  if (!url) {
+    el.textContent = title;
+    return;
+  }
+
+  const link = document.createElement('a');
+  link.className = 'pane-task-title-link';
+  link.href = '#'; // 実 URL は入れない（Electron の target="_blank" 経由の新 BrowserWindow 防止）
+  link.setAttribute('role', 'link');
+  link.setAttribute('aria-label', `${title}（外部ブラウザで開く）`);
+  // ホバー時のツールチップで URL を確認できるようにする
+  link.title = url;
+
+  const labelSpan = document.createElement('span');
+  labelSpan.className = 'pane-task-title-text';
+  labelSpan.textContent = title;
+  link.appendChild(labelSpan);
+
+  const iconSpan = document.createElement('span');
+  iconSpan.className = 'pane-task-title-icon';
+  iconSpan.setAttribute('aria-hidden', 'true');
+  iconSpan.textContent = '↗';
+  link.appendChild(iconSpan);
+
+  // クリック: ペインのアクティブ化（mousedown 経路）は止めない。click のみ抑止し
+  // shell.openExternal でブラウザを開く。
+  link.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // main 側で検証済みでも二段構えで再チェック（http(s): 以外は無視）
+    if (!isSafeExternalUrl(url)) return;
+    try {
+      // Electron の shell.openExternal は Promise を返すが、reject 時にハンドラがないと
+      // unhandled rejection になるため明示的にハンドリングする。同期 throw もありうるので
+      // 念のため try/catch でラップしておく。
+      const p = shell.openExternal(url);
+      if (p && typeof p.catch === 'function') {
+        p.catch(() => { /* 失敗時は何もしない */ });
+      }
+    } catch (_e) {
+      /* 同期エラー時も無視 */
+    }
+  });
+  // mousedown は止めない（ペインのフォーカス移譲は通常通り）
+  // ただしリンク自体のテキスト選択は意図しないドラッグを起こしやすいので、
+  // ユーザビリティのため pointer 系イベントの伝搬は維持しつつ、別操作とは衝突しない。
+
+  el.appendChild(link);
+}
+
 function updatePaneTitle(paneId) {
   const t = terminals[paneId];
   if (!t) return;
   const el = document.querySelector(`.pane[data-id="${paneId}"] .pane-task-title`);
   if (!el) return;
   const title = getDisplayTitle(t);
-  el.textContent = title;
+  const url = getDisplayUrl(t);
+  renderTaskTitleContent(el, title, url);
+  // ホバー時のツールチップは「タイトル本文」を表示（URL は <a> 側の title で別途見える）
   el.title = title;
   el.classList.toggle('empty', title.length === 0);
+  el.classList.toggle('has-link', !!url);
 }
 
 // .pane-status バッジ（ヘッダ最左）と .pane.waiting 枠点滅の両方を更新する。
@@ -728,6 +819,8 @@ function renderLeaf(node, parentDirection) {
   const focused = node.id === focusedPaneId;
   // apiTitle（API 由来）優先、無ければ taskTitle（OSC 由来）にフォールバック。
   const taskTitle = getDisplayTitle(t);
+  // apiTitle 表示時かつ apiUrl があるときのみリンク化（OSC 由来時は URL を出さない）
+  const taskUrl = getDisplayUrl(t);
   const collapsed = !!node.collapsed;
   // 親 split が split-v（上下分割）の場合のみ折り畳みボタンを表示する。
   // 親 split-h（横並び）の場合は折り畳むと縦のストリップになるが、今回はスコープ外。
@@ -743,9 +836,12 @@ function renderLeaf(node, parentDirection) {
 
   // タスクタイトル行（OSC 0/2 または POST /api/set-title で設定された文字列を表示）。
   // 空のときは .empty クラスで非表示にし、xterm の表示領域を圧迫しない。
+  // apiUrl があるときは .has-link を付与し、内部を <a> 化する（renderTaskTitleContent）。
   const taskTitleEl = document.createElement('div');
-  taskTitleEl.className = 'pane-task-title' + (taskTitle ? '' : ' empty');
-  taskTitleEl.textContent = taskTitle;
+  taskTitleEl.className = 'pane-task-title'
+    + (taskTitle ? '' : ' empty')
+    + (taskUrl ? ' has-link' : '');
+  renderTaskTitleContent(taskTitleEl, taskTitle, taskUrl);
   if (taskTitle) taskTitleEl.title = taskTitle;
   el.appendChild(taskTitleEl);
 
@@ -1062,9 +1158,11 @@ setInterval(() => {
       lastLines: t.lastLines,
       // taskTitle: OSC 0/2 由来のタイトル（後方互換のため既存キーを維持）
       // apiTitle:  POST /api/set-title 由来のタイトル（issue #22 で分離）
+      // apiUrl:    POST /api/set-title 由来の URL（issue #29）。apiTitle 表示時のみリンク化される
       // displayTitle: 実際にペイン上部に表示している値（apiTitle || taskTitle）
       taskTitle: t.taskTitle || '',
       apiTitle: t.apiTitle || '',
+      apiUrl: t.apiUrl || '',
       displayTitle: getDisplayTitle(t),
       collapsed: !!(leaf && leaf.collapsed),
     };
@@ -1101,10 +1199,19 @@ ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
 // API 由来のタイトルは apiTitle に保存し、OSC 由来の taskTitle とは別フィールドで管理する。
 // これにより claude TUI が継続的に発行する OSC 0/2 で API 設定タイトルが上書きされない。
 // 空文字を送ると apiTitle がクリアされ、OSC 由来の taskTitle にフォールバックする。
-ipcRenderer.on('terminal:title', (event, termId, title) => {
+// 第3引数 url（issue #29）: タイトル全体をリンク化するための URL。
+//   - undefined → 後方互換のため URL 変更なしと解釈（ただし main 側は常に第3引数を送る）
+//   - 空文字  → apiUrl をクリア
+//   - 文字列 → http(s): スキームのみ（main 側で検証済み）。apiUrl にセット
+// title と url はペアで都度送る置換セマンティクス。
+ipcRenderer.on('terminal:title', (event, termId, title, url) => {
   const paneId = Object.keys(terminals).find(k => terminals[k]?.termId === termId);
   if (!paneId) return;
   terminals[paneId].apiTitle = title || '';
+  // url が string で渡ってきた場合のみ書き換える（旧来の 2 引数呼び出しとの後方互換のため）
+  if (typeof url === 'string') {
+    terminals[paneId].apiUrl = url;
+  }
   updatePaneTitle(paneId);
 });
 

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -153,6 +153,59 @@ html, body {
   background: #22282f;
 }
 
+/* ─── Pane task title link (issue #29) ─────────────────────────────────────
+ * apiTitle + apiUrl が設定されているときだけ、タイトル全体を <a> として描画する。
+ * 通常時はタイトル文字色に同化（color: inherit）、hover/focus で軽く色を変えつつ下線。
+ * ↗ アイコンは flex-shrink: 0 で長文タイトル省略時にも必ず残す。
+ * テキストは省略表示（ellipsis）を維持するため min-width: 0 を当てる。 */
+.pane-task-title-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: 3px;
+  /* リンクのフォーカスリングと色変化のみの transition。 */
+  transition: color 0.12s ease, text-decoration-color 0.12s ease;
+}
+
+.pane-task-title-link:hover {
+  color: #79c0ff;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.pane-task-title-link:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+
+/* タイトル本文側だけ省略表示にする（↗ アイコンは省略させない）。
+ * .pane-task-title 自体にも overflow:hidden / text-overflow:ellipsis が当たっているが、
+ * <a> 内の inline-flex 構造では子要素ごとに ellipsis を効かせる必要がある。 */
+.pane-task-title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.pane-task-title-icon {
+  flex-shrink: 0;
+  font-size: 10px;
+  opacity: 0.75;
+  /* ↗ は emoji 系フォントで大きく描画されることがあるため line-height を抑える */
+  line-height: 1;
+}
+
+.pane-task-title-link:hover .pane-task-title-icon {
+  opacity: 1;
+}
+
 /* ─── Pane header ──────────────────────────────────────────────────────────── */
 .pane-header {
   display: flex;


### PR DESCRIPTION
## 概要

closes #29

task-queue 等から issue タイトルとセットで URL を投げられるよう、`POST /api/set-title` に `url` フィールドを追加しました。API 由来のタイトル（`apiTitle`）表示時かつ `url` が設定されているときに限り、ペイン上部のタスクタイトル文字列全体が `<a>` 化され、末尾に外部リンクマーク `↗` が表示されます。クリックすると `shell.openExternal()` で OS の既定ブラウザが開きます。

OSC 0 / 2 由来のタイトル（claude TUI などが流す `taskTitle`）が表示されている間は URL を表示しません。

## 主な変更点

### HTTP API（`main.js`）

- `POST /api/set-title` のリクエストボディに `url` フィールドを追加（任意・後方互換あり）
- バリデーション
  - `http:` / `https:` スキームのみ許可
  - `new URL()` で parse 必須
  - 長さ 2048 文字以内
  - 違反時は `400` を返す（具体的なエラーメッセージ付き）
- `url` 省略時は従来通り URL なし扱い、空文字 `""` で既存 URL をクリア
- `title` と `url` はペアで都度送る**置換セマンティクス**（patch ではない）
- IPC `terminal:title` を `(termId, title, url)` の 3 引数に拡張

### renderer（`renderer/app.js`）

- `terminals[paneId]` に `apiUrl` フィールドを追加
- タスクタイトル要素を URL 有無で動的に組み立て直す `renderTaskTitleContent` を新設
  - URL 無し → テキストノードのみ（見た目は完全互換）
  - URL 有り → `<a role="link"> + <span>title</span> + <span aria-hidden>↗</span>`
- `href` には URL を直接入れない（Electron で `<a target="_blank">` が新 BrowserWindow を開く挙動を回避するため `href="#"` を採用）
- クリック時は `e.preventDefault()` + `e.stopPropagation()` の後 `shell.openExternal()` で OS の既定ブラウザを開く
- `mousedown` は止めずペインのアクティブ化フォーカス移譲は維持（リンククリックでもペインがアクティブになる）
- `aria-label="（タイトル）（外部ブラウザで開く）"` をスクリーンリーダー向けに付与
- `shell.openExternal()` 直前に再度 `http(s):` チェック（main 側との二段構え）
- DOM は `textContent` ／ DOM API で組み立て、`innerHTML` は不使用
- `~/.vk-terminals/states.json` および `GET /api/states` のペイロードに `apiUrl` フィールドを追加

### CSS（`renderer/style.css`）

- `.pane-task-title-link` / `.pane-task-title-text` / `.pane-task-title-icon` を追加
- `color: inherit` で通常時はタイトル文字色に同化、hover で軽く色変化 + 下線
- `:focus-visible` でフォーカスリング（キーボード操作時のみ）
- `↗` アイコンは `flex-shrink: 0` で長文タイトルの省略時にも必ず残るよう保持
- 本文側にだけ `text-overflow: ellipsis` を当てて省略表示を維持

### ドキュメント

- `README.md` の HTTP API 節に `POST /api/set-title` のドキュメントを新規追加。`url` フィールドの仕様・バリデーション・エラーレスポンスを明記
- `CHANGELOG.md` に機能追加として追記

## 確認手順

### 前提条件

- `npm install` 済みの vk-terminals を `npm start` で起動できる状態
- ターミナルで `curl` が使えること
- ブラウザの既定アプリが設定されていること（Safari / Chrome 等）

### 手順

1. `npm start` で vk-terminals を起動する
   → ✓ 最初のペインが開き、claude が自動起動する
2. `curl -s http://127.0.0.1:13847/api/states | python3 -m json.tool` で動作中のターミナルの `termId` を控える（例: `\"1\"`）

#### 1. URL 付きでタイトルを設定（リンクとして描画される）

3. 以下のコマンドで `url` を含めてタイトルを送信する
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/set-title \\
     -H 'Content-Type: application/json' \\
     -d '{\"termId\": \"1\", \"title\": \"issue #29\", \"url\": \"https://github.com/vektor-inc/vk-terminals/issues/29\"}'
   ```
   → ✓ ペイン上部のタスクタイトル行に「issue #29 ↗」と表示される
   → ✓ タイトルにマウスを乗せると hover で色が変わり、下線が付く
   → ✓ `↗` アイコンが末尾に表示されている
4. タスクタイトル部分をクリックする
   → ✓ OS の既定ブラウザで `https://github.com/vektor-inc/vk-terminals/issues/29` が開く
   → ✓ Electron アプリ内で新しいウィンドウが開いたりはしない
5. クリック後にペイン本体のフォーカス枠も確認する
   → ✓ リンクをクリックしてもペインがアクティブ化される（mousedown のフォーカス移譲は維持されている）
6. キーボードで Tab して `.pane-task-title-link` にフォーカスする
   → ✓ `:focus-visible` のフォーカスリング（青の outline）が表示される

#### 2. URL なしでタイトルだけ設定（後方互換）

7. `url` を空文字で送ってクリアする
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/set-title \\
     -H 'Content-Type: application/json' \\
     -d '{\"termId\": \"1\", \"title\": \"プレーンタイトル\", \"url\": \"\"}'
   ```
   → ✓ タイトル行が「プレーンタイトル」のみ（`↗` も `<a>` も無し）に戻る
   → ✓ 見た目は従来の仕様と完全互換
8. `url` フィールドを完全に省略して送る
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/set-title \\
     -H 'Content-Type: application/json' \\
     -d '{\"termId\": \"1\", \"title\": \"省略テスト\"}'
   ```
   → ✓ こちらも `↗` 無しの素のテキスト表示になる

#### 3. URL バリデーション（400 が返る）

9. `file:` スキームで送る
   ```bash
   curl -i -s -X POST http://127.0.0.1:13847/api/set-title \\
     -H 'Content-Type: application/json' \\
     -d '{\"termId\": \"1\", \"title\": \"x\", \"url\": \"file:///etc/passwd\"}'
   ```
   → ✓ `HTTP/1.1 400` で `{\"error\":\"url must be http(s)\"}` が返る
   → ✓ ペイン側の表示は変わらない（前回の正常設定が維持される）
10. 不正な URL を送る
    ```bash
    curl -i -s -X POST http://127.0.0.1:13847/api/set-title \\
      -H 'Content-Type: application/json' \\
      -d '{\"termId\": \"1\", \"title\": \"x\", \"url\": \"not a url\"}'
    ```
    → ✓ `400` で `{\"error\":\"invalid url\"}` が返る
11. 2049 文字超の URL を送る
    ```bash
    LONG=\$(printf 'https://example.com/?q=%s' \"\$(printf 'a%.0s' {1..2050})\")
    curl -i -s -X POST http://127.0.0.1:13847/api/set-title \\
      -H 'Content-Type: application/json' \\
      --data-raw \"{\\\"termId\\\":\\\"1\\\",\\\"title\\\":\\\"x\\\",\\\"url\\\":\\\"\$LONG\\\"}\"
    ```
    → ✓ `400` で `{\"error\":\"url too long (max 2048 chars)\"}` が返る

#### 4. OSC 0/2 由来のタイトル時は URL を出さない

12. API 由来のタイトルをクリアしておく
    ```bash
    curl -s -X POST http://127.0.0.1:13847/api/set-title \\
      -H 'Content-Type: application/json' \\
      -d '{\"termId\": \"1\", \"title\": \"\", \"url\": \"\"}'
    ```
13. ペイン内のシェルで OSC タイトルを発行する
    ```
    printf '\\033]0;OSC由来タイトル\\007'
    ```
    → ✓ タイトル行に「OSC由来タイトル」が表示される
    → ✓ `↗` は表示されず、リンク化もされない（`apiTitle` が空の間は `apiUrl` を無視する仕様）

#### 5. `/api/states` に `apiUrl` が含まれる

14. URL 付きタイトルを設定してから状態を取得する
    ```bash
    curl -s -X POST http://127.0.0.1:13847/api/set-title \\
      -H 'Content-Type: application/json' \\
      -d '{\"termId\":\"1\",\"title\":\"確認\",\"url\":\"https://example.com/\"}'
    curl -s http://127.0.0.1:13847/api/states | python3 -m json.tool
    ```
    → ✓ 該当ペインに `\"apiUrl\": \"https://example.com/\"` が含まれている
    → ✓ 既存フィールド（`apiTitle` / `taskTitle` / `displayTitle` / `waiting` / `status` 等）も従来通り出力される

#### デグレ確認

15. URL を一切渡さない呼び出し（旧来クライアント互換）でタイトルだけ更新する
    ```bash
    curl -s -X POST http://127.0.0.1:13847/api/set-title \\
      -H 'Content-Type: application/json' \\
      -d '{\"termId\":\"1\",\"title\":\"旧クライアント互換\"}'
    ```
    → ✓ タイトル行が「旧クライアント互換」のみで表示され、`<a>` 化されない
    → ✓ 直前に設定されていた `apiUrl` が残っていないか確認するには `/api/states` を見て `apiUrl` が空文字になっていることを確認する（main 側で url 未指定時は空文字を IPC 送信して上書きする仕様）

## スクリーンショット

GUI 環境のあるレビュアー側で `npm start` を実行し、確認手順 3〜6 を試してスクリーンショットを取得していただけると助かります（macOS 必須）。

## スコープ外（別 issue 対応）

- 再起動時の `apiUrl` 復元: `states.json` の読み戻し自体が未実装なので、本 issue ではスコープ外（必要なら別 issue）
- task-queue 側で実際に URL を送る処理: 別作業（vektor-inc/task-queue 側で対応）

## 関連

- issue #29
- 既存の `apiTitle` / `taskTitle` 分離（issue #22）の上に乗る変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ペイン上部のタスクタイトルに外部リンクを設定可能に。APIでURLを設定するとタイトルがクリック可能になり、末尾に外部リンクマーク（↗）が表示され、外部ブラウザで開けます。空文字で既存URLをクリア、無効なURLはエラーとなります。

* **ドキュメント**
  * 新規 POST /api/set-title 仕様を追加（title/url の指定・クリア挙動、エラー例、states への反映を明記）。

* **スタイル**
  * タイトルをリンクとして表示するための表示スタイルを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/30)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->