### PR TITLE
[ デザイン不具合修正 ] ペインステータスインジケータのスタイル・アクセシビリティを改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ デザイン不具合修正 ] ペイン上部ステータスインジケータ（issue #27）について、`.pane.drag-over` の緑（#3fb950）と衝突していた running 色を同系統に統一、idle ↔ 表示の切替で発生していた cwd 位置のジッタを `visibility: hidden` + `min-width` 予約で解消、`role="status" aria-live="polite"` と `aria-label` 動的更新で SR 対応、絵文字（🟢🟡）を `::before` で描画する 6×6 の currentColor ドットに置換、`.pane-badge` 共通クラスへ `.pane-status` / `.auto-input-badge` の共通プロパティを集約、`badge-pulse` の周期を `1.5s` に揃え `.pane.waiting` 枠と位相を同期するよう修正
 - [ 機能追加 ] 入力待ち判定（WAITING_PATTERNS）に日本語パターンを追加。vk-kore など Claude が確認を求めて中断するケース（「ご確認をお願いします」「続行しますか」「進めてよろしい」「〜よろしいでしょうか」）と、PR 作成後のマージ判断委譲（「マージ判断」「マージ〜ご判断/お任せ/お願い」等）で「🟡 入力待ち」インジケータが点灯するように
 - [ 機能追加 ] ペイン上部のタスクタイトル行に外部リンクを指定できるように変更。`POST /api/set-title` に `url` フィールド（任意・`http(s):` のみ・2048 文字以内）を追加し、API 由来タイトル（`apiTitle`）表示時かつ `url` が設定されているときに限り、タイトル全体を `<a>` 化（末尾に外部リンクマーク `↗` を表示）。クリックすると `shell.openExternal()` で OS の既定ブラウザを開く。`url` を省略すると従来通り URL なし表示、空文字 `""` で既存 URL をクリア。`url` のバリデーション違反は `400` を返す。`states.json` および `GET /api/states` のレスポンスに `apiUrl` フィールドを追加（後方互換のため既存フィールドは維持）
 - [ その他 ] `main.js` と `renderer/app.js` に重複していた `stripAnsi` を `utils/stripAnsi.js` に共通化（用途別に表示用 `stripAnsiForDisplay` とパターンマッチング用 `stripAnsiForPattern` の 2 関数をエクスポート。正規表現は両方の意図を維持したまま据え置き）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -421,13 +421,18 @@ function updatePaneStatus(paneId) {
   if (!badge) return;
   const status = t.status || 'idle';
   badge.dataset.status = status;
-  // 色覚配慮: 絵文字＋テキストで明示。idle は CSS 側で display:none になるので textContent は空でも可。
+  // 視覚: ラベルテキスト（ドットは CSS の ::before で描画）。
+  // a11y: aria-label でステータスを明示し、aria-live="polite" により変化のみ読み上げ。
+  //       idle は visibility:hidden により読み上げ対象外（aria-live 非発火）。
   if (status === 'waiting') {
-    badge.textContent = '🟡 入力待ち';
+    badge.textContent = '入力待ち';
+    badge.setAttribute('aria-label', 'ステータス: 入力待ち');
   } else if (status === 'running') {
-    badge.textContent = '🟢 実行中';
+    badge.textContent = '実行中';
+    badge.setAttribute('aria-label', 'ステータス: 実行中');
   } else {
     badge.textContent = '';
+    badge.removeAttribute('aria-label');
   }
 }
 
@@ -827,11 +832,16 @@ function renderLeaf(node, parentDirection) {
   const t = terminals[node.id];
   const cwd = t?.cwd || '~';
   const waiting = t?.waiting || false;
-  // 表示用ステータス（issue #23）。idle は CSS で display:none、それ以外は label を表示。
+  // 表示用ステータス（issue #23, #27）。idle 時は CSS の visibility:hidden で不可視のまま幅は保持。
+  // ドットは CSS の .pane-status::before（currentColor）で描画するため、ラベルはテキストのみ。
   const status = t?.status || 'idle';
-  const statusLabel = status === 'waiting' ? '🟡 入力待ち'
-                    : status === 'running' ? '🟢 実行中'
+  const statusLabel = status === 'waiting' ? '入力待ち'
+                    : status === 'running' ? '実行中'
                     : '';
+  // aria-label は updatePaneStatus と同じフォーマットで静的にも生成しておく（初期描画時の SR 用）。
+  const statusAriaLabel = status === 'waiting' ? 'ステータス: 入力待ち'
+                        : status === 'running' ? 'ステータス: 実行中'
+                        : '';
   const focused = node.id === focusedPaneId;
   // apiTitle（API 由来）優先、無ければ taskTitle（OSC 由来）にフォールバック。
   const taskTitle = getDisplayTitle(t);
@@ -875,13 +885,15 @@ function renderLeaf(node, parentDirection) {
          aria-expanded="${!collapsed}"
          title="${collapsed ? '展開する' : '折り畳む'}">${collapsed ? '▴' : '▾'}</button>`
     : '';
-  // .pane-status はヘッダ最左に常時挿入し、CSS の data-status="idle" で見えなくする方式。
+  // .pane-status はヘッダ最左に常時挿入し、CSS の data-status="idle" を visibility:hidden で扱う。
+  // role="status" + aria-live="polite" で SR にステータス変化を通知（aria-label は動的更新）。
+  // 共通バッジ basis は .pane-badge（issue #27）、固有スタイルは .pane-status / .auto-input-badge。
   // 旧 .waiting-badge は role を .pane-status に一本化したため削除済（issue #23）。
   header.innerHTML = `
-    <span class="pane-status" data-status="${status}">${statusLabel}</span>
+    <span class="pane-badge pane-status" data-status="${status}" role="status" aria-live="polite"${statusAriaLabel ? ` aria-label="${statusAriaLabel}"` : ''}>${statusLabel}</span>
     <span class="pane-cwd" title="${cwd}">${cwd}</span>
     <div class="pane-actions">
-      <span class="auto-input-badge" style="display:none"></span>
+      <span class="pane-badge auto-input-badge" style="display:none"></span>
       <button class="btn btn-move btn-move-left" title="左へ移動">◀</button>
       <button class="btn btn-move btn-move-down" title="下へ移動">▼</button>
       <button class="btn btn-move btn-move-up" title="上へ移動">▲</button>

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -424,14 +424,12 @@ function updatePaneStatus(paneId) {
   // 視覚: ラベルテキスト（ドットは CSS の ::before で描画）。
   // a11y: aria-label でステータスを明示し、aria-live="polite" により変化のみ読み上げ。
   //       idle は visibility:hidden により読み上げ対象外（aria-live 非発火）。
-  if (status === 'waiting') {
-    badge.textContent = '入力待ち';
-    badge.setAttribute('aria-label', 'ステータス: 入力待ち');
-  } else if (status === 'running') {
-    badge.textContent = '実行中';
-    badge.setAttribute('aria-label', 'ステータス: 実行中');
+  // ラベル / aria-label のマッピングは getStatusPresentation に集約（renderLeaf と共用）。
+  const { label, ariaLabel } = getStatusPresentation(status);
+  badge.textContent = label;
+  if (ariaLabel) {
+    badge.setAttribute('aria-label', ariaLabel);
   } else {
-    badge.textContent = '';
     badge.removeAttribute('aria-label');
   }
 }
@@ -828,20 +826,23 @@ function renderNode(node, parentDirection = null) {
     : renderSplit(node);
 }
 
+// status → { label, ariaLabel } のマッピングを一元化する（updatePaneStatus / renderLeaf 共用）。
+// 'idle' および未知の値は空文字を返し、呼び出し側で「非表示・aria-label 除去」相当の扱いになる。
+function getStatusPresentation(status) {
+  if (status === 'waiting') return { label: '入力待ち', ariaLabel: 'ステータス: 入力待ち' };
+  if (status === 'running') return { label: '実行中',   ariaLabel: 'ステータス: 実行中' };
+  return { label: '', ariaLabel: '' };
+}
+
 function renderLeaf(node, parentDirection) {
   const t = terminals[node.id];
   const cwd = t?.cwd || '~';
   const waiting = t?.waiting || false;
   // 表示用ステータス（issue #23, #27）。idle 時は CSS の visibility:hidden で不可視のまま幅は保持。
   // ドットは CSS の .pane-status::before（currentColor）で描画するため、ラベルはテキストのみ。
+  // ラベル / aria-label の対応は getStatusPresentation に集約（updatePaneStatus と共用）。
   const status = t?.status || 'idle';
-  const statusLabel = status === 'waiting' ? '入力待ち'
-                    : status === 'running' ? '実行中'
-                    : '';
-  // aria-label は updatePaneStatus と同じフォーマットで静的にも生成しておく（初期描画時の SR 用）。
-  const statusAriaLabel = status === 'waiting' ? 'ステータス: 入力待ち'
-                        : status === 'running' ? 'ステータス: 実行中'
-                        : '';
+  const { label: statusLabel, ariaLabel: statusAriaLabel } = getStatusPresentation(status);
   const focused = node.id === focusedPaneId;
   // apiTitle（API 由来）優先、無ければ taskTitle（OSC 由来）にフォールバック。
   const taskTitle = getDisplayTitle(t);

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -276,7 +276,7 @@ html, body {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
   flex-shrink: 0;
 }
 

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -241,42 +241,64 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ─── Pane status indicator (issue #23) ─────────────────────────────────────
- * ヘッダ最左に常時挿入されるバッジ。data-status で表示を切り替える。
- *   - idle    : display:none で要素ごと非表示（ユーザー要望：idle ラベルは出さない）
- *   - running : 緑（PTY 出力中）
- *   - waiting : 黄（WAITING_PATTERNS ヒット、点滅アニメで注意喚起）
- * 旧 .waiting-badge はこのバッジに役割を一本化したため削除済。 */
-.pane-status {
+/* ─── Pane badge (共通バッジ basis, issue #27) ──────────────────────────────
+ * .pane-status / .auto-input-badge 共通の見た目（サイズ・タイポ・配置）を集約。
+ * 個別バッジ固有の padding / margin-right / 色 / アニメは各クラスで上書きする。 */
+.pane-badge {
   display: inline-flex;
   align-items: center;
   gap: 3px;
   font-size: 10px;
   font-weight: 600;
-  padding: 0 6px;
   height: 18px;
   border-radius: 3px;
-  margin-right: 6px;
   white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ─── Pane status indicator (issue #23, refined in #27) ───────────────────
+ * ヘッダ最左に常時挿入されるバッジ。data-status で表示を切り替える。
+ *   - idle    : visibility:hidden でレイアウト幅を保ったまま不可視（cwd ジッタ防止）
+ *   - running : 緑（PTY 出力中, .pane.drag-over の #3fb950 と同系統に統一）
+ *   - waiting : 黄（WAITING_PATTERNS ヒット、点滅アニメで注意喚起）
+ * 旧 .waiting-badge はこのバッジに役割を一本化したため削除済。
+ * ::before で 6×6 のドットを currentColor で描画し、絵文字依存を排除した。 */
+.pane-status {
+  padding: 0 6px;
+  margin-right: 6px;
+  /* 最長ラベル「入力待ち」基準で min-width を予約（idle 時もレイアウトを保つ） */
+  min-width: 6ch;
   transition: color 0.15s, background 0.15s;
+}
+
+.pane-status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
   flex-shrink: 0;
 }
 
 .pane-status[data-status="idle"] {
-  display: none;
+  /* visibility:hidden により (1) レイアウト幅維持 (2) フォーカス対象外
+   * (3) aria-live 非発火 を同時に満たす。display:none だと cwd 位置がジッタする。 */
+  visibility: hidden;
 }
 
 .pane-status[data-status="running"] {
-  color: #56d364;
-  background: rgba(86, 211, 100, 0.15);
-  border: 1px solid rgba(86, 211, 100, 0.3);
+  /* .pane.drag-over の緑（#3fb950）と同系統に揃え、衝突を回避 */
+  color: #3fb950;
+  background: rgba(63, 185, 80, 0.15);
+  border: 1px solid rgba(63, 185, 80, 0.3);
 }
 
 .pane-status[data-status="waiting"] {
   color: #d29922;
   background: rgba(210, 153, 34, 0.15);
   border: 1px solid rgba(210, 153, 34, 0.3);
-  animation: badge-pulse 1.2s ease-in-out infinite;
+  /* .pane.waiting 枠の waiting-pulse(1.5s) と位相を揃える */
+  animation: badge-pulse 1.5s ease-in-out infinite;
 }
 
 @keyframes badge-pulse {
@@ -286,19 +308,11 @@ html, body {
 
 /* ─── Auto-input badge ────────────────────────────────────────────────────── */
 .auto-input-badge {
-  display: flex;
-  align-items: center;
-  gap: 3px;
   color: #58a6ff;
-  font-size: 10px;
-  font-weight: 600;
   background: rgba(88, 166, 255, 0.15);
   border: 1px solid rgba(88, 166, 255, 0.3);
   padding: 0 5px;
-  height: 18px;
-  border-radius: 3px;
   margin-right: 2px;
-  white-space: nowrap;
   animation: auto-input-flash 0.5s ease-out;
 }
 


### PR DESCRIPTION
## 概要

ペイン上部のステータスインジケータ（`.pane-status`）について、issue #27 で報告された複数の視覚・操作・アクセシビリティ上の不具合を一括で修正。

closes #27

仕様コメント: https://github.com/vektor-inc/vk-terminals/issues/27#issuecomment-4457464325

## 変更内容

- **running 色衝突解消**: `.pane-status[data-status="running"]` の色を `#56d364` 系から `#3fb950` 系（`rgba(63, 185, 80, ...)`）に統一し、`.pane.drag-over`（D&D 緑枠）との色衝突を回避
- **idle ジッタ解消**: `.pane-status[data-status="idle"]` を `display: none` から `visibility: hidden` に変更し、`.pane-status` 本体に `min-width: 6ch` を予約することで idle ↔ running/waiting 切替時に発生していた cwd 位置の左右ジッタを解消
- **アクセシビリティ対応**: `.pane-status` 要素に `role=\"status\" aria-live=\"polite\"` を静的に付与し、状態変化のたびに `aria-label=\"ステータス: 入力待ち\"` / `\"ステータス: 実行中\"` 形式を動的に更新（idle 時は `aria-label` を除去）。idle 遷移は `visibility: hidden` により aria-live 非発火・SR 読み上げ対象外
- **`.pane-badge` 共通化**: `.pane-status` と `.auto-input-badge` の共通プロパティ（`display: inline-flex` / `align-items` / `gap` / `font-size` / `font-weight` / `height` / `border-radius` / `white-space` / `flex-shrink`）を `.pane-badge` クラスに集約。HTML は `class=\"pane-badge pane-status\"` / `class=\"pane-badge auto-input-badge\"` の併記。`padding` / `margin-right` / 色 / アニメは個別クラスに残置
- **アニメ位相同期**: `@keyframes badge-pulse` の周期を `1.2s` から `1.5s` に変更し、`.pane.waiting` 枠の `waiting-pulse(1.5s)` と位相を同期
- **絵文字依存排除**: `🟢` / `🟡` 絵文字を廃止し、`.pane-status::before` 擬似要素で 6×6 の円を `border-radius: 50%` + `background: currentColor` で描画。JS 側のラベルを `'実行中'` / `'入力待ち'` に変更（idle 時は親の `visibility: hidden` が `::before` にも継承されてドットも自動的に不可視）

## 変更ファイル

- `renderer/style.css` — `.pane-badge` 新設、`.pane-status` の色・display・min-width・::before・animation 周期を更新、`.auto-input-badge` の共通プロパティを削除
- `renderer/app.js` — `updatePaneStatus()` の textContent と `aria-label` 動的更新、`renderLeaf()` の HTML テンプレートに共通クラス併記・`role` / `aria-live` / `aria-label` 静的付与
- `CHANGELOG.md` — `[ デザイン不具合修正 ]` エントリを追加

## 確認手順

### 前提条件

- `npm install` 済みの vk-terminals ローカル環境
- macOS なら VoiceOver（`Cmd + F5`）、Windows なら NVDA など任意のスクリーンリーダー

### 手順

1. `npm start` でアプリを起動
2. ヘッダの「分割」ボタンで **3 ペイン以上** に分割（左右分割と上下分割を組み合わせる）
3. 各ペインで `claude` を起動し、idle / running / waiting の状態を発生させる
   - idle: 何もせずプロンプトで待機する状態
   - running: 何か出力させる（例: `ls -la /` を実行）
   - waiting: Claude に質問してプロンプト承認待ち状態にする（または `vk-kore` のような承認系コマンドを実行）
4. ヘッダ最左のステータスバッジの表示を確認する
   - → running 時に緑（`#3fb950`）のドット + 「実行中」のテキストが表示される
   - → waiting 時に黄（`#d29922`）のドット + 「入力待ち」のテキストが 1.5s 周期で点滅し、`.pane.waiting` の枠点滅と位相が揃う
   - → idle 時はバッジ自体が不可視になるが、cwd 表示の位置は running / waiting 時と同じ位置を保ち、**左右にジッタしない**
5. ペイン上に他のペインタブをドラッグして `.pane.drag-over` の緑枠を表示させる
   - → running バッジの緑とドラッグオーバー枠の緑が同系統に揃い、衝突しない
6. スクリーンリーダーを有効化し、ステータスが running ↔ waiting に切り替わる瞬間を確認する
   - → 「ステータス: 実行中」「ステータス: 入力待ち」と読み上げられる（idle 遷移時は読み上げられない）
7. デグレ確認: 自動入力（HTTP API 経由 `/api/send-input`）を発火させる
   - → ヘッダ右側の `🤖 自動入力` バッジが従来通り 3 秒間表示され、その後消える

## スクリーンショット

UI の色・余白・絵文字に関わる変更を含むが、軽微な視覚調整のためテキストでの差分説明で代替する（必要なら別途追加）。

## レビュアー向けメモ

- `auto-input-badge` の `style.display` インライン上書き運用は `.pane-badge` の `display: inline-flex` を上書きしてしまう懸念があるが、本 PR では既存挙動を維持する目的で意図的に touch していない。別 issue でクラストグル方式に置き換える方向で別途起票予定
- 安藤・植草の手元レビューは PASS 済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ローカルHTTP APIで外部から状態取得・コマンド送信が可能に（新規ペイン作成・状態取得など）
  * タスクタイトルで外部リンク表示に対応、追加のペイン設定（分割/追加ペイン）をサポート
  * コマンドオプション（例: --no-claude/--plain）追加

* **改善**
  * ペインステータスを絵文字からテキスト表示へ変更し視認性とARIAを強化
  * バッジの見た目・アニメーション・レイアウトを最適化
  * 入力待ち判定に日本語パターンを追加

* **不具合修正**
  * 信頼確認プロンプトや初期コマンド周り、状態書き出しなどの動作を修正

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/34)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->