### PR TITLE
[ セキュリティ修正 ] renderLeaf の innerHTML テンプレートリテラルに escape ヘルパーを適用

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ セキュリティ修正 ] `renderer/app.js` の `renderLeaf()` で `innerHTML` テンプレートリテラル経由でペインヘッダを組み立てる際、`cwd`（OS ファイルシステム由来）や `statusAriaLabel` などの動的文字列を属性値・テキスト内容にエスケープせず挿入していたため、ディレクトリ名に `"` や `<` を含むパスでヘッダ DOM が壊れ任意の HTML が注入されうる問題を修正（属性値用 `escAttr` / テキスト用 `escText` のエスケープヘルパーを導入し、`data-status` / `aria-label` / `pane-cwd` の `title` 属性とテキストノードに適用）（[#39](https://github.com/vektor-inc/vk-terminals/issues/39)）
 - [ 不具合修正 ] 自動入力バッジ（`🤖 自動入力`）の自動非表示用 `setTimeout` のタイマー ID を保持していなかったため、短時間に複数回 `terminal:auto-input` イベントが発火すると先発タイマーが残ったままになり、後発の表示が想定の 3 秒より早く消える不具合を修正（[#38](https://github.com/vektor-inc/vk-terminals/issues/38)）
 - [ 仕様変更 ] ペインを角丸カード状デザインに変更（`margin: 6px` ＋ `border-radius` を `.pane` / `.term-container` に付与、body 背景を `#333` に変更）。あわせて共通利用想定の CSS カスタムプロパティ `--vktm--border-radius--md` を導入
 - [ デザイン不具合修正 ] ペイン下部に body 背景が透けて白い余白が表示される不具合を修正（xterm.js が文字グリッド整数倍でしか描画できないために `.term-container` の下端に残る隙間を、`.term-container` の背景にターミナルテーマ色 `#0d1117` を当てることで隠す）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -275,6 +275,38 @@ function formatCwd(fullPath) {
   return '~/' + parts.slice(-2).join('/');
 }
 
+// ─── HTML escape helpers ──────────────────────────────────────────────────────
+// renderLeaf() などで innerHTML テンプレートリテラルに外部由来の文字列を挿入する際の
+// XSS 対策ヘルパー（issue #39）。
+//
+// なぜ必要か:
+//   - cwd は OS ファイルシステム由来（通常は安全だがディレクトリ名に `"` や `<` を含めることは技術的に可能）
+//   - statusAriaLabel は現状内部状態のみだが、将来 API 連携等で外部入力と統合される可能性があるため
+//     防御的にエスケープしておく
+//
+// 設計方針:
+//   - escText: テキストコンテンツ用（`<`, `>`, `&` をエスケープ）
+//   - escAttr: 属性値用（`<`, `>`, `&`, `"`, `'` をエスケープ。属性は常にダブルクォートで囲む前提）
+//   - 入力が文字列でない場合は空文字を返す（null/undefined の安全側フォールバック）
+//   - 既知の安全な静的リテラル（ボタンの title 属性など）には適用しない（差分最小化）
+function escText(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escAttr(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // ─── IPC: data from pty ───────────────────────────────────────────────────────
 ipcRenderer.on('terminal:data', (event, id, data) => {
   const paneId = Object.keys(terminals).find(k => terminals[k]?.termId === id);
@@ -925,9 +957,15 @@ function renderLeaf(node, parentDirection) {
   // role="status" + aria-live="polite" で SR にステータス変化を通知（aria-label は動的更新）。
   // 共通バッジ basis は .pane-badge（issue #27）、固有スタイルは .pane-status / .auto-input-badge。
   // 旧 .waiting-badge は role を .pane-status に一本化したため削除済（issue #23）。
+  //
+  // セキュリティ: テンプレートリテラル経由で innerHTML に挿入する外部由来の文字列は
+  // escAttr / escText でエスケープする（issue #39）。
+  //   - status / statusAriaLabel: 内部状態だが将来の外部入力統合を想定し防御的にエスケープ
+  //   - cwd: OS ファイルシステム由来。ディレクトリ名に `"` や `<` を含めることは技術的に可能
+  //   - statusLabel: getStatusPresentation() からの静的文字列だが、念のためエスケープ
   header.innerHTML = `
-    <span class="pane-badge pane-status" data-status="${status}" role="status" aria-live="polite"${statusAriaLabel ? ` aria-label="${statusAriaLabel}"` : ''}>${statusLabel}</span>
-    <span class="pane-cwd" title="${cwd}">${cwd}</span>
+    <span class="pane-badge pane-status" data-status="${escAttr(status)}" role="status" aria-live="polite"${statusAriaLabel ? ` aria-label="${escAttr(statusAriaLabel)}"` : ''}>${escText(statusLabel)}</span>
+    <span class="pane-cwd" title="${escAttr(cwd)}">${escText(cwd)}</span>
     <div class="pane-actions">
       <span class="pane-badge auto-input-badge" hidden></span>
       <button class="btn btn-move btn-move-left" title="左へ移動">◀</button>


### PR DESCRIPTION
## 概要

`renderer/app.js` の `renderLeaf()` でペインヘッダを `innerHTML` テンプレートリテラルから組み立てる際、外部由来の動的値（`cwd` / `status` / `statusAriaLabel` / `statusLabel`）にエスケープが無く、属性ブレイクアウト経由で DOM が破壊される・XSS が成立しうる状態だった。属性値用 `escAttr` / テキスト用 `escText` のエスケープヘルパーを新規追加し、`data-status` / `aria-label` / `.pane-cwd` の `title` 属性とテキストノードに適用してリスクを潰した。

Closes #39

## 採用方針

**案A（エスケープヘルパー導入、テンプレートリテラル維持）** を採用。

- `escText`: `&` `<` `>` をエスケープ（テキストノード用）
- `escAttr`: 上記に加え `"` `'` もエスケープ（属性値用、属性は常にダブルクォートで囲む前提）
- 入力が文字列でない場合は空文字を返す安全側フォールバック

**案B（`createElement` ベースへの全面置換）を選ばなかった理由**:

- `header.querySelector('.btn-move-left')` などで各ボタンのイベントハンドラを後段で接続しているため、DOM 構造を作り直すと接続コードへの波及が大きい
- 既に `renderTaskTitleContent()` で部分的に DOM API 化が進んでいる前例があり、リスクの高い箇所から段階移行する流儀と整合的
- 案A であれば既存テンプレートの可読性と挙動を完全保持しつつ最小差分で対処できる

## 確認手順

### 前提条件

- vk-terminals をローカルにクローン済み・`npm install` 済み
- macOS（OSC 7 でカレントディレクトリを報告するシェル設定があること。zsh の chpwd_functions 等）

### 手順

#### Before（修正前の再現手順）

1. `main` ブランチで `npm start` でアプリを起動する
2. 任意のターミナルペインで以下を実行:
   ```sh
   cd /tmp && mkdir -p 'evil\"<x>dir' && cd 'evil\"<x>dir'
   ```
3. ペインヘッダの cwd 表示を確認する
   → ✗ `\"` で `title` 属性がブレイクされ、`<x>` 部分が HTML として解釈されてヘッダ DOM が壊れる（属性ブレイクアウトが成立）
4. DevTools で `.pane-cwd` 要素を確認する
   → ✗ 属性値・テキストノードがエスケープされていない

#### After（修正後の確認手順）

1. このブランチ（`feature/issue-39`）で `npm start` でアプリを起動する
2. ヘッダ左の `pane-cwd` にカレントディレクトリ（例: `~/Documents/...`）が通常表示されること
   → ✓ 既存挙動と同じ
3. 任意のターミナルペインで以下を実行し、`\"` `<` `>` を含むディレクトリへ移動:
   ```sh
   cd /tmp && mkdir -p 'evil\"<x>dir' && cd 'evil\"<x>dir'
   ```
   → ✓ OSC 7 報告でヘッダ cwd 表示が `~/.../evil\"<x>dir` のように壊れず文字列として表示される
4. DevTools で `.pane-cwd` 要素を確認する
   → ✓ `title=\"~/.../evil&quot;&lt;x&gt;dir\"` のように属性値がエスケープされている
   → ✓ テキストノードも `evil\"&lt;x&gt;dir` 相当に正しくエスケープされて表示される
5. ステータスインジケータ（🟢 実行中 / 🟡 入力待ち）が従来通り表示・切替されること
   → ✓ `status` / `aria-label` のエスケープが既存挙動に影響しない
6. ペインを左右・上下に分割し、移動ボタン（◀ ▼ ▲ ▶）・閉じるボタン（✕）・折り畳みボタン（▾/▴）を操作する
   → ✓ いずれも従来通り動作する（`header.querySelector` でのイベント接続に影響していない）
7. タスクタイトル行（API 由来 `POST /api/set-title` / OSC 0,2 由来）の表示・リンク化が従来通り動作すること
   → ✓ デグレなし

## 影響範囲

- renderer プロセスのみ（`renderer/app.js` の 1 ファイル + `CHANGELOG.md`）
- Electron アプリのため WordPress プラグイン・テーマ等への影響なし
- 既存の DOM 構造・クラス名・属性値の見え方は不変（エスケープ前と後で「安全な入力（英数字＋一般的なパス文字）」に対する出力は完全一致）

## 変更ファイル

- `renderer/app.js`: HTML エスケープヘルパー（`escText` / `escAttr`）を追加 + `renderLeaf()` の `header.innerHTML` に適用
- `CHANGELOG.md`: `[ セキュリティ修正 ]` エントリ追記

セキュリティレビュー（安藤）PASS 済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ修正**
  * ペインヘッダにおける動的文字列の不適切なエスケープ問題を修正しました。入力値が予期しない動作を引き起こす可能性が解消されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->