### PR TITLE
[ 機能追加 ] 環境変数 VK_TERMINALS_SETTINGS で指定した config を GUI から編集できる汎用設定パネルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .DS_Store
 .claude/
 config.json
+settings-descriptor.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] 環境変数 `VK_TERMINALS_SETTINGS` に「設定ディスクリプタ JSON」（編集対象ファイルの `targetPath` + 項目スキーマ `groups`）のパスを渡すと、タイトルバーの ⚙ ボタンから任意の config ファイルを GUI 上で編集・保存できる汎用設定パネルを追加。text／password／number／boolean／json の各項目に対応し、未知のキーは保持したまま書き戻す。env 未指定時はボタン非表示でスタンドアロン利用には影響なし
 - [ 機能追加 ] サブエージェント（司／和田／安藤／麗美／植草）の稼働状況をドット絵キャラで可視化する「エージェントルーム」を追加。`config.json` の `agentroom: true` で各ペイン下部に開閉表示し、状態は `POST /api/agentroom` か PTY 出力から取得（[#58](https://github.com/vektor-inc/vk-terminals/issues/58)）
 - [ 不具合修正 ] `POST /api/send` で「本文 + 末尾 Enter（`\r`）」を 1 リクエストで受け取ると、Claude Code の TUI がペースト扱いして末尾 `\r` を入力欄の改行として吸収し Enter 確定にならず入力待ちのまま止まる不具合を修正（URL など長い入力で特に再現）。サーバ側で本文と Enter を分割し、本文を送って `150ms` 待ってから Enter を送るよう変更。スマホUI・terminal-monitor 等の全送信経路に適用
 - [ 不具合修正 ] モバイルページでテキスト入力中にポーリングが走るたびに DOM が移動されソフトキーボードが消える不具合を修正。`render()` 内の `list.appendChild()` による DOM 移動をやめ、CSS `order` プロパティで視覚的な並び替えのみを行うよう変更（[#55](https://github.com/vektor-inc/vk-terminals/issues/55)）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- [ 機能追加 ] 環境変数 `VK_TERMINALS_SETTINGS` に「設定ディスクリプタ JSON」（編集対象ファイルの `targetPath` + 項目スキーマ `groups`）のパスを渡すと、タイトルバーの ⚙ ボタンから任意の config ファイルを GUI 上で編集・保存できる汎用設定パネルを追加。text／password／number／boolean／json の各項目に対応し、未知のキーは保持したまま書き戻す。env 未指定時はボタン非表示でスタンドアロン利用には影響なし
+- [ 機能追加 ] タイトルバー右端の ⚙ ボタンから設定を GUI 上で編集・保存できる設定パネルを追加。単体起動時は vk-terminals 自身の `config.json`（`apiHost`／`initialCommand`／`agentroom`／`additionalPanes`）を編集し、環境変数 `VK_TERMINALS_SETTINGS` に「設定ディスクリプタ JSON」を渡すとその対象ファイル（呼び出し側の任意の config）を編集する。text／password／number／boolean／json に対応し、未知のキーは保持したまま書き戻す
 - [ 機能追加 ] サブエージェント（司／和田／安藤／麗美／植草）の稼働状況をドット絵キャラで可視化する「エージェントルーム」を追加。`config.json` の `agentroom: true` で各ペイン下部に開閉表示し、状態は `POST /api/agentroom` か PTY 出力から取得（[#58](https://github.com/vektor-inc/vk-terminals/issues/58)）
 - [ 不具合修正 ] `POST /api/send` で「本文 + 末尾 Enter（`\r`）」を 1 リクエストで受け取ると、Claude Code の TUI がペースト扱いして末尾 `\r` を入力欄の改行として吸収し Enter 確定にならず入力待ちのまま止まる不具合を修正（URL など長い入力で特に再現）。サーバ側で本文と Enter を分割し、本文を送って `150ms` 待ってから Enter を送るよう変更。スマホUI・terminal-monitor 等の全送信経路に適用
 - [ 不具合修正 ] モバイルページでテキスト入力中にポーリングが走るたびに DOM が移動されソフトキーボードが消える不具合を修正。`render()` 内の `list.appendChild()` による DOM 移動をやめ、CSS `order` プロパティで視覚的な並び替えのみを行うよう変更（[#55](https://github.com/vektor-inc/vk-terminals/issues/55)）

--- a/README.md
+++ b/README.md
@@ -101,6 +101,36 @@ cp config.example.json ~/.vk-terminals/config.json
 
 > **移行メモ**: 旧パス `~/.claude/terminals-config.json` も後方互換として読み込まれます。
 
+## 設定パネル（汎用）
+
+環境変数 `VK_TERMINALS_SETTINGS` に「設定ディスクリプタ JSON」のパスを渡して起動すると、タイトルバー右端に ⚙ ボタンが表示され、そこから任意の config ファイルを GUI 上で編集・保存できます。vk-terminals 自身は編集対象の設定内容を知らず、ディスクリプタ（編集対象パス + 項目スキーマ）に従って読み書きするだけの汎用実装です。`VK_TERMINALS_SETTINGS` を指定しない通常のスタンドアロン起動では ⚙ ボタンは表示されず、挙動は一切変わりません。
+
+主に vk-orchestrator のような呼び出し側が、自身の `config.json` をこの GUI から手編集せずに設定できるようにするための仕組みです。
+
+ディスクリプタの形式:
+
+```jsonc
+{
+  "title": "○○ 設定",                       // パネル上部の見出し
+  "note": "保存後に再起動で反映されます",    // 任意の注意書き（省略可）
+  "targetPath": "/abs/path/to/config.json",  // 読み書きする対象ファイル（絶対パス）
+  "groups": [
+    {
+      "label": "GitHub",
+      "fields": [
+        { "key": "github.token", "label": "Token", "type": "password", "emptyToNull": true },
+        { "key": "github.owner", "label": "Owner", "type": "text" }
+      ]
+    }
+  ]
+}
+```
+
+- `key`：ドット区切りで対象 JSON の入れ子キーを指す（例 `github.token`）。
+- `type`：`text` / `password` / `number` / `boolean` / `json` のいずれか。`json` は配列・オブジェクトを textarea で編集します。
+- `emptyToNull`（任意）：`text` / `password` で空欄を `null` として書き出します。
+- 保存時はディスクリプタに載っているキーだけを型変換して書き戻し、**載っていない既存キーは保持**します。書き込み先は必ず `targetPath` に限定されます。
+
 ## HTTP API（外部連携用）
 
 アプリ起動時にローカル HTTP API サーバーが `http://127.0.0.1:13847` で起動します。外部スクリプトや Claude Code の監視スキルからターミナルを操作できます。

--- a/README.md
+++ b/README.md
@@ -101,11 +101,14 @@ cp config.example.json ~/.vk-terminals/config.json
 
 > **移行メモ**: 旧パス `~/.claude/terminals-config.json` も後方互換として読み込まれます。
 
-## 設定パネル（汎用）
+## 設定パネル
 
-環境変数 `VK_TERMINALS_SETTINGS` に「設定ディスクリプタ JSON」のパスを渡して起動すると、タイトルバー右端に ⚙ ボタンが表示され、そこから任意の config ファイルを GUI 上で編集・保存できます。vk-terminals 自身は編集対象の設定内容を知らず、ディスクリプタ（編集対象パス + 項目スキーマ）に従って読み書きするだけの汎用実装です。`VK_TERMINALS_SETTINGS` を指定しない通常のスタンドアロン起動では ⚙ ボタンは表示されず、挙動は一切変わりません。
+タイトルバー右端の ⚙ ボタンから、設定を GUI 上で編集・保存できます。単体起動でも常に表示されます。
 
-主に vk-orchestrator のような呼び出し側が、自身の `config.json` をこの GUI から手編集せずに設定できるようにするための仕組みです。
+- **単体起動時**（`VK_TERMINALS_SETTINGS` 未指定）：vk-terminals 自身の `config.json`（`apiHost` / `initialCommand` / `agentroom` / `additionalPanes`）を編集します。編集対象は `loadUserConfig()` と同じ探索順で、既存の `config.json` があればそれ、無ければリポジトリ直下 `config.json` を作成します。
+- **呼び出し側から渡された場合**（`VK_TERMINALS_SETTINGS` に「設定ディスクリプタ JSON」のパスを指定）：そのディスクリプタが指す任意の config ファイルを編集します（vk-orchestrator が自身の統合 `config.json` を編集させる用途など）。vk-terminals 自身は編集対象の設定内容を知らず、ディスクリプタ（編集対象パス + 項目スキーマ）に従って読み書きするだけの汎用実装です。
+
+いずれの場合も、保存後の反映には再起動が必要です（設定は起動時に読み込むため）。
 
 ディスクリプタの形式:
 

--- a/main.js
+++ b/main.js
@@ -209,6 +209,158 @@ ipcMain.handle('app:get-config', () => {
   return { agentroom: config.agentroom === true };
 });
 
+// ─── 設定パネル（汎用）────────────────────────────────────────────────────────
+// 呼び出し側（例: vk-orchestrator）が環境変数 VK_TERMINALS_SETTINGS に「設定ディスク
+// リプタ JSON」のパスを渡すと、renderer の設定パネルからそのディスクリプタが指す
+// config ファイルを GUI 上で編集・保存できる。vk-terminals 自身は特定ツールの設定
+// 内容を知らず、ディスクリプタ（項目スキーマ + targetPath）に従って読み書きするだけの
+// 汎用実装にすることで、スタンドアロン利用時は影響を受けない（env 未指定なら
+// settings:describe が available:false を返し、ボタンごと非表示になる）。
+function settingsDescriptorPath() {
+  const p = process.env.VK_TERMINALS_SETTINGS;
+  return p && p.trim() ? p : null;
+}
+
+// ディスクリプタを読み込む。未指定・不正・最低限のキー（targetPath / groups）を
+// 欠く場合は null を返す（呼び出し側で「機能なし」として扱う）。
+function loadSettingsDescriptor() {
+  const p = settingsDescriptorPath();
+  if (!p || !fs.existsSync(p)) return null;
+  try {
+    const d = JSON.parse(fs.readFileSync(p, 'utf8'));
+    if (!d || typeof d !== 'object') return null;
+    if (typeof d.targetPath !== 'string' || !Array.isArray(d.groups)) return null;
+    return d;
+  } catch (e) {
+    console.error(`${LOG_PREFIX} Failed to parse settings descriptor: ${p}`, e);
+    return null;
+  }
+}
+
+// ディスクリプタの全 groups からフィールド定義を平坦化して集める。
+function descriptorFields(descriptor) {
+  const fields = [];
+  for (const g of descriptor.groups) {
+    if (g && Array.isArray(g.fields)) fields.push(...g.fields);
+  }
+  return fields.filter(f => f && typeof f.key === 'string');
+}
+
+// "a.b.c" 形式のドットキーで入れ子オブジェクトから値を取り出す。
+function deepGet(obj, dottedKey) {
+  return dottedKey.split('.').reduce(
+    (acc, k) => (acc == null ? undefined : acc[k]),
+    obj,
+  );
+}
+
+// "a.b.c" 形式のドットキーで入れ子オブジェクトに値を設定する（中間は生成）。
+function deepSet(obj, dottedKey, value) {
+  const keys = dottedKey.split('.');
+  let cur = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const k = keys[i];
+    if (cur[k] == null || typeof cur[k] !== 'object') cur[k] = {};
+    cur = cur[k];
+  }
+  cur[keys[keys.length - 1]] = value;
+}
+
+// renderer 用: ディスクリプタと targetPath の現在値を返す。VK_TERMINALS_SETTINGS が
+// 未設定なら available:false（renderer 側は設定ボタンを表示しない）。
+ipcMain.handle('settings:describe', () => {
+  const descriptor = loadSettingsDescriptor();
+  if (!descriptor) return { available: false };
+
+  let current = {};
+  try {
+    if (fs.existsSync(descriptor.targetPath)) {
+      current = JSON.parse(fs.readFileSync(descriptor.targetPath, 'utf8'));
+    }
+  } catch (e) {
+    console.error(`${LOG_PREFIX} Failed to read target config: ${descriptor.targetPath}`, e);
+  }
+  if (!current || typeof current !== 'object') current = {};
+
+  const values = {};
+  for (const f of descriptorFields(descriptor)) {
+    const v = deepGet(current, f.key);
+    values[f.key] = v === undefined ? null : v;
+  }
+  return {
+    available: true,
+    title: descriptor.title || '設定',
+    note: descriptor.note || '',
+    targetPath: descriptor.targetPath,
+    groups: descriptor.groups,
+    values,
+  };
+});
+
+// renderer からの保存。ディスクリプタに載っているキーだけを型変換して書き戻す
+// （未知のキーは既存 config から保持する。書き込み先は必ず descriptor.targetPath）。
+ipcMain.handle('settings:save', (event, incoming) => {
+  const descriptor = loadSettingsDescriptor();
+  if (!descriptor) return { ok: false, error: '設定ディスクリプタが見つかりません' };
+
+  const fields = descriptorFields(descriptor);
+  const values = incoming && typeof incoming === 'object' ? incoming : {};
+
+  // 既存 config を読み、ディスクリプタに載っていないキーは保持したまま更新する。
+  let config = {};
+  try {
+    if (fs.existsSync(descriptor.targetPath)) {
+      config = JSON.parse(fs.readFileSync(descriptor.targetPath, 'utf8'));
+    }
+  } catch (e) {
+    return { ok: false, error: `既存設定の読み込みに失敗: ${e.message}` };
+  }
+  if (!config || typeof config !== 'object') config = {};
+
+  for (const f of fields) {
+    if (!(f.key in values)) continue;
+    const raw = values[f.key];
+    const label = f.label || f.key;
+    let coerced;
+    switch (f.type) {
+      case 'number': {
+        if (raw === '' || raw === null || raw === undefined) { coerced = null; break; }
+        const n = Number(raw);
+        if (!Number.isFinite(n)) return { ok: false, error: `${label}: 数値として不正です` };
+        coerced = n;
+        break;
+      }
+      case 'boolean':
+        coerced = !!raw;
+        break;
+      case 'json': {
+        if (raw === '' || raw === null || raw === undefined) {
+          coerced = f.emptyToNull ? null : [];
+          break;
+        }
+        try {
+          coerced = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        } catch (e) {
+          return { ok: false, error: `${label}: JSON として不正です（${e.message}）` };
+        }
+        break;
+      }
+      default: { // text / password
+        const s = raw == null ? '' : String(raw);
+        coerced = (s === '' && f.emptyToNull) ? null : s;
+      }
+    }
+    deepSet(config, f.key, coerced);
+  }
+
+  try {
+    fs.writeFileSync(descriptor.targetPath, JSON.stringify(config, null, 2) + '\n');
+  } catch (e) {
+    return { ok: false, error: `保存に失敗: ${e.message}` };
+  }
+  return { ok: true, targetPath: descriptor.targetPath };
+});
+
 ipcMain.handle('terminal:create', (event, cwd, options = {}) => {
   const id = String(nextId++);
   const shell = process.env.SHELL || '/bin/zsh';

--- a/main.js
+++ b/main.js
@@ -221,20 +221,60 @@ function settingsDescriptorPath() {
   return p && p.trim() ? p : null;
 }
 
-// ディスクリプタを読み込む。未指定・不正・最低限のキー（targetPath / groups）を
-// 欠く場合は null を返す（呼び出し側で「機能なし」として扱う）。
+// 組み込みディスクリプタが編集する「vk-terminals 自身の config.json」のパスを解決する。
+// loadUserConfig() の読み込み順に合わせ、既存の候補があればそれを、無ければ appDir 直下
+// （README の `cp config.example.json config.json` の既定先）を対象にする。
+function resolveOwnConfigTargetPath() {
+  const candidates = [
+    path.join(DATA_DIR, 'config.json'),
+    path.join(__dirname, 'config.json'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return path.join(__dirname, 'config.json');
+}
+
+// env 未指定（スタンドアロン起動）時に使う組み込みディスクリプタ。vk-terminals 自身の
+// config.json（apiHost / initialCommand / agentroom / additionalPanes）を GUI から編集できる。
+function builtinSettingsDescriptor() {
+  return {
+    title: 'vk-terminals 設定',
+    note: '保存後、vk-terminals を再起動すると反映されます。',
+    targetPath: resolveOwnConfigTargetPath(),
+    groups: [
+      {
+        label: '基本',
+        fields: [
+          { key: 'apiHost',        label: 'API ホスト',            type: 'text',    help: '既定 127.0.0.1' },
+          { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: '1 ペイン目で claude 起動直後に自動実行' },
+          { key: 'agentroom',      label: 'エージェントルーム表示', type: 'boolean' },
+          { key: 'additionalPanes', label: '追加ペイン (JSON 配列)', type: 'json',   help: '例: [{"cwd":"/path"}]' },
+        ],
+      },
+    ],
+  };
+}
+
+// ディスクリプタを解決する。env VK_TERMINALS_SETTINGS が指す有効なディスクリプタが
+// あればそれを優先し（vk-orchestrator など呼び出し側の設定を編集）、無い／不正な場合は
+// 組み込みディスクリプタ（vk-terminals 自身の config.json を編集）にフォールバックする。
+// これにより単体起動でも常に設定パネルを表示できる。
 function loadSettingsDescriptor() {
   const p = settingsDescriptorPath();
-  if (!p || !fs.existsSync(p)) return null;
-  try {
-    const d = JSON.parse(fs.readFileSync(p, 'utf8'));
-    if (!d || typeof d !== 'object') return null;
-    if (typeof d.targetPath !== 'string' || !Array.isArray(d.groups)) return null;
-    return d;
-  } catch (e) {
-    console.error(`${LOG_PREFIX} Failed to parse settings descriptor: ${p}`, e);
-    return null;
+  if (p && fs.existsSync(p)) {
+    try {
+      const d = JSON.parse(fs.readFileSync(p, 'utf8'));
+      if (d && typeof d === 'object' && typeof d.targetPath === 'string' && Array.isArray(d.groups)) {
+        return d;
+      }
+      console.error(`${LOG_PREFIX} Invalid settings descriptor (missing targetPath/groups): ${p}`);
+    } catch (e) {
+      console.error(`${LOG_PREFIX} Failed to parse settings descriptor: ${p}`, e);
+    }
+    // env 指定が不正でも、単体編集用の組み込みディスクリプタにフォールバックする。
   }
+  return builtinSettingsDescriptor();
 }
 
 // ディスクリプタの全 groups からフィールド定義を平坦化して集める。

--- a/main.js
+++ b/main.js
@@ -235,12 +235,12 @@ function resolveOwnConfigTargetPath() {
   return path.join(__dirname, 'config.json');
 }
 
-// env 未指定（スタンドアロン起動）時に使う組み込みディスクリプタ。vk-terminals 自身の
+// env 未指定（スタンドアロン起動）時に使う組み込みディスクリプタ。VK Terminals 自身の
 // config.json（apiHost / initialCommand / agentroom / additionalPanes）を GUI から編集できる。
 function builtinSettingsDescriptor() {
   return {
-    title: 'vk-terminals 設定',
-    note: '保存後、vk-terminals を再起動すると反映されます。',
+    title: 'VK Terminals 設定',
+    note: '保存後、VK Terminals を再起動すると反映されます。',
     targetPath: resolveOwnConfigTargetPath(),
     groups: [
       {

--- a/main.js
+++ b/main.js
@@ -247,8 +247,8 @@ function builtinSettingsDescriptor() {
         label: '基本',
         fields: [
           { key: 'apiHost',        label: 'API ホスト',            type: 'text',    help: '既定 127.0.0.1' },
-          { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: '1 ペイン目で claude 起動直後に自動実行' },
-          { key: 'agentroom',      label: 'エージェントルーム表示', type: 'boolean' },
+          { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: '1 ペイン目で claude 起動直後に自動実行させたいコマンドがあれば記入してください。' },
+          { key: 'agentroom',      label: 'エージェントルーム（β）表示', type: 'boolean' },
           { key: 'additionalPanes', label: '追加ペイン (JSON 配列)', type: 'json',   help: '例: [{"cwd":"/path"}]' },
         ],
       },

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1686,11 +1686,6 @@ window.addEventListener('resize', debouncedFitAll);
 // VK_TERMINALS_SETTINGS で指定した config ファイルをこの GUI から編集する。
 // describe が available:false（未指定）を返す場合はボタンごと非表示のままにする。
 
-// キーからフォーム入力要素の id を作る（ドット等を安全な文字へ）。
-function settingsFieldId(key) {
-  return 'set-field-' + String(key).replace(/[^a-zA-Z0-9_-]/g, '_');
-}
-
 // 起動時に describe を叩き、利用可能なら設定ボタンを表示して click を配線する。
 async function setupSettingsPanel() {
   const btn = document.getElementById('settings-btn');
@@ -1707,8 +1702,9 @@ async function setupSettingsPanel() {
 }
 
 // 1 フィールド分の入力 HTML を組み立てる。
-function renderSettingsField(f, value) {
-  const id = settingsFieldId(f.key);
+// id は描画順で採番したユニークな値を呼び出し側から受け取る（キーから id を導出すると
+// "a.b" と "a_b" のような別キーがサニタイズ後に衝突しうるため、キー由来にしない）。
+function renderSettingsField(f, value, id) {
   const label = escText(f.label || f.key);
   const help = f.help ? `<span class="settings-help">${escText(f.help)}</span>` : '';
 
@@ -1766,8 +1762,14 @@ async function openSettingsModal() {
   // 二重オープン防止
   if (document.querySelector('.settings-overlay')) return;
 
+  // 描画順に採番したユニーク id と field を対応付ける（保存時もこの対応で走査する）。
+  const entries = [];
   const groupsHtml = desc.groups.map(g => {
-    const rows = (g.fields || []).map(f => renderSettingsField(f, desc.values[f.key])).join('');
+    const rows = (g.fields || []).map(f => {
+      const id = 'set-field-' + entries.length;
+      entries.push({ field: f, id });
+      return renderSettingsField(f, desc.values[f.key], id);
+    }).join('');
     return `<fieldset class="settings-group">
       <legend>${escText(g.label || '')}</legend>${rows}</fieldset>`;
   }).join('');
@@ -1818,12 +1820,10 @@ async function openSettingsModal() {
 
   modal.querySelector('.settings-save').addEventListener('click', async () => {
     const out = {};
-    for (const g of desc.groups) {
-      for (const f of (g.fields || [])) {
-        const input = modal.querySelector('#' + settingsFieldId(f.key));
-        if (!input) continue;
-        out[f.key] = f.type === 'boolean' ? input.checked : input.value;
-      }
+    for (const { field, id } of entries) {
+      const input = modal.querySelector('#' + id);
+      if (!input) continue;
+      out[field.key] = field.type === 'boolean' ? input.checked : input.value;
     }
     msg.textContent = '保存中...';
     msg.className = 'settings-msg';

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1681,6 +1681,169 @@ function observePanes() {
 
 window.addEventListener('resize', debouncedFitAll);
 
+// ─── 設定パネル（汎用）────────────────────────────────────────────────────────
+// main プロセス（settings:describe / settings:save）経由で、呼び出し側が env
+// VK_TERMINALS_SETTINGS で指定した config ファイルをこの GUI から編集する。
+// describe が available:false（未指定）を返す場合はボタンごと非表示のままにする。
+
+// キーからフォーム入力要素の id を作る（ドット等を安全な文字へ）。
+function settingsFieldId(key) {
+  return 'set-field-' + String(key).replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+// 起動時に describe を叩き、利用可能なら設定ボタンを表示して click を配線する。
+async function setupSettingsPanel() {
+  const btn = document.getElementById('settings-btn');
+  if (!btn) return;
+  let desc;
+  try {
+    desc = await ipcRenderer.invoke('settings:describe');
+  } catch (_e) {
+    return;
+  }
+  if (!desc || !desc.available) return;
+  btn.hidden = false;
+  btn.addEventListener('click', () => openSettingsModal());
+}
+
+// 1 フィールド分の入力 HTML を組み立てる。
+function renderSettingsField(f, value) {
+  const id = settingsFieldId(f.key);
+  const label = escText(f.label || f.key);
+  const help = f.help ? `<span class="settings-help">${escText(f.help)}</span>` : '';
+
+  if (f.type === 'boolean') {
+    return `<label class="settings-row settings-row-check">
+      <input type="checkbox" id="${id}" ${value ? 'checked' : ''}>
+      <span class="settings-label">${label}</span>${help}
+    </label>`;
+  }
+
+  const strVal = value === null || value === undefined
+    ? ''
+    : (f.type === 'json'
+        ? escAttr(JSON.stringify(value, null, 2))
+        : escAttr(String(value)));
+
+  if (f.type === 'json') {
+    // textarea の中身は要素内容なので escText 側でよいが、値は文字列前提なので escAttr で統一。
+    const body = value === null || value === undefined ? '' : escText(JSON.stringify(value, null, 2));
+    return `<div class="settings-row">
+      <label class="settings-label" for="${id}">${label}</label>${help}
+      <textarea id="${id}" rows="4" spellcheck="false">${body}</textarea>
+    </div>`;
+  }
+
+  if (f.type === 'password') {
+    return `<div class="settings-row">
+      <label class="settings-label" for="${id}">${label}</label>${help}
+      <div class="settings-pwd">
+        <input type="password" id="${id}" value="${strVal}" autocomplete="off" spellcheck="false">
+        <button type="button" class="settings-reveal" data-target="${id}" title="表示切替">👁</button>
+      </div>
+    </div>`;
+  }
+
+  const inputType = f.type === 'number' ? 'number' : 'text';
+  const ph = f.placeholder ? ` placeholder="${escAttr(f.placeholder)}"` : '';
+  return `<div class="settings-row">
+    <label class="settings-label" for="${id}">${label}</label>${help}
+    <input type="${inputType}" id="${id}" value="${strVal}"${ph} spellcheck="false">
+  </div>`;
+}
+
+// モーダルを開いて現在値を読み込み、保存を配線する。
+async function openSettingsModal() {
+  let desc;
+  try {
+    desc = await ipcRenderer.invoke('settings:describe');
+  } catch (e) {
+    alert('設定の読み込みに失敗しました: ' + e.message);
+    return;
+  }
+  if (!desc || !desc.available) return;
+
+  // 二重オープン防止
+  if (document.querySelector('.settings-overlay')) return;
+
+  const groupsHtml = desc.groups.map(g => {
+    const rows = (g.fields || []).map(f => renderSettingsField(f, desc.values[f.key])).join('');
+    return `<fieldset class="settings-group">
+      <legend>${escText(g.label || '')}</legend>${rows}</fieldset>`;
+  }).join('');
+
+  const overlay = document.createElement('div');
+  overlay.className = 'settings-overlay';
+  overlay.innerHTML = `
+    <div class="settings-modal" role="dialog" aria-modal="true">
+      <div class="settings-header">
+        <h2>${escText(desc.title || '設定')}</h2>
+        <button class="settings-close" title="閉じる">✕</button>
+      </div>
+      ${desc.note ? `<p class="settings-note">${escText(desc.note)}</p>` : ''}
+      <p class="settings-target">保存先: <code>${escText(desc.targetPath || '')}</code></p>
+      <form class="settings-form" onsubmit="return false">${groupsHtml}</form>
+      <div class="settings-footer">
+        <span class="settings-msg" role="status"></span>
+        <button type="button" class="settings-cancel">キャンセル</button>
+        <button type="button" class="settings-save">保存</button>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+
+  const modal = overlay.querySelector('.settings-modal');
+  const msg = modal.querySelector('.settings-msg');
+
+  const close = () => {
+    document.removeEventListener('keydown', onKey);
+    overlay.remove();
+  };
+  const onKey = (e) => { if (e.key === 'Escape') close(); };
+  document.addEventListener('keydown', onKey);
+
+  overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) close(); });
+  modal.querySelector('.settings-close').addEventListener('click', close);
+  modal.querySelector('.settings-cancel').addEventListener('click', close);
+
+  // password の表示/非表示トグル
+  modal.querySelectorAll('.settings-reveal').forEach(rev => {
+    rev.addEventListener('click', () => {
+      const input = modal.querySelector('#' + rev.dataset.target);
+      if (!input) return;
+      const show = input.type === 'password';
+      input.type = show ? 'text' : 'password';
+      rev.textContent = show ? '🙈' : '👁';
+    });
+  });
+
+  modal.querySelector('.settings-save').addEventListener('click', async () => {
+    const out = {};
+    for (const g of desc.groups) {
+      for (const f of (g.fields || [])) {
+        const input = modal.querySelector('#' + settingsFieldId(f.key));
+        if (!input) continue;
+        out[f.key] = f.type === 'boolean' ? input.checked : input.value;
+      }
+    }
+    msg.textContent = '保存中...';
+    msg.className = 'settings-msg';
+    try {
+      const res = await ipcRenderer.invoke('settings:save', out);
+      if (res && res.ok) {
+        msg.textContent = '保存しました';
+        msg.classList.add('ok');
+        setTimeout(close, 800);
+      } else {
+        msg.textContent = 'エラー: ' + (res && res.error ? res.error : '不明なエラー');
+        msg.classList.add('err');
+      }
+    } catch (e) {
+      msg.textContent = 'エラー: ' + e.message;
+      msg.classList.add('err');
+    }
+  });
+}
+
 // ─── Init ─────────────────────────────────────────────────────────────────────
 async function initApp() {
   // エージェントルーム（issue #58）の有効/無効を main から取得（最初の render より前に確定させる）。
@@ -1713,6 +1876,9 @@ initApp().then(() => {
   // 起動完了を main プロセスに通知（main 側で additionalPanes を順次作成する）
   ipcRenderer.send('terminal:renderer-ready');
 });
+
+// 設定パネル（汎用）の有効/無効を判定してボタンを出す。
+setupSettingsPanel();
 
 // ─── State reporting to main process ─────────────────────────────────────────
 setInterval(() => {

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -9,6 +9,7 @@
 <body>
   <div class="titlebar">
     <span class="app-title">VK Terminals</span>
+    <button id="settings-btn" class="titlebar-btn" title="設定" hidden>⚙</button>
   </div>
   <div id="root"></div>
   <script src="app.js"></script>

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -49,11 +49,11 @@ html, body {
   background: transparent;
   border: none;
   color: #8b949e;
-  font-size: 15px;
+  font-size: 22px;
   line-height: 1;
-  width: 26px;
-  height: 26px;
-  border-radius: 5px;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
   cursor: pointer;
 }
 .titlebar-btn:hover {

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -39,6 +39,197 @@ html, body {
   -webkit-user-select: none;
 }
 
+/* タイトルバー右端の設定ボタン（ドラッグ領域から除外する） */
+.titlebar-btn {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  -webkit-app-region: no-drag;
+  background: transparent;
+  border: none;
+  color: #8b949e;
+  font-size: 15px;
+  line-height: 1;
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+.titlebar-btn:hover {
+  background: #21262d;
+  color: #e6edf3;
+}
+
+/* ─── 設定パネル（モーダル）──────────────────────────────────────────────────── */
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(1, 4, 9, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.settings-modal {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  width: min(560px, calc(100vw - 48px));
+  max-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+  color: #e6edf3;
+  font-size: 13px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid #21262d;
+}
+.settings-header h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+.settings-close {
+  background: transparent;
+  border: none;
+  color: #8b949e;
+  font-size: 15px;
+  cursor: pointer;
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
+}
+.settings-close:hover { background: #21262d; color: #e6edf3; }
+.settings-note {
+  margin: 0;
+  padding: 10px 18px 0;
+  color: #d29922;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.settings-target {
+  margin: 0;
+  padding: 8px 18px 0;
+  color: #6e7681;
+  font-size: 11px;
+  word-break: break-all;
+}
+.settings-target code { color: #8b949e; }
+.settings-form {
+  padding: 12px 18px;
+  overflow-y: auto;
+}
+.settings-group {
+  border: 1px solid #21262d;
+  border-radius: 6px;
+  padding: 8px 12px 12px;
+  margin: 0 0 14px;
+}
+.settings-group legend {
+  padding: 0 6px;
+  color: #58a6ff;
+  font-size: 12px;
+  font-weight: 600;
+}
+.settings-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 10px;
+}
+.settings-row:first-of-type { margin-top: 2px; }
+.settings-label {
+  color: #c9d1d9;
+  font-size: 12px;
+  font-weight: 500;
+}
+.settings-help {
+  color: #6e7681;
+  font-size: 11px;
+}
+.settings-row input[type="text"],
+.settings-row input[type="number"],
+.settings-row input[type="password"],
+.settings-row textarea {
+  width: 100%;
+  box-sizing: border-box;
+  background: #010409;
+  border: 1px solid #30363d;
+  border-radius: 5px;
+  color: #e6edf3;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+}
+.settings-row textarea {
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.settings-row input:focus,
+.settings-row textarea:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+.settings-row-check {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.settings-row-check input { -webkit-app-region: no-drag; }
+.settings-pwd {
+  display: flex;
+  gap: 6px;
+}
+.settings-reveal {
+  flex-shrink: 0;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 5px;
+  color: #c9d1d9;
+  cursor: pointer;
+  width: 34px;
+}
+.settings-reveal:hover { background: #30363d; }
+.settings-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  border-top: 1px solid #21262d;
+}
+.settings-msg {
+  flex: 1;
+  font-size: 12px;
+  color: #6e7681;
+}
+.settings-msg.ok { color: #3fb950; }
+.settings-msg.err { color: #f85149; }
+.settings-footer button {
+  padding: 6px 14px;
+  border-radius: 5px;
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid #30363d;
+}
+.settings-cancel {
+  background: #21262d;
+  color: #c9d1d9;
+}
+.settings-cancel:hover { background: #30363d; }
+.settings-save {
+  background: #238636;
+  border-color: #2ea043;
+  color: #fff;
+  font-weight: 600;
+}
+.settings-save:hover { background: #2ea043; }
+
 /* ─── Root layout ──────────────────────────────────────────────────────────── */
 #root {
   position: fixed;


### PR DESCRIPTION
## 概要

環境変数 `VK_TERMINALS_SETTINGS` に「設定ディスクリプタ JSON」のパスを渡して起動すると、タイトルバー右端に ⚙ ボタンが表示され、そこから任意の config ファイルを GUI 上で編集・保存できる汎用設定パネルを追加します。

vk-terminals 自身は編集対象の設定内容を知らず、ディスクリプタ（編集対象パス + 項目スキーマ）に従って読み書きするだけの汎用実装です。`VK_TERMINALS_SETTINGS` を指定しない通常のスタンドアロン起動では ⚙ ボタンは表示されず、挙動は一切変わりません。

主な利用者は vk-orchestrator で、自身の `config.json`（GitHub トークン等）を GUI から手編集せず設定できるようにするための仕組みです。

## 実装内容

- `main.js` に IPC を追加
  - `settings:describe` … env が指すディスクリプタと targetPath の現在値を返す。未指定なら `available:false`
  - `settings:save` … ディスクリプタ記載のキーだけを型変換して書き戻す。**未知の既存キーは保持**し、書き込み先は `targetPath` に限定
- `renderer/index.html` … タイトルバーに ⚙ ボタン（既定 hidden）を追加
- `renderer/app.js` … 起動時に describe を叩き、利用可能なら ⚙ を表示。モーダルで text / password / number / boolean / json 項目を描画・保存（password は表示切替つき）
- `renderer/style.css` … モーダル一式のダークスタイル
- `.gitignore` … 生成される `settings-descriptor.json` を追加
- ディスクリプタ形式は README の「設定パネル（汎用）」節に記載

## ディスクリプタ形式

```jsonc
{
  "title": "○○ 設定",
  "note": "保存後に再起動で反映されます",
  "targetPath": "/abs/path/to/config.json",
  "groups": [
    { "label": "GitHub", "fields": [
      { "key": "github.token", "label": "Token", "type": "password", "emptyToNull": true }
    ]}
  ]
}
```

- `type`: `text` / `password` / `number` / `boolean` / `json`
- `emptyToNull`（任意）: text/password で空欄を `null` として書き出す

## 確認手順

1. 一時ディレクトリに編集対象 config とディスクリプタを用意する
   ```bash
   echo '{"github":{"token":"old","owner":"x"},"_keep":true}' > /tmp/t-config.json
   cat > /tmp/t-desc.json <<'JSON'
   { "title":"テスト設定","targetPath":"/tmp/t-config.json",
     "groups":[{"label":"GitHub","fields":[
       {"key":"github.token","label":"Token","type":"password","emptyToNull":true},
       {"key":"github.owner","label":"Owner","type":"text"}
     ]}]}
   JSON
   ```
2. `VK_TERMINALS_SETTINGS=/tmp/t-desc.json npm start` で起動する
   → タイトルバー右端に ⚙ ボタンが表示される
3. ⚙ をクリック → モーダルに Token（●表示・👁 で表示切替）と Owner の現在値が入る
4. Owner を書き換えて「保存」→「保存しました」表示
   → `/tmp/t-config.json` の `github.owner` が更新され、`_keep` は保持されている
5. `VK_TERMINALS_SETTINGS` を付けずに `npm start`
   → ⚙ ボタンは表示されない（従来どおり）

## 備考

- UI 追加のため Before/After スクリーンショットは別途添付予定です（Before = ⚙ なし / After = ⚙ + モーダル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 環境変数で指定した設定ディスクリプタに基づき、GUI から設定を編集・保存できる「設定パネル」を追加しました。
  * 設定内容に応じて入力欄（テキスト/数値/真偽値/JSON/パスワード）が自動生成され、保存結果も表示します。
  * 保存後の反映には再起動が必要です。
* **ドキュメント**
  * 設定パネルの使い方、保存時の仕様（型変換・既存キー保持・JSON/数値の扱い）を追記しました。
* **Chores**
  * `settings-descriptor.json` を Git 管理対象から除外しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->