### PR TITLE
[ 機能追加 ] 入力待ち判定に日本語パターンを追加（vk-kore 確認待ち・マージ待ち対応）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] 入力待ち判定（WAITING_PATTERNS）に日本語パターンを追加。vk-kore など Claude が確認を求めて中断するケース（「ご確認をお願いします」「続行しますか」「進めてよろしい」「〜よろしいでしょうか」）と、PR 作成後のマージ判断委譲（「マージ判断」「マージ〜ご判断/お任せ/お願い」等）で「🟡 入力待ち」インジケータが点灯するように
 - [ 機能追加 ] ペイン上部のタスクタイトル行に外部リンクを指定できるように変更。`POST /api/set-title` に `url` フィールド（任意・`http(s):` のみ・2048 文字以内）を追加し、API 由来タイトル（`apiTitle`）表示時かつ `url` が設定されているときに限り、タイトル全体を `<a>` 化（末尾に外部リンクマーク `↗` を表示）。クリックすると `shell.openExternal()` で OS の既定ブラウザを開く。`url` を省略すると従来通り URL なし表示、空文字 `""` で既存 URL をクリア。`url` のバリデーション違反は `400` を返す。`states.json` および `GET /api/states` のレスポンスに `apiUrl` フィールドを追加（後方互換のため既存フィールドは維持）
 - [ その他 ] `main.js` と `renderer/app.js` に重複していた `stripAnsi` を `utils/stripAnsi.js` に共通化（用途別に表示用 `stripAnsiForDisplay` とパターンマッチング用 `stripAnsiForPattern` の 2 関数をエクスポート。正規表現は両方の意図を維持したまま据え置き）
 - [ 機能追加 ] ペイン上部のヘッダ左側に動作ステータスインジケータ（🟢 実行中／🟡 入力待ち）を追加。PTY 出力中は緑、入力待ち（既存の WAITING_PATTERNS ヒット時）は黄、それ以外は非表示。`states.json` および `GET /api/states` のレスポンスに `status` フィールド（`'idle' | 'running' | 'waiting'`）を追加（既存 `waiting` フィールドは後方互換のため維持）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -68,6 +68,14 @@ const WAITING_PATTERNS = [
   /\[\s*D\s*\]eny/i,
   /approve.*\(y\/n\)/i,
   // NOTE: /permission/i は削除 — Claude Code の UI フッター "bypass permissions on" に誤反応するため
+  // 日本語の確認待ちパターン（vk-kore など、Claude が確認を求めて中断する場面で出る文言）
+  /ご確認(?:を|ください|お願い)/,
+  /続行しますか/,
+  /進めて(?:よろしい|よい)/,
+  /(?:よろしい|いかが)(?:でしょうか|ですか)[。？?]?\s*$/m,
+  // マージ待ちパターン（vk-kore の PR 作成後・マージ判断委譲のタイミング）
+  /マージ(?:判断|してください|してもよろしい)/,
+  /マージ.{0,30}(?:ご判断|お願い|よろしい|お任せ)/,
 ];
 
 function checkWaiting(paneId) {


### PR DESCRIPTION
## 概要

`WAITING_PATTERNS`（renderer/app.js）に日本語の確認待ちパターンを追加し、`/vk-kore` などのスキルで Claude が日本語で確認を求めて中断するケース、および PR 作成後のマージ判断委譲の場面でも「🟡 入力待ち」インジケータが点灯するように拡張。

これまでは英語の確認プロンプト（`[y/N]`、`Continue?`、`Allow`/`Deny` など）と inquirer / Claude Code 形式のプロンプトのみ検出していたため、Claude が「ご確認をお願いします」「マージ判断はお任せします」といった日本語で停止している間はインジケータが点灯せず、ユーザーが気付きにくかった。

## 追加したパターン

**確認待ち系**
- `/ご確認(?:を|ください|お願い)/` — 仕様提案後・PR 報告などで頻出
- `/続行しますか/` — vk-kore の vektor-inc 以外リポジトリ続行確認
- `/進めて(?:よろしい|よい)/` — 仕様確認
- `/(?:よろしい|いかが)(?:でしょうか|ですか)[。？?]?\s*$/m` — 行末アンカー付き汎用確認

**マージ待ち系**
- `/マージ(?:判断|してください|してもよろしい)/`
- `/マージ.{0,30}(?:ご判断|お願い|よろしい|お任せ)/`

## 確認手順

### 前提条件
- `npm install` 済みの vk-terminals がローカルで起動できる状態

### 手順

1. `npm start` で vk-terminals を起動
2. 任意のペインで Claude Code を起動した状態で、ペインに以下のテキストを `printf` で流し込み確認パターンごとに挙動を見る:
   ```sh
   printf '\nご確認をお願いします。\n'
   ```
   → ✓ 該当ペインのヘッダー左に `🟡 入力待ち` バッジが表示され、ペイン枠が点滅、ビープ音が鳴る
3. 同様に以下も順番に試して、いずれも `🟡 入力待ち` になることを確認:
   - `printf '\n続行しますか？\n'`
   - `printf '\nこの仕様で進めてよいか教えてください。\n'`
   - `printf '\nマージ判断はお任せします。\n'`
   - `printf '\nマージのご判断をお願いします。\n'`
   → ✓ いずれも `🟡 入力待ち` 状態になる
4. 該当ペインに何か入力（例: Enter）を送る
   → ✓ `lastLines` がリセットされ、`🟡 入力待ち` が解除される（バッジが非表示 or `🟢 実行中` に切り替わる）
5. デグレ確認: 既存の英語パターン（例: `printf '\nContinue? [y/N]\n'`）でも引き続き `🟡 入力待ち` になることを確認
   → ✓ 既存挙動に影響なし

### 補足

- `lastLines` バッファは末尾 15 行のため、対象文言の後に長文出力が続くと自然に解除される（仕様通り）
- ユーザー入力時に `lastLines` がクリアされるため、過去のメッセージで再点灯することはない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 日本語の確認待ちメッセージ（「ご確認ください」「続行しますか」「進めてよろしいですか」など）に対応し、入力待ちインジケータ（🟡）が正しく表示されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/31)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->