### PR TITLE
[ 不具合修正 ] /api/send で本文と末尾 Enter をまとめて送ると Enter が確定せず入力待ちで止まる不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 不具合修正 ] `POST /api/send` で「本文 + 末尾 Enter（`\r`）」を 1 リクエストで受け取ると、Claude Code の TUI がペースト扱いして末尾 `\r` を入力欄の改行として吸収し Enter 確定にならず入力待ちのまま止まる不具合を修正（URL など長い入力で特に再現）。サーバ側で本文と Enter を分割し、本文を送って `150ms` 待ってから Enter を送るよう変更。スマホUI・terminal-monitor 等の全送信経路に適用
 - [ 不具合修正 ] モバイルページでテキスト入力中にポーリングが走るたびに DOM が移動されソフトキーボードが消える不具合を修正。`render()` 内の `list.appendChild()` による DOM 移動をやめ、CSS `order` プロパティで視覚的な並び替えのみを行うよう変更（[#55](https://github.com/vektor-inc/vk-terminals/issues/55)）
 
 - [ 機能追加 ] モバイルページ（`renderer/mobile.html`）の各ターミナルカードのヘッダに PR リンク（PR ↗）を表示できるように変更。`apiPrUrl` が設定され安全な http(s) URL のときだけ表示し、タップで GitHub の PR を新規タブで開く（[#53](https://github.com/vektor-inc/vk-terminals/issues/53)）

--- a/main.js
+++ b/main.js
@@ -29,6 +29,12 @@ const API_PORT = 13847;
 const DATA_DIR = path.join(os.homedir(), '.vk-terminals');
 const STATE_FILE = path.join(DATA_DIR, 'states.json');
 const LOG_PREFIX = '[vk-terminals]';
+// /api/send で「本文 + 末尾 Enter」を 1 リクエストで受け取ったとき、本文と Enter を
+// 分割して送るまでの待機時間（ms）。本文と \r を 1 回の write でまとめて流すと、
+// Claude Code の TUI がペースト（複数行入力）扱いして末尾 \r を入力欄の改行として
+// 吸収し Enter 確定にならない（URL のような長い入力で特に再現しやすい）。
+// 本文を先に流して TUI の再描画が落ち着いてから Enter を送ることで確実に確定させる。
+const SEND_ENTER_SPLIT_DELAY_MS = 150;
 let cachedStates = {};  // renderer から受け取った状態キャッシュ
 let httpServer = null;
 
@@ -493,7 +499,23 @@ function startHttpApi() {
             res.end(JSON.stringify({ error: `terminal ${termId} not found` }));
             return;
           }
-          p.write(input);
+          // 「本文 + 末尾 Enter」を 1 リクエストで受け取った場合は、本文と Enter を
+          // 別々の write に分割して送る（まとめて送ると Claude Code が末尾 \r を
+          // ペーストの改行として吸収し Enter 確定にならないため。SEND_ENTER_SPLIT_DELAY_MS 参照）。
+          const trailingNewline = input.match(/[\r\n]+$/);
+          const hasBodyBeforeNewline = trailingNewline && input.length > trailingNewline[0].length;
+          if (hasBodyBeforeNewline) {
+            const bodyPart = input.slice(0, input.length - trailingNewline[0].length);
+            p.write(bodyPart);
+            setTimeout(() => {
+              // 待機中にターミナルが閉じられている可能性があるので存在を再確認する
+              if (ptys.get(String(termId)) === p) {
+                p.write(trailingNewline[0]);
+              }
+            }, SEND_ENTER_SPLIT_DELAY_MS);
+          } else {
+            p.write(input);
+          }
           // renderer に通知（バッジ表示用）
           if (win && !win.isDestroyed()) {
             win.webContents.send('terminal:auto-input', termId);


### PR DESCRIPTION
## 概要

`POST /api/send` で「本文 + 末尾 Enter（`\r`）」を 1 リクエストでまとめて受け取ると、Claude Code の TUI がそれをペースト（複数行入力）扱いし、末尾 `\r` を入力欄内の改行として吸収してしまい、**Enter 確定にならず入力待ちのまま止まる**不具合を修正します。URL のような長い入力で特に再現しやすい症状でした。

## 原因

`/api/send` は受け取った `input` をそのまま 1 回の `ptyProcess.write()` で PTY に流していました（`main.js`）。スマホ UI（`mobile.html`）や terminal-monitor スキルは `本文 + "\r"` を 1 リクエストで送るため、テキストと改行がひとかたまりのバイト列で届き、TUI がペースト扱いして末尾 `\r` を改行として取り込んでいました。

> task-queue のオーケストレーターはこの問題を `submitToClaude()`（本文と `\r` を別送信＋再送確認）で回避済みでしたが、その処理を通らない手動経路（スマホ UI・監視スキル）では再現していました。

## 修正

サーバ側（`/api/send`）で「本文 + 末尾 Enter」を自動分割します。

- 末尾が `\r`/`\n` で、その前に本文がある場合 → **本文を `write` → 150ms 待つ → Enter を別 `write`**
- 末尾改行のみ（`\r` 単体）／本文のみ → 従来どおりそのまま送る
- 待機中にターミナルが閉じられても安全なよう `ptys.get(termId) === p` で再確認してから Enter 送信

これで全送信経路（スマホ UI・terminal-monitor・将来の呼び出し元）が一括で恩恵を受けます。orchestrator は本文単体・`\r` 単体を別々に送るため、いずれも分割対象外で二重処理になりません。

## テスト（確認手順）

1. アプリを再起動する
2. スマホ UI または `curl` で URL を含む本文 + `\r` を 1 リクエストで送る:
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/send \
     -H 'Content-Type: application/json' \
     -d '{"termId":"1","input":"/vk-kore https://github.com/vektor-inc/vk-terminals/issues/1\r"}'
   ```
3. 入力欄に貼り付くだけで止まらず、**そのまま送信（Enter 確定）される**ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* API経由での入力送信時に、本文と改行が同時に受け取られた場合、改行が正しく処理されない不具合を修正。本文と改行を分割送信することで、スマートフォンUIやターミナル経由など、全送信経路での安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->