### PR TITLE
[ 機能追加 ] モバイルページのターミナルカードに PR リンク (PR ↗) を表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] モバイルページ（`renderer/mobile.html`）の各ターミナルカードのヘッダに PR リンク（PR ↗）を表示できるように変更。`apiPrUrl` が設定され安全な http(s) URL のときだけ表示し、タップで GitHub の PR を新規タブで開く（[#53](https://github.com/vektor-inc/vk-terminals/issues/53)）
 - [ 機能追加 ] モバイルページ（`renderer/mobile.html`）の各ターミナルカードを、ヘッダをタップして折り畳めるように変更。折り畳むと出力・操作ボタンが隠れ、状態は再読込をまたいで保持（[#49](https://github.com/vektor-inc/vk-terminals/issues/49)）
 - [ セキュリティ修正 ] HTTP API の更新系エンドポイント（`POST /api/send`・`POST /api/set-title`・`POST /api/new-pane`）に Origin 検証を追加。ブラウザが cross-origin POST 時に必ず送る `Origin` ヘッダと `Host` を突き合わせ、不一致なら `403` を返す。悪意あるサイトから `http://<apiHost>:13847/api/send` へ CSRF でターミナルへ任意入力を流す攻撃を防ぐ。`Origin` ヘッダを持たない非ブラウザクライアント（curl 等）や同一オリジンのモバイルページは従来どおり素通り（後方互換）
 - [ 機能追加 ] スマホ等のリモート端末から状態確認・応答するためのモバイルページを追加。HTTP API に `GET /`（`/index.html` も同義）を追加し、`renderer/mobile.html` を配信する。ページは既存の `GET /api/states` を 2 秒ごとにポーリングして各ターミナルをカード表示（`status` を `idle`／`running`／`waiting` で色分け・ドット表示、`waiting` を点滅、`waiting` > `running` > `idle` の順でソート）、`lastLines` は ANSI 制御コードを除去して末尾を表示する。各カードに quick ボタン（`1`／`2`／`3`／`↵`／`Yes(y↵)`／`No(n↵)`／`Esc`／`Ctrl-C`）と自由入力欄（末尾改行トグル付き）を備え、`POST /api/send` で応答できる

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -65,6 +65,7 @@
     background: rgba(63,185,80,0.15); border: 1px solid rgba(63,185,80,0.3); color: #6fd58a; }
   a.pr-link.show { display: inline-flex; }
   a.pr-link:active { background: rgba(63,185,80,0.28); border-color: rgba(63,185,80,0.5); }
+  a.pr-link:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
   a.pr-link .pr-icon { font-size: 10px; opacity: 0.85; line-height: 1; flex: none; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 1.45;

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -55,6 +55,17 @@
   .badge.idle { background: #2a2f37; color: #9aa3ae; }
   .badge.running { background: rgba(59,130,246,0.15); color: #7fb0ff; }
   .badge.waiting { background: rgba(245,166,35,0.18); color: #ffce7a; }
+  /* PR リンク（issue #53）。PC 版の [ PR ↗ ] バッジ（GitHub PR グリーン系）に寄せる。
+     ヘッダ帯（暗背景 var(--card)）上に置くため、PC の濃緑ではなく明るい緑文字にする。
+     .badge と同じ角丸・font-size に調和させつつ、タップ領域確保のため min-height 32px・
+     padding 縦広めにして指で押しやすくする（ヘッダ自体は min-height 44px）。 */
+  a.pr-link { display: none; align-items: center; gap: 4px; flex: none;
+    font-size: 10px; font-weight: 700; padding: 4px 8px; min-height: 32px; border-radius: 6px;
+    text-transform: uppercase; letter-spacing: 0.04em; text-decoration: none;
+    background: rgba(63,185,80,0.15); border: 1px solid rgba(63,185,80,0.3); color: #6fd58a; }
+  a.pr-link.show { display: inline-flex; }
+  a.pr-link:active { background: rgba(63,185,80,0.28); border-color: rgba(63,185,80,0.5); }
+  a.pr-link .pr-icon { font-size: 10px; opacity: 0.85; line-height: 1; flex: none; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 1.45;
     white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow-y: auto;
@@ -102,6 +113,20 @@ function stripAnsi(s) {
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, ""); // その他制御文字（改行・タブは残す）
 }
 function tail(s, n) { return s.length > n ? s.slice(s.length - n) : s; }
+
+// href に入れる URL を http(s) のみに制限する防御（issue #53）。
+// new URL() で parse し protocol が http:/https: のときだけ true を返す。
+// javascript: / data: 等のスキーム注入を防ぐ。これを通った URL だけ href にセットする。
+function isSafeHttpUrl(u) {
+  if (typeof u !== "string" || !u) return false;
+  if (u.length > 2048) return false;
+  try {
+    var parsed = new URL(u);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch (e) {
+    return false;
+  }
+}
 
 // スクロール位置の保存・復元。
 // このページは Cache-Control: no-store で配信され、#list の中身は読み込み後に
@@ -249,9 +274,22 @@ function ensureCard(termId) {
   var cwd = document.createElement("div"); cwd.className = "cwd";
   title.appendChild(name); title.appendChild(cwd);
   var badge = document.createElement("span"); badge.className = "badge idle"; badge.textContent = "idle";
+  // PR リンク（issue #53）。ヘッダ帯に置くことで折り畳んでも残り、PC の「常時表示」方針と整合する。
+  // モバイルは通常ブラウザなので実 URL を href に入れた通常リンク（target=_blank）にする。
+  // href へのセットは render() 側で isSafeHttpUrl() を通った値だけ行う。
+  var prLink = document.createElement("a");
+  prLink.className = "pr-link"; // 初期は display:none。.show 付与で表示
+  prLink.target = "_blank";
+  prLink.rel = "noopener noreferrer";
+  prLink.setAttribute("aria-label", "プルリクエストを開く");
+  var prLabel = document.createElement("span"); prLabel.textContent = "PR";
+  var prIcon = document.createElement("span"); prIcon.className = "pr-icon";
+  prIcon.setAttribute("aria-hidden", "true"); prIcon.textContent = "↗";
+  prLink.appendChild(prLabel); prLink.appendChild(prIcon);
   var chevron = document.createElement("span"); chevron.className = "chevron";
   chevron.setAttribute("aria-hidden", "true"); chevron.textContent = "▾";
-  head.appendChild(dot); head.appendChild(title); head.appendChild(badge); head.appendChild(chevron);
+  head.appendChild(dot); head.appendChild(title); head.appendChild(badge);
+  head.appendChild(prLink); head.appendChild(chevron);
 
   // ヘッダ帯全体をタップで開閉トグル。将来ヘッダ内に
   // ボタン/入力/リンクを置いた場合の保険で、それらをタップした時はトグルしない。
@@ -309,7 +347,7 @@ function ensureCard(termId) {
   list.appendChild(root);
 
   cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge,
-    head: head, chevron: chevron };
+    prLink: prLink, head: head, chevron: chevron };
   // 復活時を含め、現在の collapsed 状態を初期反映
   syncCollapseUI(cards[termId], termId);
   return cards[termId];
@@ -343,6 +381,17 @@ function render(data) {
     var title = t.displayTitle || t.apiTitle || t.taskTitle || "";
     c.name.textContent = title.trim() ? title : ("Terminal " + termId);
     c.cwd.textContent = t.cwdShort || t.cwd || "";
+    // PR リンク（issue #53）。安全な http(s) URL のときだけ href にセットして表示、
+    // そうでなければ href を空にして非表示にする。
+    if (isSafeHttpUrl(t.apiPrUrl)) {
+      c.prLink.href = t.apiPrUrl;
+      c.prLink.title = t.apiPrUrl;
+      c.prLink.classList.add("show");
+    } else {
+      c.prLink.removeAttribute("href");
+      c.prLink.removeAttribute("title");
+      c.prLink.classList.remove("show");
+    }
     c.pre.textContent = tail(stripAnsi(t.lastLines || ""), 1400).replace(/\n{3,}/g, "\n\n").trim();
     // 折り畳み状態を毎回当て直す（再描画・端末の消失→復活をまたいで一致させる）
     syncCollapseUI(c, termId);


### PR DESCRIPTION
## 概要

issue #53 対応。モバイルページ（`renderer/mobile.html`、スマホのブラウザから `http://<apiHost>:13847/` で開くリモート操作画面）の各ターミナルカードに、PC 版（Electron ウィンドウ）と同様の PR リンク（`[ PR ↗ ]`）を表示できるようにしました。

PR の URL を運ぶ `apiPrUrl` フィールドは既に `GET /api/states` のレスポンスに含まれており（issue #44/#45 で PC 版実装時に追加済み）、モバイルページがこの値を描画していなかっただけでした。本対応はモバイル側の描画追加のみで、サーバ側 API・PC 版の挙動は変更していません。

## 変更内容

- `renderer/mobile.html`
  - 各カードヘッダ（`.card-head`）の chevron 直前に PR リンク `<a class="pr-link">` を追加。`apiPrUrl` が設定され、かつ安全な http(s) URL のときだけ `.show` クラスで表示する。
  - モバイルは通常ブラウザのため、PC 版（Electron の `shell.openExternal`）と異なり、実 URL を `href` に入れた通常リンク（`target="_blank"` / `rel="noopener noreferrer"`）でタップ時に GitHub の PR を新規タブで開く。
  - URL 検証ヘルパー `isSafeHttpUrl()` を追加。`new URL()` で parse し `http:` / `https:` のみ許可（2048 文字上限）。`javascript:` / `data:` 等のスキーム注入を防ぐ。検証を通らない値は `href` を残さず非表示にする。
  - CSS は PC 版の `[ PR ↗ ]` バッジ（GitHub PR グリーン系）に意匠を寄せつつ、暗背景ヘッダ向けに明るい緑文字（`#6fd58a`、コントラスト 8.9:1）を採用。`:focus-visible` アウトライン（`#58a6ff`）も PC 版に合わせて付与。
- `CHANGELOG.md`
  - `[ 機能追加 ]` エントリを 1 件追記。

## レビュー結果（/vk-kore 内で実施済み）

- 🔍 安藤（セキュリティ）: **PASS** — URL 注入耐性（http(s) 限定・プロトコル相対 URL も例外で弾く）・tabnabbing 防御（`noopener noreferrer`）・DOM API 構築を確認。
- 🎨 植草（UX）: **PASS** — コントラスト 8.9:1（AAA 超）、誤タップ防止ガード、折り畳み整合を確認。`:focus-visible` の一貫性指摘を本 PR で反映済み。

## 確認手順

### 前提条件
- vk-terminals アプリを起動し、ターミナルを 1 つ以上開く
- `config.json` の `apiHost` をスマホから到達できる値（Tailscale IP 等）に設定、または同一マシンの別ブラウザで `http://127.0.0.1:13847/` を開く
- 対象ターミナルに PR URL をセットする:
  ```
  curl -X POST http://127.0.0.1:13847/api/set-title \
    -H 'Content-Type: application/json' \
    -d '{"termId":"1","title":"テスト","prUrl":"https://github.com/vektor-inc/vk-terminals/pull/1"}'
  ```

### Before（修正前）
1. モバイルページ（`http://127.0.0.1:13847/`）を開く
2. 該当ターミナルのカードを確認する
   → ✗ カードヘッダに PR リンクが表示されない（PC 版には出ているのに）

### After（修正後）/ 確認手順
1. モバイルページ（`http://127.0.0.1:13847/`）を開く
2. 該当ターミナルのカードヘッダを確認する
   → ✓ status バッジの右に緑色の `[ PR ↗ ]` リンクが表示される
3. `[ PR ↗ ]` をタップする
   → ✓ 新規タブで `prUrl` の GitHub PR が開く
4. カードヘッダの PR リンク以外の領域をタップする
   → ✓ 従来どおりカードの折り畳み/展開がトグルする（PR リンクのタップではトグルしない）
5. `prUrl` を空文字でクリアする（`-d '{"termId":"1","prUrl":""}'`）
   → ✓ PR リンクが消える（`href` も残らない）
6. `prUrl` に `javascript:alert(1)` 等の不正値をセットしてみる
   → ✓ リンクは表示されない（http(s) 以外は弾かれる）

## スクリーンショット

実機ブラウザでの表示確認・スクリーンショットは麗美の e2e/UI テスト（本 PR へのコメント）で添付します。

Closes #53

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * モバイルページのターミナルカードヘッダに PR リンク表示機能を追加。新規タブで GitHub PR が開けるようになりました。安全な HTTP(S) URL のみ対応し、セキュリティ対策を実施しています。

* **Documentation**
  * リリースノートを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->