### PR TITLE
[ 不具合修正 ] モバイルページで再読み込みするとスクロール位置が一番上に戻り出力の途中が読めなくなる不具合を修正

### DIFF
--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -112,8 +112,15 @@ function tail(s, n) { return s.length > n ? s.slice(s.length - n) : s; }
 // 初回描画でカードが入った後に一度だけ復元する。
 if ("scrollRestoration" in history) { history.scrollRestoration = "manual"; }
 var SCROLL_KEY = "vkt.scrollY";
-var restoredScroll = false; // 復元は初回描画完了時の一度きり（毎回の再描画でスクロールを飛ばさない）
+var restoredScroll = false; // 復元は一度きり（毎回の再描画でスクロールを飛ばさない）
 var scrollSaveScheduled = false;
+// 復元の再試行上限。初回 render() でドキュメント高さが保存位置に届かない場合、
+// 次回以降の poll() で再試行する（端末カードの描画完了が遅れるケースの保険）。
+// ただし無制限に再試行すると、高さが永久に届かない状況（端末数が減った等）で
+// ずっと後にコンテンツが伸びた瞬間 scrollTo が走りユーザーを引き戻す回帰を招く。
+// 目的はあくまでリロード直後の復元なので、最初の数回（≒数秒）だけ再試行して諦める。
+var SCROLL_RESTORE_MAX_TRIES = 5;
+var scrollRestoreTries = 0;
 
 function saveScrollY() {
   // scroll イベントは高頻度に発火するため requestAnimationFrame で 1 フレーム 1 回に間引く。
@@ -129,14 +136,25 @@ window.addEventListener("scroll", saveScrollY, { passive: true });
 
 function restoreScrollOnce() {
   if (restoredScroll) return;
-  restoredScroll = true;
   var saved;
   try { saved = sessionStorage.getItem(SCROLL_KEY); }
   catch (e) { saved = null; }
-  if (saved == null) return;
+  // 復元すべき値が無い／不正なら、これ以上試す意味がないので確定して終了。
+  if (saved == null) { restoredScroll = true; return; }
   var y = parseInt(saved, 10);
-  if (isNaN(y) || y <= 0) return;
-  // レイアウト確定後に復元（window.scrollTo は最大スクロール量に自動クランプされる）。
+  if (isNaN(y) || y <= 0) { restoredScroll = true; return; }
+  // まだドキュメント高さが保存位置 y に届いていない場合は、復元フラグを立てずに
+  // return して次回 poll() で再試行する（カード描画完了が初回に間に合わないケースの保険）。
+  var maxY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+  if (maxY < y) {
+    // ただし再試行は上限まで。超えたら高さは永久に届かないとみなし諦める
+    // （無制限再試行による「後からの引き戻し」回帰を防ぐ）。
+    if (++scrollRestoreTries >= SCROLL_RESTORE_MAX_TRIES) restoredScroll = true;
+    return;
+  }
+  // ここまで来たら復元できる。フラグを確定してからレイアウト確定後に復元する
+  // （window.scrollTo は最大スクロール量に自動クランプされる）。
+  restoredScroll = true;
   requestAnimationFrame(function () { window.scrollTo(0, y); });
 }
 

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -103,6 +103,43 @@ function stripAnsi(s) {
 }
 function tail(s, n) { return s.length > n ? s.slice(s.length - n) : s; }
 
+// スクロール位置の保存・復元。
+// このページは Cache-Control: no-store で配信され、#list の中身は読み込み後に
+// fetch('/api/states') 完了を待って非同期に描画される（poll() → render()）。
+// そのためブラウザ標準の自動スクロール復元は #list がまだ空（ドキュメント高さ≒0）の
+// 段階で走り、深い位置を復元できず最上部に戻ってしまう。標準復元を切り、自前で
+// sessionStorage（タブ単位・再読込で保持・タブを閉じると消える）に scrollY を保存し、
+// 初回描画でカードが入った後に一度だけ復元する。
+if ("scrollRestoration" in history) { history.scrollRestoration = "manual"; }
+var SCROLL_KEY = "vkt.scrollY";
+var restoredScroll = false; // 復元は初回描画完了時の一度きり（毎回の再描画でスクロールを飛ばさない）
+var scrollSaveScheduled = false;
+
+function saveScrollY() {
+  // scroll イベントは高頻度に発火するため requestAnimationFrame で 1 フレーム 1 回に間引く。
+  if (scrollSaveScheduled) return;
+  scrollSaveScheduled = true;
+  requestAnimationFrame(function () {
+    scrollSaveScheduled = false;
+    try { sessionStorage.setItem(SCROLL_KEY, String(window.scrollY)); }
+    catch (e) { /* 保存失敗は無視（プライベートモード等） */ }
+  });
+}
+window.addEventListener("scroll", saveScrollY, { passive: true });
+
+function restoreScrollOnce() {
+  if (restoredScroll) return;
+  restoredScroll = true;
+  var saved;
+  try { saved = sessionStorage.getItem(SCROLL_KEY); }
+  catch (e) { saved = null; }
+  if (saved == null) return;
+  var y = parseInt(saved, 10);
+  if (isNaN(y) || y <= 0) return;
+  // レイアウト確定後に復元（window.scrollTo は最大スクロール量に自動クランプされる）。
+  requestAnimationFrame(function () { window.scrollTo(0, y); });
+}
+
 var errEl = document.getElementById("err");
 function showErr(msg) {
   if (!msg) { errEl.style.display = "none"; return; }
@@ -322,6 +359,9 @@ async function poll() {
     if (!res.ok) throw new Error("HTTP " + res.status);
     var data = await res.json();
     render(data);
+    // 初回描画でカードが #list に入った後に一度だけスクロール位置を復元する。
+    // 2 回目以降のポーリング再描画では呼ばない（ユーザーのスクロール操作と競合させない）。
+    restoreScrollOnce();
     showErr("");
   } catch (e) {
     document.getElementById("meta").textContent = "接続エラー";


### PR DESCRIPTION
## 概要

モバイルページ（`renderer/mobile.html`）で、ターミナル出力の途中まで下にスクロールした状態で再読み込み（リロード／プルトゥリフレッシュ）すると、スクロール位置が一番上に戻ってしまい、続きが読めなくなる不具合を修正します。

Close #51

## 原因

このページは `Cache-Control: no-store` で配信され、`#list`（ターミナルカード一覧）の中身は読み込み後に `fetch('/api/states')` の完了を待って**非同期に**描画されます。そのためブラウザ標準のスクロール位置自動復元は、`#list` がまだ空（ドキュメント高さ ≒ 0）の段階で走ってしまい、深い位置を復元できず最上部に戻されていました。スクロール位置を保存・復元するロジックも存在しませんでした。

## 修正内容

`renderer/mobile.html` の `<script>` にスクロール位置の保存・復元処理を追加しました。

- `history.scrollRestoration = "manual"`（対応ブラウザのみ）でブラウザ標準の自動復元を無効化
- `scroll` イベント（`{ passive: true }`）で `window.scrollY` を `sessionStorage`（キー `vkt.scrollY`）に保存。高頻度発火を `requestAnimationFrame` で 1 フレーム 1 回に間引き、`setItem` は try/catch で保護
- 初回描画でカードが入った後に**一度だけ** `window.scrollTo(0, y)` で復元（`restoredScroll` フラグ）。2 回目以降のポーリング再描画では復元せず、ユーザーのスクロール操作と競合させない
- `sessionStorage` を採用（タブ単位・再読込で保持・タブを閉じると消える）。`localStorage` だと別セッションにまで位置が引き継がれ違和感が出るため

> changelog は追記していません。対象のモバイルページは未リリース機能（最新タグ 1.3.0 より後の未リリース分）であり、`rules/changelog.md` の「未リリース機能の不具合修正は changelog 追記不要」に該当するためです。

## 確認手順

### 前提条件
- `npm start` で VK Terminals を起動し、ターミナルカードが画面の高さを超える程度に複数稼働している状態にする
- スマートフォン（または PC ブラウザのモバイル表示／ウィンドウを縦に小さくした状態）で `http://<apiHost>:13847/` を開く

### Before（修正前の再現手順）
1. ページを開き、下の方のターミナルカードまでスクロールする
2. ブラウザを再読み込みする（リロードボタン／プルトゥリフレッシュ）
   → ✗ スクロール位置が一番上に戻り、見ていたカードまで再度スクロールし直す必要がある

### After（修正後）
1. ページを開き、下の方のターミナルカードまでスクロールする
2. ブラウザを再読み込みする
   → ✓ 再読み込み後も直前のスクロール位置に留まり、続きをそのまま読める
3. 2 秒ごとの自動更新（ポーリング）が走る様子をしばらく観察する
   → ✓ 自動更新のたびにスクロールが飛んだり上に戻ったりしない（デグレなし）
4. タブを閉じてから開き直す
   → ✓ スクロール位置はリセットされ最上部から表示される（sessionStorage の期待動作）

## スクリーンショット

スクロール挙動（動的な動作）の修正のため、静止画では差分が伝わりにくく省略します。上記 Before / After の手順で挙動を確認できます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * モバイル表示で非同期描画後にブラウザの自動スクロール復元が誤作動する問題を解消しました。スクロール位置の保存・復元を安定化し、復元はリロード直後の一度のみ行われるよう制御。復元の再試行と保存の間引きで不正な位置復元を防ぎます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/133