### PR TITLE
[ デザイン不具合修正 ] auto-input-badge のトグルをインラインスタイルから hidden 属性に置き換え

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -921,7 +921,7 @@ function renderLeaf(node, parentDirection) {
     <span class="pane-badge pane-status" data-status="${status}" role="status" aria-live="polite"${statusAriaLabel ? ` aria-label="${statusAriaLabel}"` : ''}>${statusLabel}</span>
     <span class="pane-cwd" title="${cwd}">${cwd}</span>
     <div class="pane-actions">
-      <span class="pane-badge auto-input-badge" style="display:none"></span>
+      <span class="pane-badge auto-input-badge" hidden></span>
       <button class="btn btn-move btn-move-left" title="左へ移動">◀</button>
       <button class="btn btn-move btn-move-down" title="下へ移動">▼</button>
       <button class="btn btn-move btn-move-up" title="上へ移動">▲</button>
@@ -1281,13 +1281,15 @@ ipcRenderer.on('terminal:auto-input', (event, termId) => {
   const badge = paneEl.querySelector('.auto-input-badge');
   if (badge) {
     badge.textContent = '🤖 自動入力';
-    badge.style.display = 'flex';
+    // インラインスタイルではなく hidden 属性でトグルし、共通バッジ basis
+    // (.pane-badge の display: inline-flex) を活かす（issue #35）
+    badge.hidden = false;
     paneEl.classList.add('auto-input');
     setTimeout(() => {
       const el = document.querySelector(`.pane[data-id="${paneId}"]`);
       if (!el) return;
       const b = el.querySelector('.auto-input-badge');
-      if (b) b.style.display = 'none';
+      if (b) b.hidden = true;
       el.classList.remove('auto-input');
     }, 3000);
   }

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -254,6 +254,14 @@ html, body {
   flex-shrink: 0;
 }
 
+/* hidden 属性で非表示にできるよう、クラスセレクタと同詳細度の UA スタイル
+ * (`[hidden] { display: none }`) ではなく、`.pane-badge[hidden]` (0,2,0) で
+ * 明示的に上書きする。これにより JS 側はインラインスタイルではなく
+ * `element.hidden = true/false` でトグルできる（issue #35）。 */
+.pane-badge[hidden] {
+  display: none;
+}
+
 /* ─── Pane status indicator (issue #23, refined in #27) ───────────────────
  * ヘッダ最左に常時挿入されるバッジ。data-status で表示を切り替える。
  *   - idle    : visibility:hidden でレイアウト幅を保ったまま不可視（cwd ジッタ防止）


### PR DESCRIPTION
Closes #35

## 概要

PR #34 で導入した `.pane-badge` 共通クラス（`display: inline-flex`）が、`.auto-input-badge` のインラインスタイル（`element.style.display = 'flex' / 'none'`）に常時上書きされて活きていなかった問題を修正します。issue #35 の推奨方針通り、HTML 標準の `hidden` 属性ベースのトグルに置き換えました。

## 変更内容

### `renderer/app.js`

- 初期 markup を `<span class="pane-badge auto-input-badge" style="display:none">` から `<span class="pane-badge auto-input-badge" hidden>` に変更
- `terminal:auto-input` ハンドラのトグルを `badge.style.display = 'flex' / 'none'` から `badge.hidden = false / true` に変更
- 意図が伝わるようコメントを追記（`.pane-badge` 共通 basis を活かすための置き換えである旨）

### `renderer/style.css`

- `.pane-badge[hidden] { display: none }` を追加

  HTML 仕様では UA stylesheet に `[hidden] { display: none }` が定義されていますが、これは詳細度 `(0,1,0)` で、作者 stylesheet 側の `.pane-badge { display: inline-flex }` と同詳細度です。同詳細度では作者 stylesheet 優先のため、`hidden` 属性をセットしても要素が消えません。`.pane-badge[hidden]`（詳細度 `(0,2,0)`）で明示的に上書きすることで、`!important` を使わずに自然な詳細度の階段で解決しています。

## 確認手順

### 前提条件
- `npm install` 済みの vk-terminals リポジトリ
- HTTP API ポート（13847）が他プロセスで使われていないこと

### 手順

#### Before（修正前の挙動 / 参考）
1. `main` ブランチで `npm start` を実行
2. 任意のペインで自動入力イベントを発火させる
   - 例: 別ターミナルから `curl -X POST http://127.0.0.1:13847/api/send -H 'Content-Type: application/json' -d '{"termId":"<TERM_ID>","text":"echo test\n"}'`
   - `<TERM_ID>` は `curl http://127.0.0.1:13847/api/states` で確認
3. ヘッダ右側に `🤖 自動入力` バッジが 3 秒間表示されることを確認
   → ✗ バッジの `display` がインラインスタイル `flex` で上書きされており、`.pane-badge` 共通定義（`inline-flex`）が効いていない（DevTools で確認可能）

#### After（修正後）
1. 本ブランチをチェックアウトして `npm start` を実行
2. 同様に HTTP API 経由で自動入力イベントを発火させる
3. ヘッダ右側に `🤖 自動入力` バッジが 3 秒間表示され、その後自動的に消えることを確認
   → ✓ バッジが正しく表示・非表示される
4. DevTools の Elements パネルでバッジ要素を確認
   → ✓ 表示中: `<span class=\"pane-badge auto-input-badge\">🤖 自動入力</span>`（インラインスタイルなし、`.pane-badge` の `display: inline-flex` が適用）
   → ✓ 非表示時: `<span class=\"pane-badge auto-input-badge\" hidden>`（`.pane-badge[hidden]` の `display: none` が適用）
5. バッジ表示中、左側の `.pane-status` バッジと同じ高さ・縦中央揃えで配置されることを確認
   → ✓ `.pane-badge` 共通の `height: 18px` / `align-items: center` が両バッジで一貫している
6. 自動入力イベントを繰り返し発火させ、毎回正しく表示・非表示が切り替わることを確認
   → ✓ デグレなし

## スクリーンショット

純粋なロジック・属性切替の修正で見た目の最終結果は変わらない（バッジの見え方自体は同じ）ため、スクリーンショットは省略します。差分は DevTools の Elements パネルでの DOM 表現（`style="display:none"` → `hidden` 属性）のみです。

## 補足

- CHANGELOG.md は更新していません。`rules/changelog.md` の「未リリース機能の不具合修正は不要」ルールに該当（vk-terminals の `CHANGELOG.md` にはバージョン番号セクションが存在せず、全エントリが未リリース状態）するためです。
- 他に同様の `.style.display = 'flex'/'none'` パターンが `renderer/app.js` 内に存在しないか確認済み（auto-input-badge 以外には該当なし）。本 PR のスコープは issue #35 通り auto-input-badge のみに絞っています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * バッジの表示制御をより確実に動作するよう改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/37)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->