### PR TITLE
[ 不具合修正 ] モバイルページでポーリングのたびに DOM 移動が起きてソフトキーボードが消える不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 不具合修正 ] モバイルページでテキスト入力中にポーリングが走るたびに DOM が移動されソフトキーボードが消える不具合を修正。`render()` 内の `list.appendChild()` による DOM 移動をやめ、CSS `order` プロパティで視覚的な並び替えのみを行うよう変更（[#55](https://github.com/vektor-inc/vk-terminals/issues/55)）
+
 - [ 機能追加 ] モバイルページ（`renderer/mobile.html`）の各ターミナルカードのヘッダに PR リンク（PR ↗）を表示できるように変更。`apiPrUrl` が設定され安全な http(s) URL のときだけ表示し、タップで GitHub の PR を新規タブで開く（[#53](https://github.com/vektor-inc/vk-terminals/issues/53)）
 - [ 機能追加 ] モバイルページ（`renderer/mobile.html`）の各ターミナルカードを、ヘッダをタップして折り畳めるように変更。折り畳むと出力・操作ボタンが隠れ、状態は再読込をまたいで保持（[#49](https://github.com/vektor-inc/vk-terminals/issues/49)）
 - [ セキュリティ修正 ] HTTP API の更新系エンドポイント（`POST /api/send`・`POST /api/set-title`・`POST /api/new-pane`）に Origin 検証を追加。ブラウザが cross-origin POST 時に必ず送る `Origin` ヘッダと `Host` を突き合わせ、不一致なら `403` を返す。悪意あるサイトから `http://<apiHost>:13847/api/send` へ CSRF でターミナルへ任意入力を流す攻撃を防ぐ。`Origin` ヘッダを持たない非ブラウザクライアント（curl 等）や同一オリジンのモバイルページは従来どおり素通り（後方互換）

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -367,7 +367,7 @@ function render(data) {
   });
 
   var seen = {};
-  keys.forEach(function(paneId) {
+  keys.forEach(function(paneId, idx) {
     var t = terms[paneId];
     var termId = String(t.termId);
     seen[termId] = true;
@@ -396,8 +396,8 @@ function render(data) {
     c.pre.textContent = tail(stripAnsi(t.lastLines || ""), 1400).replace(/\n{3,}/g, "\n\n").trim();
     // 折り畳み状態を毎回当て直す（再描画・端末の消失→復活をまたいで一致させる）
     syncCollapseUI(c, termId);
-    // DOM 並び替え
-    list.appendChild(c.root);
+    // CSS order で並び替え（DOM移動をやめてモバイルでの入力フォーカス消失を防ぐ）
+    c.root.style.order = String(idx);
   });
   // 消えた端末のカードを削除
   Object.keys(cards).forEach(function(termId) {


### PR DESCRIPTION
## 概要

closes #55

モバイル（特に iOS Safari）でテキスト入力欄にフォーカス中、2秒ごとのポーリング（`render()`）のたびに `list.appendChild(c.root)` が呼ばれ、フォーカス中の `input` 要素を含む DOM ノードが移動していた。

iOS Safari では、フォーカス中の input が含まれる DOM ノードが移動されると、ソフトキーボードが消えてフォーカスも外れる。これが「すぐ画面再読み込みで入力できない」に見えていた原因。

## 修正内容

`render()` 内の `keys.forEach` ループで行っていた `list.appendChild(c.root)` による DOM 移動をやめ、代わりに `c.root.style.order = String(idx)` で CSS `order` プロパティを設定して視覚的な並び替えのみを行うよう変更。

- `#list` はすでに `display: flex; flex-direction: column;` なので追加の CSS 変更は不要
- `ensureCard()` 内の `list.appendChild(root)`（初回挿入）は変更しない

## 動作確認

- [ ] iOS Safari でテキスト入力欄にフォーカスしてもポーリングでキーボードが消えないこと
- [ ] 端末のステータス変化（waiting → running → idle）でカードの並び順が正しく更新されること
- [ ] ポーリング中にカードの折り畳み状態が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 不具合修正
- モバイルページでテキスト入力中にソフトキーボードが消える問題を修正しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->