### PR TITLE
[ 機能追加 ] ペインのタスクタイトル行ドラッグで他ペインの上下左右に再分割挿入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] ペインのタスクタイトル行をドラッグして他ペインの上下左右にドロップすると、その方向に再分割して挿入できる機能を追加（タスクタイトル行に `cursor: grab` / `grabbing`、ドロップ予定領域を半透明アクセントカラーで塗りつぶす視覚フィードバック、中央 20% はデッドゾーンとして無効化、ペイン1枚状態ではドラッグ不可）（[#40](https://github.com/vektor-inc/vk-terminals/issues/40)）
 - [ セキュリティ修正 ] `renderer/app.js` の `renderLeaf()` で `innerHTML` テンプレートリテラル経由でペインヘッダを組み立てる際、`cwd`（OS ファイルシステム由来）や `statusAriaLabel` などの動的文字列を属性値・テキスト内容にエスケープせず挿入していたため、ディレクトリ名に `"` や `<` を含むパスでヘッダ DOM が壊れ任意の HTML が注入されうる問題を修正（属性値用 `escAttr` / テキスト用 `escText` のエスケープヘルパーを導入し、`data-status` / `aria-label` / `pane-cwd` の `title` 属性とテキストノードに適用）（[#39](https://github.com/vektor-inc/vk-terminals/issues/39)）
 - [ 不具合修正 ] 自動入力バッジ（`🤖 自動入力`）の自動非表示用 `setTimeout` のタイマー ID を保持していなかったため、短時間に複数回 `terminal:auto-input` イベントが発火すると先発タイマーが残ったままになり、後発の表示が想定の 3 秒より早く消える不具合を修正（[#38](https://github.com/vektor-inc/vk-terminals/issues/38)）
 - [ 仕様変更 ] ペインを角丸カード状デザインに変更（`margin: 6px` ＋ `border-radius` を `.pane` / `.term-container` に付与、body 背景を `#333` に変更）。あわせて共通利用想定の CSS カスタムプロパティ `--vktm--border-radius--md` を導入

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1093,16 +1093,18 @@ function renderLeaf(node, parentDirection) {
   // タスクタイトル行（OSC 0/2 または POST /api/set-title で設定された文字列を表示）。
   // 空のときは .empty クラスで非表示にし、xterm の表示領域を圧迫しない。
   // apiUrl があるときは .has-link を付与し、内部を <a> 化する（renderTaskTitleContent）。
+  // ペイン D&D の可否判定（issue #40）。leaf が 2 つ以上ある時のみ drag 起点になれる。
+  // ルート leaf（ペイン 1 枚状態）は移動先が無いため drag 不可。
+  // 空タイトル時も D&D 可なら .empty を付けず、ハンドルとして掴める高さを確保する。
+  const canDragPane = !!(tree && getAllLeafIds(tree).length > 1);
   const taskTitleEl = document.createElement('div');
   taskTitleEl.className = 'pane-task-title'
-    + (taskTitle ? '' : ' empty')
+    + (taskTitle || canDragPane ? '' : ' empty')
     + (taskUrl ? ' has-link' : '');
   renderTaskTitleContent(taskTitleEl, taskTitle, taskUrl);
   // URL 有りのときは子 <a> 側の title 属性に集約するため、親には付けない（親子競合回避）。
   if (taskTitle && !taskUrl) taskTitleEl.title = taskTitle;
-  // ペイン D&D 起点（issue #40）。leaf が 2 つ以上ある時のみ draggable を付与する。
-  // ルート leaf（ペイン 1 枚状態）は移動先が無いため drag 不可。
-  if (tree && getAllLeafIds(tree).length > 1) {
+  if (canDragPane) {
     taskTitleEl.draggable = true;
     taskTitleEl.addEventListener('dragstart', e => {
       // 独自 MIME に paneId を載せる。これにより受け側はファイル D&D と分岐できる。

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -6,6 +6,14 @@ const { stripAnsiForDisplay } = require('../utils/stripAnsi');
 
 // ─── State ────────────────────────────────────────────────────────────────────
 let tree = null;       // Layout tree root
+// ペイン D&D 中の状態（issue #40）。リサイズ用の dragState とは別変数で衝突回避。
+//   - srcId: ドラッグ中のペイン id
+//   - lastTargetId / lastDir: 直前フレームで描画したオーバーレイの対象と方向（再描画スキップ判定用）
+let paneDragState = null;
+// pane D&D 用の独自 MIME。既存のファイル D&D（パス挿入）と分岐するためのキー（issue #40）
+const PANE_DRAG_MIME = 'application/x-vk-pane';
+// 中央デッドゾーンの比率（issue #40）。0.2 = 中央 20% を無効ゾーンとして扱う
+const PANE_DROP_DEADZONE = 0.2;
 // terminals[paneId] のフィールド概要（status / runningTimer は issue #23 で追加）:
 //   - waiting (bool): 内部判定用フラグ。WAITING_PATTERNS ヒットで true。
 //     states.json 後方互換のために残してある（task-queue 等の外部連携が参照している）。
@@ -404,6 +412,8 @@ function renderTaskTitleContent(el, title, url) {
   link.href = '#'; // 実 URL は入れない（Electron の target="_blank" 経由の新 BrowserWindow 防止）
   link.setAttribute('role', 'link');
   link.setAttribute('aria-label', `${title}（外部ブラウザで開く）`);
+  // ペイン D&D 起点は親 .pane-task-title 側。リンクの URL drag（href のドラッグ）が割り込まないよう抑止（issue #40）。
+  link.draggable = false;
   // ホバー時のツールチップにはタイトル本文と URL の両方を改行区切りで含める。
   // 親要素 .pane-task-title の title 属性は has-link 時に外して競合を避ける
   // （ブラウザ実装により親子 title の優先順位が不定なため。updatePaneTitle / renderLeaf 側で制御）。
@@ -540,6 +550,31 @@ function swapLeavesInTree(node, idA, idB) {
 function getAllLeafIds(node) {
   if (node.type === 'leaf') return [node.id];
   return [...getAllLeafIds(node.first), ...getAllLeafIds(node.second)];
+}
+
+// tree 内の targetId（leaf）の位置を、srcLeaf を dir 方向に挿入した split で置き換える（issue #40）。
+//   dir = 'left'  : 新 split は split-h、srcLeaf が左 / target が右
+//   dir = 'right' : 新 split は split-h、target が左 / srcLeaf が右
+//   dir = 'up'    : 新 split は split-v、srcLeaf が上 / target が下
+//   dir = 'down'  : 新 split は split-v、target が上 / srcLeaf が下
+// 新規 split の ratio は 0.5 固定（ドロップ位置から動的算出は UX が裏切られやすいため）。
+function insertBesideLeaf(node, targetId, srcLeaf, dir) {
+  if (!srcLeaf || (dir !== 'left' && dir !== 'right' && dir !== 'up' && dir !== 'down')) {
+    return node;
+  }
+  const direction = (dir === 'left' || dir === 'right') ? 'h' : 'v';
+  const targetNode = findNode(node, targetId);
+  if (!targetNode) return node;
+  // src と target の順序を dir から決める
+  const srcFirst = (dir === 'left' || dir === 'up');
+  const newSplit = {
+    type: 'split',
+    direction,
+    ratio: 0.5,
+    first: srcFirst ? srcLeaf : targetNode,
+    second: srcFirst ? targetNode : srcLeaf,
+  };
+  return replaceNode(node, targetId, newSplit);
 }
 
 // tree 内で指定 leaf を直接の子に持つ split ノードと、そのどちら側にいるか（'first' or 'second'）を返す。
@@ -830,6 +865,133 @@ function movePane(paneId, dir) {
   });
 }
 
+// ─── Pane D&D helpers (issue #40) ────────────────────────────────────────────
+// dragover の event 座標から、対象ペイン内のドロップ方向を算出する。
+//   - 中央 PANE_DROP_DEADZONE (= 0.2) 範囲は無効（null を返す）
+//   - 外周は最も端に近い辺（左/右/上/下）を選ぶ
+// 引数は対象ペインの DOM 要素と dragover イベント。
+function computePaneDropDir(paneEl, event) {
+  const rect = paneEl.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  // offsetX/Y は paneEl 基準ではない場合があるので getBoundingClientRect ベースで再計算する
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  const fx = x / rect.width;   // 0..1
+  const fy = y / rect.height;  // 0..1
+  // 中央デッドゾーン: 中心からの距離が PANE_DROP_DEADZONE/2 以内
+  const dz = PANE_DROP_DEADZONE / 2;
+  if (Math.abs(fx - 0.5) <= dz && Math.abs(fy - 0.5) <= dz) return null;
+  // 各辺までの距離（正規化後）
+  const distLeft = fx;
+  const distRight = 1 - fx;
+  const distTop = fy;
+  const distBottom = 1 - fy;
+  const min = Math.min(distLeft, distRight, distTop, distBottom);
+  if (min === distLeft) return 'left';
+  if (min === distRight) return 'right';
+  if (min === distTop) return 'up';
+  return 'down';
+}
+
+// `#pane-drop-indicator` を body 直下にグローバル 1 個だけ用意して使い回す。
+// `dragover` で対象ペインの矩形 + dir からその半分を半透明アクセントカラーで塗りつぶす。
+// pointer-events: none 必須（オーバーレイ自身が dragover を奪わないため）。
+function getPaneDropIndicator() {
+  let el = document.getElementById('pane-drop-indicator');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'pane-drop-indicator';
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+function updatePaneDropIndicator(paneEl, dir) {
+  const indicator = getPaneDropIndicator();
+  if (!dir) {
+    indicator.style.display = 'none';
+    return;
+  }
+  const r = paneEl.getBoundingClientRect();
+  let top = r.top;
+  let left = r.left;
+  let width = r.width;
+  let height = r.height;
+  // dir 方向の半分の矩形に縮める
+  if (dir === 'left') {
+    width = r.width / 2;
+  } else if (dir === 'right') {
+    left = r.left + r.width / 2;
+    width = r.width / 2;
+  } else if (dir === 'up') {
+    height = r.height / 2;
+  } else if (dir === 'down') {
+    top = r.top + r.height / 2;
+    height = r.height / 2;
+  }
+  indicator.style.display = 'block';
+  indicator.style.top = `${top}px`;
+  indicator.style.left = `${left}px`;
+  indicator.style.width = `${width}px`;
+  indicator.style.height = `${height}px`;
+}
+
+function removePaneDropIndicator() {
+  const el = document.getElementById('pane-drop-indicator');
+  if (el) el.style.display = 'none';
+}
+
+// drop 完了後 / dragend / キャンセル時の共通クリーンアップ。
+function cleanupPaneDrag() {
+  document.body.classList.remove('pane-dragging');
+  document.querySelectorAll('.pane.pane-drag-source').forEach(el => {
+    el.classList.remove('pane-drag-source');
+  });
+  removePaneDropIndicator();
+  paneDragState = null;
+}
+
+// 実際のツリー再構築（issue #40）。
+//   1. src / target 両方に expandIfCollapsed（畳まれたまま新 split に入って操作不能ペインになるのを防止）
+//   2. removeNode(tree, srcId) でドラッグ元を抜く（親 split が単一子になるケースは removeNode 側で自動処理）
+//   3. insertBesideLeaf で target の位置に srcLeaf を dir 方向で挿入
+//   4. render() → requestAnimationFrame(() => { fitAll(); focusPane(srcId); })
+//   5. sanitizeCollapsedFlags(tree) を必ず実行（split-h 配下に collapsed leaf が紛れ込むケースの補正）
+function handlePaneDrop(srcId, targetId, dir) {
+  if (!tree) return;
+  if (!srcId || !targetId || srcId === targetId) return;
+  const srcLeaf = findNode(tree, srcId);
+  if (!srcLeaf || srcLeaf.type !== 'leaf') return;
+
+  // 折り畳み状態のまま動かすと新 split で操作不能ペインになるため、両方とも展開しておく
+  expandIfCollapsed(srcId);
+  expandIfCollapsed(targetId);
+
+  // 動かす leaf のスナップショット（collapsed 等の付随フィールドごと持ち運ぶ。
+  // ただし上で expandIfCollapsed を通したので collapsed は false 化されている）
+  const srcSnapshot = { ...findNode(tree, srcId) };
+
+  // src を抜いた tree を作る
+  const removed = removeNode(tree, srcId);
+  if (!removed) return; // 想定外（leaf が 1 枚しかなかった等）
+  // 抜いた結果 target が消えるケースは無いはずだが、念のためチェック
+  if (!findNode(removed, targetId)) return;
+
+  // target の位置に srcSnapshot を dir 方向で挿入
+  const next = insertBesideLeaf(removed, targetId, srcSnapshot, dir);
+  if (!next) return;
+  tree = next;
+
+  // split-h 配下に collapsed leaf が紛れ込むなどの不整合を補正
+  sanitizeCollapsedFlags(tree);
+
+  render();
+  requestAnimationFrame(() => {
+    fitAll();
+    focusPane(srcId);
+  });
+}
+
 function focusPane(paneId) {
   // 折り畳まれているペインに focus が当たっても自動展開はしない（明示操作のみで展開する方針）。
   // フォーカス枠は当てるが xterm への入力フォーカスはスキップする（ヘッダだけ見える状態のまま）。
@@ -938,6 +1100,25 @@ function renderLeaf(node, parentDirection) {
   renderTaskTitleContent(taskTitleEl, taskTitle, taskUrl);
   // URL 有りのときは子 <a> 側の title 属性に集約するため、親には付けない（親子競合回避）。
   if (taskTitle && !taskUrl) taskTitleEl.title = taskTitle;
+  // ペイン D&D 起点（issue #40）。leaf が 2 つ以上ある時のみ draggable を付与する。
+  // ルート leaf（ペイン 1 枚状態）は移動先が無いため drag 不可。
+  if (tree && getAllLeafIds(tree).length > 1) {
+    taskTitleEl.draggable = true;
+    taskTitleEl.addEventListener('dragstart', e => {
+      // 独自 MIME に paneId を載せる。これにより受け側はファイル D&D と分岐できる。
+      try {
+        e.dataTransfer.setData(PANE_DRAG_MIME, node.id);
+      } catch (_e) { /* setData が失敗しても続行 */ }
+      e.dataTransfer.effectAllowed = 'move';
+      paneDragState = { srcId: node.id, lastTargetId: null, lastDir: null };
+      document.body.classList.add('pane-dragging');
+      el.classList.add('pane-drag-source');
+    });
+    taskTitleEl.addEventListener('dragend', () => {
+      // 念のための後始末。drop ハンドラが先に動いていればここはすべて no-op になる。
+      cleanupPaneDrag();
+    });
+  }
   el.appendChild(taskTitleEl);
 
   const header = document.createElement('div');
@@ -1022,6 +1203,69 @@ function renderLeaf(node, parentDirection) {
     closePane(node.id);
   });
   el.addEventListener('mousedown', () => focusPane(node.id));
+
+  // ─── Drag & Drop: pane insertion (issue #40) ─────────────────────────────
+  // 別ペインのタスクタイトル行をドラッグして、このペインの上下左右にドロップすると
+  // その方向に再分割して挿入する。同一ペインへのドロップは no-op。
+  // ファイル D&D（パス挿入）とは独自 MIME（PANE_DRAG_MIME）で分岐する。
+  el.addEventListener('dragover', e => {
+    if (!e.dataTransfer.types.includes(PANE_DRAG_MIME)) return;
+    if (!paneDragState) return;
+    // 同一ペインへのドロップは無効化（インジケータも出さない）
+    if (paneDragState.srcId === node.id) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'none';
+      // 同一ペイン上ではオーバーレイを消しておく
+      if (paneDragState.lastTargetId !== null) {
+        removePaneDropIndicator();
+        paneDragState.lastTargetId = null;
+        paneDragState.lastDir = null;
+      }
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'move';
+    const dir = computePaneDropDir(el, e);
+    // 前フレームと同じ判定ならオーバーレイ更新スキップ（負荷低減）
+    if (paneDragState.lastTargetId === node.id && paneDragState.lastDir === dir) return;
+    paneDragState.lastTargetId = node.id;
+    paneDragState.lastDir = dir;
+    updatePaneDropIndicator(el, dir);
+  });
+  el.addEventListener('dragleave', e => {
+    if (!paneDragState) return;
+    if (!e.dataTransfer.types.includes(PANE_DRAG_MIME)) return;
+    // ペイン要素の外（自要素内の子から親自身は relatedTarget が自要素になりうるので除外）
+    if (!el.contains(e.relatedTarget)) {
+      if (paneDragState.lastTargetId === node.id) {
+        removePaneDropIndicator();
+        paneDragState.lastTargetId = null;
+        paneDragState.lastDir = null;
+      }
+    }
+  });
+  el.addEventListener('drop', e => {
+    if (!e.dataTransfer.types.includes(PANE_DRAG_MIME)) return;
+    if (!paneDragState) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const srcId = e.dataTransfer.getData(PANE_DRAG_MIME) || paneDragState.srcId;
+    // 同一ペインは no-op
+    if (!srcId || srcId === node.id) {
+      cleanupPaneDrag();
+      return;
+    }
+    const dir = computePaneDropDir(el, e);
+    if (!dir) {
+      // デッドゾーン（中央20%）は何もしない
+      cleanupPaneDrag();
+      return;
+    }
+    handlePaneDrop(srcId, node.id, dir);
+    cleanupPaneDrag();
+  });
 
   // ─── Drag & Drop: file path insertion ─────────────────────────────────────
   el.addEventListener('dragover', e => {
@@ -1175,6 +1419,16 @@ document.addEventListener('drop', e => {
   e.preventDefault();
   e.stopPropagation();
   resetFileDragState();
+  // ペイン D&D が進行中のまま、ペイン外でドロップされた場合の保険（issue #40）。
+  // ペイン側 drop ハンドラはバブリングを stopPropagation するため通常はここまで来ない。
+  if (paneDragState) cleanupPaneDrag();
+});
+
+// ESC キャンセル / ウィンドウ外ドロップ / ブラウザによる中断時の保険（issue #40）。
+// dragend は dragstart した element に届くが、render() で要素が差し替わるケース等を考慮して
+// document レベルにも保険を仕掛けておく。
+document.addEventListener('dragend', () => {
+  if (paneDragState) cleanupPaneDrag();
 });
 
 // ─── Global drag handler ──────────────────────────────────────────────────────

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1226,8 +1226,9 @@ function renderLeaf(node, parentDirection) {
     }
     e.preventDefault();
     e.stopPropagation();
-    e.dataTransfer.dropEffect = 'move';
     const dir = computePaneDropDir(el, e);
+    // 中央デッドゾーン（dir=null）はカーソルを no-drop に。オーバーレイも消す。
+    e.dataTransfer.dropEffect = dir ? 'move' : 'none';
     // 前フレームと同じ判定ならオーバーレイ更新スキップ（負荷低減）
     if (paneDragState.lastTargetId === node.id && paneDragState.lastDir === dir) return;
     paneDragState.lastTargetId = node.id;

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1434,6 +1434,13 @@ document.addEventListener('dragend', () => {
   if (paneDragState) cleanupPaneDrag();
 });
 
+document.addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape') return;
+  if (!paneDragState) return;
+  e.preventDefault();
+  cleanupPaneDrag();
+});
+
 // ─── Global drag handler ──────────────────────────────────────────────────────
 document.addEventListener('mousemove', e => {
   if (!dragState) return;

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -527,21 +527,30 @@ body.pane-dragging .term-container {
   pointer-events: none;
 }
 
-/* ドラッグ元ペインのうっすら表示 */
-.pane.pane-drag-source {
+/* ドラッグ中はテキスト選択を抑止（既存の resizing 系と同じパターン）。
+ * タイトル行を掴んだ際の選択ハイライト残りを防ぐ。 */
+body.pane-dragging * {
+  user-select: none;
+}
+
+/* ドラッグ元ペインのうっすら表示。ペイン全体ではなく xterm 本体のみに絞ることで、
+ * タイトル行・ヘッダの識別性（どのペインを掴んでいるか）を確保する。 */
+.pane.pane-drag-source .term-container {
   opacity: 0.5;
 }
 
 /* ドロップ予定領域のオーバーレイ（body 直下にグローバル 1 個）。
  * 位置とサイズは JS が dragover で毎フレーム top/left/width/height を更新する。
- * pointer-events:none を当てないとオーバーレイ自身が dragover を奪う。 */
+ * pointer-events:none を当てないとオーバーレイ自身が dragover を奪う。
+ * z-index はタイトルバー（1000）の一段上に揃え、最前面意図を明示。
+ * dir 切替時のアニメは斜めに伸縮して紛らわしいので transition は付けず即時スナップ。
+ * border-radius も実際の split 結果（角は四角）と齟齬が出ないよう 0。 */
 #pane-drop-indicator {
   position: fixed;
   display: none;
   pointer-events: none;
-  z-index: 9999;
-  background: rgba(88, 166, 255, 0.25);
+  z-index: 1100;
+  background: rgba(88, 166, 255, 0.18);
   border: 2px solid #58a6ff;
-  border-radius: var(--vktm--border-radius--md);
-  transition: top 0.06s linear, left 0.06s linear, width 0.06s linear, height 0.06s linear;
+  border-radius: 0;
 }

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -498,3 +498,50 @@ body.resizing-v * {
 body.file-dragging .pane {
   cursor: copy;
 }
+
+/* ─── Pane drag & drop (issue #40) ─────────────────────────────────────────
+ * ペインタイトル行をドラッグ起点として、他ペインの上下左右にドロップして
+ * その方向に再分割して挿入する機能。
+ *
+ *   - .pane-task-title の cursor を grab に（draggable 属性が付いているときのみ）
+ *   - ドラッグ中は body.pane-dragging が付き、.term-container を pointer-events:none
+ *     にして xterm の領域上でも dragover が中断されないようにする
+ *   - ドラッグ元ペインは opacity:0.5 でうっすら見せる
+ *   - ドロップ予定の半分（または1/2矩形）は #pane-drop-indicator を body 直下に
+ *     position:fixed で出してアクセントカラーで塗りつぶす（pointer-events:none 必須） */
+.pane-task-title[draggable="true"] {
+  cursor: grab;
+}
+
+.pane-task-title[draggable="true"]:active {
+  cursor: grabbing;
+}
+
+body.pane-dragging .pane-task-title[draggable="true"] {
+  cursor: grabbing;
+}
+
+/* ドラッグ中は xterm 領域で dragover が止まらないように pointer-events を切る。
+ * .pane-task-title / .pane-header は引き続きイベントを受け取れる必要がある。 */
+body.pane-dragging .term-container {
+  pointer-events: none;
+}
+
+/* ドラッグ元ペインのうっすら表示 */
+.pane.pane-drag-source {
+  opacity: 0.5;
+}
+
+/* ドロップ予定領域のオーバーレイ（body 直下にグローバル 1 個）。
+ * 位置とサイズは JS が dragover で毎フレーム top/left/width/height を更新する。
+ * pointer-events:none を当てないとオーバーレイ自身が dragover を奪う。 */
+#pane-drop-indicator {
+  position: fixed;
+  display: none;
+  pointer-events: none;
+  z-index: 9999;
+  background: rgba(88, 166, 255, 0.25);
+  border: 2px solid #58a6ff;
+  border-radius: var(--vktm--border-radius--md);
+  transition: top 0.06s linear, left 0.06s linear, width 0.06s linear, height 0.06s linear;
+}


### PR DESCRIPTION
## 概要

ペイン上部のタスクタイトル行を掴んで他ペインの上半分／下半分／左半分／右半分へドラッグ＆ドロップすると、ドロップした方向に再分割（split）してそのペインが挿入されるようにする機能追加です。issue #40 のリクエスト「ペインのタイトル部分あたりをドラッグ＆ドロップで移動できるようにしたい」に対応します。

これまでは「⇔」「⇕」ボタンや `Cmd+\` / `Cmd+-` でしか分割方向を選べず、既存ペインの好きな辺に対して別ペインを差し込むには一度閉じて作り直す必要がありました。本対応で、視覚的にどの方向に挿入されるかを確認しながらマウス操作だけでレイアウトを組み直せるようにしています。

Closes #40

## 主な変更

- `renderer/app.js`
  - タスクタイトル行（`.pane-title`）を `draggable="true"` 化し、`dragstart` / `dragover` / `dragleave` / `drop` / `dragend` のハンドラと ESC キャンセル / クリーンアップを追加
  - ドロップ先ペインのカーソル位置から **上 / 下 / 左 / 右** の 4 方向を判定（中央 20% は dead zone とし、`dropEffect = 'none'` で no-drop カーソルを返す）
  - 既存のペインツリー（split / leaf）に対し、ドロップ方向に応じて新しい split ノードを挿入する処理を追加（同一ペイン上へのドロップは無効化）
  - ペイン1枚（ルート leaf）状態では `draggable` を付けず、ドラッグそのものを開始できないようにガード
- `renderer/style.css`
  - タスクタイトル行に `cursor: grab` / ドラッグ中 `grabbing`
  - ドラッグ中、元ペインの xterm 部分（`.term-container`）を `opacity` で半透明にして「いま掴んでいるペイン」が分かるように
  - ドロップ予定領域（上下左右の半分）を `.pane-drop-overlay` の半透明アクセントカラーで塗りつぶし、どの方向に挿入されるかを視覚化（植草レビューでアクセントカラー・濃度・dead zone 表示を調整済み）
- `CHANGELOG.md`
  - `[ 機能追加 ]` エントリを 1 件追加（#40 リンク付き）

## 確認手順

### 前提条件

- `npm install` 済みの vk-terminals ローカル環境
- ペイン分割に必要な複数ターミナルが起動できる状態（特別なテストデータは不要）

### 手順

1. main から最新を取得し、ブランチ `feature/issue-40-pane-drag-drop` をチェックアウト
2. `npm start` でアプリを起動
3. 既存の「⇔」「⇕」ボタン、または `Cmd+\` / `Cmd+-` などで複数ペイン状態にする
4. あるペインのタスクタイトル行をマウスで掴み、別ペインの **上半分** にゆっくり移動させる
   → ✓ 元ペインの xterm 部分が半透明になる
   → ✓ ドロップ先ペインの **上半分** に半透明アクセントカラーの矩形オーバーレイが表示される
5. そのままドロップする
   → ✓ ドロップ先ペインの上側に元ペインが挿入される形で再分割される（split が作られる）
   → ✓ xterm の表示が崩れず、focus は元ペインに残る
6. 同様に、別ペインの **下半分 / 左半分 / 右半分** へドラッグしてドロップする
   → ✓ それぞれ下 / 左 / 右に再分割で挿入される
7. ドラッグ中、ドロップ先ペインの **中央 20%** にカーソルを止める
   → ✓ オーバーレイが消え、カーソルが no-drop 表示になる
   → ✓ そのままドロップしても何も起こらない（レイアウト変化なし）
8. ドラッグを開始してから ESC キーを押す
   → ✓ オーバーレイ・半透明表示がクリーンアップされ、元の状態に戻る
   → ✓ もう一度同じタイトル行を掴み直してドラッグできる
9. ペインを 1 枚（ルート leaf）の状態まで閉じる
   → ✓ タスクタイトル行が `draggable` になっておらず、そもそもドラッグを開始できない（カーソルも `grab` にならない）

### デグレ確認

- ドラッグせず通常クリックでタスクタイトルの編集や URL リンクが従来どおり動くこと
- 「⇔」「⇕」ボタン・`Cmd+\` / `Cmd+-` での通常の分割が変わらず動くこと
- ペイン折り畳み（▾ / ▴）・自動入力バッジ・ステータスインジケータなど既存表示に影響がないこと

## スクリーンショット

> 動作中の D&D オーバーレイを伴うため、レビュー時に司または植草が実機で撮影し追加してください（和田の作業環境では Electron アプリのスクリーンショット添付ができないためプレースホルダで失礼します）。

### Before
（ドラッグ機能がないので静止画像なし）

### After
- ドラッグ中: 元ペイン xterm が半透明 + ドロップ先候補の半分にアクセントカラーのオーバーレイ
- 中央 20% にカーソル: オーバーレイ消失 + no-drop カーソル

## 関連

- Issue: #40
- 植草レビュー反映済み（視覚フィードバック調整: コミット 584a507）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ペインのタスク行をドラッグして他ペインの上下左右へドロップし、その方向で再分割して挿入可能に。中央20%はデッドゾーン、単一ペイン時はドラッグ不可（関連Issueあり）。
* **スタイル**
  * ドラッグ時のカーソル変更、ドラッグ元の半透明化、グローバルなドロップインジケータ表示、選択抑止などの視覚挙動を追加。
* **不具合修正**
  * 外部リンクとのドラッグ競合を抑止し、ドラッグ中断（ESC含む）時の状態クリアを確実化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-terminals/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->