### PR TITLE
[ 機能追加 ] モバイルページのターミナルカードを折り畳めるように変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] モバイルページ（`renderer/mobile.html`）の各ターミナルカードを、ヘッダをタップして折り畳めるように変更。折り畳むと出力・操作ボタンが隠れ、状態は再読込をまたいで保持（[#49](https://github.com/vektor-inc/vk-terminals/issues/49)）
 - [ セキュリティ修正 ] HTTP API の更新系エンドポイント（`POST /api/send`・`POST /api/set-title`・`POST /api/new-pane`）に Origin 検証を追加。ブラウザが cross-origin POST 時に必ず送る `Origin` ヘッダと `Host` を突き合わせ、不一致なら `403` を返す。悪意あるサイトから `http://<apiHost>:13847/api/send` へ CSRF でターミナルへ任意入力を流す攻撃を防ぐ。`Origin` ヘッダを持たない非ブラウザクライアント（curl 等）や同一オリジンのモバイルページは従来どおり素通り（後方互換）
 - [ 機能追加 ] スマホ等のリモート端末から状態確認・応答するためのモバイルページを追加。HTTP API に `GET /`（`/index.html` も同義）を追加し、`renderer/mobile.html` を配信する。ページは既存の `GET /api/states` を 2 秒ごとにポーリングして各ターミナルをカード表示（`status` を `idle`／`running`／`waiting` で色分け・ドット表示、`waiting` を点滅、`waiting` > `running` > `idle` の順でソート）、`lastLines` は ANSI 制御コードを除去して末尾を表示する。各カードに quick ボタン（`1`／`2`／`3`／`↵`／`Yes(y↵)`／`No(n↵)`／`Esc`／`Ctrl-C`）と自由入力欄（末尾改行トグル付き）を備え、`POST /api/send` で応答できる
 - [ 機能追加 ] HTTP API のバインド先ホストを `config.json` の `apiHost` で変更できるように追加（既定 `127.0.0.1`）。Tailscale IP（`100.x.x.x`）を指定すると tailnet 内からのみ到達可能になり、スマホ等から `http://<apiHost>:13847/`（上記モバイルページ）で状態確認・応答できる（LAN や公開インターネットには出さない）。`0.0.0.0` 指定で全 I/F 待ち受けも可。指定ホストが未割り当て（`EADDRNOTAVAIL`、例: Tailscale 未接続）の場合は `127.0.0.1` にフォールバックして API を起動し続ける。`config.example.json` に `apiHost` の既定値を追記

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -30,7 +30,15 @@
   #list { padding: 10px; display: flex; flex-direction: column; gap: 10px; }
   .card { background: var(--card); border: 1px solid var(--card-border); border-radius: 12px;
     overflow: hidden; }
-  .card-head { display: flex; align-items: center; gap: 8px; padding: 10px 12px; }
+  .card-head { display: flex; align-items: center; gap: 8px; padding: 10px 12px;
+    min-height: 44px; cursor: pointer; user-select: none; -webkit-user-select: none; }
+  .card-head:active { background: #232830; }
+  .chevron { flex: none; color: var(--muted); font-size: 13px; line-height: 1;
+    transition: transform 0.12s ease; }
+  .card.collapsed .chevron { transform: rotate(-90deg); }
+  @media (prefers-reduced-motion: reduce) {
+    .chevron { transition: none; }
+  }
   .dot { width: 10px; height: 10px; border-radius: 50%; flex: none; }
   .dot.idle { background: var(--idle); }
   .dot.running { background: var(--running); box-shadow: 0 0 0 3px rgba(59,130,246,0.18); }
@@ -49,8 +57,9 @@
   .badge.waiting { background: rgba(245,166,35,0.18); color: #ffce7a; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 1.45;
-    white-space: pre-wrap; word-break: break-word; max-height: 180px; overflow-y: auto;
+    white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow-y: auto;
     border-top: 1px solid var(--card-border); }
+  .card.collapsed pre.lines, .card.collapsed .actions { display: none; }
   .actions { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 7px; }
   .row { display: flex; gap: 6px; flex-wrap: wrap; }
   button.k { flex: 1 1 auto; min-width: 44px; padding: 9px 6px; border-radius: 8px;
@@ -135,7 +144,44 @@ var QUICK = [
 ];
 
 var list = document.getElementById("list");
-var cards = {}; // termId -> { root, pre, name, cwd, dot, badge }
+var cards = {}; // termId -> { root, pre, name, cwd, dot, badge, head, chevron }
+
+// 折り畳み状態は cards とは独立した plain object で持つ（termId -> bool）。
+// 理由: render() 末尾で states から消えた端末は cards[termId].root.remove() され
+// cards から消える。端末が一瞬消えて復活すると ensureCard がまっさらな DOM を
+// 作り直すため、DOM の classList を状態の真実にすると吹き飛ぶ。collapsed を
+// 別管理し、render のカード更新ループで毎回 classList を当て直すことで
+// 再描画・復活をまたいで状態を一致させる。
+var COLLAPSE_KEY = "vkt.collapsed";
+var collapsed = {}; // termId -> bool
+try {
+  var saved = localStorage.getItem(COLLAPSE_KEY);
+  if (saved) {
+    var parsed = JSON.parse(saved);
+    if (parsed && typeof parsed === "object") collapsed = parsed;
+  }
+} catch (e) { /* 壊れた JSON でも落とさない */ }
+
+function saveCollapsed() {
+  try { localStorage.setItem(COLLAPSE_KEY, JSON.stringify(collapsed)); }
+  catch (e) { /* 保存失敗は無視（プライベートモード等） */ }
+}
+
+// chevron / aria-expanded を collapsed 状態に同期
+function syncCollapseUI(c, termId) {
+  var isCollapsed = !!collapsed[termId];
+  c.root.classList.toggle("collapsed", isCollapsed);
+  c.head.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
+  // chevron のグリフは ▾ 固定。向きは CSS の rotate(-90deg) で表現する。
+}
+
+function toggleCollapse(termId) {
+  var c = cards[termId];
+  if (!c) return;
+  collapsed[termId] = !collapsed[termId];
+  syncCollapseUI(c, termId);
+  saveCollapsed();
+}
 
 function ensureCard(termId) {
   if (cards[termId]) return cards[termId];
@@ -148,7 +194,25 @@ function ensureCard(termId) {
   var cwd = document.createElement("div"); cwd.className = "cwd";
   title.appendChild(name); title.appendChild(cwd);
   var badge = document.createElement("span"); badge.className = "badge idle"; badge.textContent = "idle";
-  head.appendChild(dot); head.appendChild(title); head.appendChild(badge);
+  var chevron = document.createElement("span"); chevron.className = "chevron";
+  chevron.setAttribute("aria-hidden", "true"); chevron.textContent = "▾";
+  head.appendChild(dot); head.appendChild(title); head.appendChild(badge); head.appendChild(chevron);
+
+  // ヘッダ帯全体をタップで開閉トグル。将来ヘッダ内に
+  // ボタン/入力/リンクを置いた場合の保険で、それらをタップした時はトグルしない。
+  head.setAttribute("role", "button");
+  head.setAttribute("tabindex", "0");
+  function onHeadToggle(e) {
+    if (e.target.closest("button, input, a")) return;
+    toggleCollapse(termId);
+  }
+  head.addEventListener("click", onHeadToggle);
+  head.addEventListener("keydown", function(e) {
+    if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      onHeadToggle(e);
+    }
+  });
 
   var pre = document.createElement("pre"); pre.className = "lines";
 
@@ -189,7 +253,10 @@ function ensureCard(termId) {
   root.appendChild(head); root.appendChild(pre); root.appendChild(actions);
   list.appendChild(root);
 
-  cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge };
+  cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge,
+    head: head, chevron: chevron };
+  // 復活時を含め、現在の collapsed 状態を初期反映
+  syncCollapseUI(cards[termId], termId);
   return cards[termId];
 }
 
@@ -222,6 +289,8 @@ function render(data) {
     c.name.textContent = title.trim() ? title : ("Terminal " + termId);
     c.cwd.textContent = t.cwdShort || t.cwd || "";
     c.pre.textContent = tail(stripAnsi(t.lastLines || ""), 1400).replace(/\n{3,}/g, "\n\n").trim();
+    // 折り畳み状態を毎回当て直す（再描画・端末の消失→復活をまたいで一致させる）
+    syncCollapseUI(c, termId);
     // DOM 並び替え
     list.appendChild(c.root);
   });


### PR DESCRIPTION
## 概要

モバイルページ（`renderer/mobile.html`）の各ターミナルカードを、ヘッダ帯をタップして折り畳めるようにしました（issue #49）。折り畳んだ分、注目していないカードが縦スペースを返すため、見たいカードがビューポート上方にせり上がり「メイン領域を広く（高く）」表示できます。

Closes #49

## 実装内容

- 各カードのヘッダ帯（`.card-head`）全体をタップ／Enter・Space で開閉トグル。折り畳み時は出力（`pre.lines`）と操作群（`.actions`）の両方を隠し、ヘッダ1行（状態ドット・タイトル・ステータスバッジ）だけ残す
- ヘッダ右端に chevron（`▾`）を追加。折り畳み時は CSS の `transform: rotate(-90deg)` で右向きに回転（`prefers-reduced-motion: reduce` ではアニメーション無効）
- 折り畳み状態は `cards` とは独立した plain object（termId→bool）で管理し、`localStorage`（キー `vkt.collapsed`）に永続化。2秒ごとのポーリング再描画・端末の一時消失→復活・ページ再読込をまたいで状態を保持
- 出力エリアの高さ上限を 180px → 240px に拡大
- アクセシビリティ: ヘッダに `role="button"` / `tabindex="0"` / `aria-expanded`（開閉と同期）/ `min-height: 44px`（タップターゲット確保）を付与。chevron は `aria-hidden="true"`

変更は `renderer/mobile.html` 単一ファイルで完結（デスクトップ版の折り畳みとは独立実装）。

## 確認手順

### 前提条件
- `npm start` でアプリを起動し、ターミナルが1つ以上稼働している状態

### 手順
1. ブラウザ（スマホ実機、または PC ブラウザの DevTools でモバイル表示）で `http://127.0.0.1:13847/` を開く
   → ✓ 稼働中ターミナルがカードとして縦に並んで表示される
2. いずれかのカードの**ヘッダ帯（状態ドット〜バッジの行）**をタップする
   → ✓ そのカードの出力エリアと操作ボタン群が隠れ、ヘッダ1行だけになる
   → ✓ ヘッダ右端の chevron が下向き `▾` から右向きへ回転する
   → ✓ 折り畳んでもステータス（ドットの色・バッジ）は見えたまま
3. もう一度同じヘッダをタップする
   → ✓ 出力・操作ボタンが再表示され、chevron が下向きに戻る
4. カードを1つ折り畳んだ状態でブラウザを**再読込**する
   → ✓ 折り畳み状態が保持されている（展開状態に戻らない）
5. キーボードで Tab を押してカードのヘッダにフォーカスを当て、Enter または Space を押す
   → ✓ クリックと同様に開閉できる（スクリーンリーダーでは開閉状態が `aria-expanded` で伝わる）
6. 展開状態のカードでターミナル出力が長い場合
   → ✓ 出力エリアが最大 240px まで表示される（従来 180px から拡大）

### デグレ確認
7. クイックボタン（`1`/`2`/`3`/`↵`/`Yes`/`No`/`Esc`/`Ctrl-C`）と自由入力欄をタップ・操作する
   → ✓ 従来どおり送信でき、ヘッダの折り畳みトグルとは干渉しない
8. 2秒ごとの自動更新が走る間、折り畳んだカードが勝手に展開しない
   → ✓ 再描画をまたいでも折り畳み状態が維持される

## スクリーンショット（モバイル 390×844）

麗美（e2e/UIテスト）が Playwright（`/api/states` スタブ）で全21項目 PASS を確認済み。詳細結果とあわせて本 PR のレビューコメントに掲載しています。

| 状態 | 説明 | リンク（vektor-inc メンバー閲覧可） |
|---|---|---|
| Before | 展開時（2台とも全表示） | https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-50/before-mobile.png |
| After | waiting カードをヘッダタップで折り畳み（ヘッダ1行＋chevron 右向き、もう一方は展開のまま） | https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-50/after-mobile.png |
