### PR TITLE
[ 機能追加 ] Claude のトークン使用量（5時間ブロックの消費状況）をタイトルバー・モバイルページに表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] Claude のトークン使用量（5 時間ブロックの消費状況・リセット時刻・過去最大比の目安）をタイトルバーとモバイルステータスページに表示（[#69](https://github.com/vektor-inc/vk-terminals/issues/69)）
 - [ 仕様変更 ] エージェントルーム（β）を一旦無効化。設定項目とペイン表示の両方を非表示に（[#70](https://github.com/vektor-inc/vk-terminals/issues/70)）
 
 ## 1.5.2

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ const { stripAnsiForPattern } = require('./utils/stripAnsi');
 // canonicalizeState / isKnownAgent は DOM 非依存なので main プロセスから require して使える。
 const { canonicalizeState, isKnownAgent } = require('./renderer/agentRoom');
 // トークン使用量トラッカー（issue #69）。トランスクリプト集計＋整形はすべて usageTracker 側。
-const { createUsageTracker } = require('./usageTracker');
+const { createUsageTracker, createTtlMemo } = require('./usageTracker');
 const execFileAsync = promisify(execFile);
 
 let win;
@@ -75,16 +75,26 @@ function loadUserConfig() {
 }
 
 // ─── トークン使用量（issue #69）────────────────────────────────────────────────
+// GET /api/states（モバイルページが ~2s ごとにポーリング）のホットパスで usage 判定の
+// たびに loadUserConfig() の同期 I/O（readFileSync + JSON.parse）を走らせないよう、
+// usage 系ヘルパー専用に config を短TTL（5s）でメモ化する（CR-1）。
+//   - このメモは usage 判定（usageEnabled / usageProjectsDirs）だけが使う。settings:describe /
+//     settings:save / app:get-config は従来どおり loadUserConfig() を直接呼ぶ（設定変更を即時反映
+//     させるため、loadUserConfig 自体はグローバルキャッシュしない）。
+//   - TTL 5s なので、設定変更後も遅くとも 5 秒で usage 表示に反映される。
+const USAGE_CONFIG_TTL_MS = 5000;
+const usageConfig = createTtlMemo(loadUserConfig, USAGE_CONFIG_TTL_MS);
+
 // showUsage は opt-out（既定 ON）。config.json で明示的に false のときだけ無効化する。
 // （settings descriptor 側でも default:true を持たせ、GUI の未設定→false 化を防ぐ。）
 function usageEnabled() {
-  return loadUserConfig().showUsage !== false;
+  return usageConfig().showUsage !== false;
 }
 
 // 集計対象の Claude projects ディレクトリ。複数アカウントは config.claudeProjectsDirs で
 // 複数指定できる。未指定なら usageTracker 側の既定（~/.claude/projects）を使う。
 function usageProjectsDirs() {
-  const raw = loadUserConfig().claudeProjectsDirs;
+  const raw = usageConfig().claudeProjectsDirs;
   if (Array.isArray(raw)) {
     const dirs = raw.filter((d) => typeof d === 'string' && d.trim());
     if (dirs.length) return dirs;

--- a/main.js
+++ b/main.js
@@ -10,6 +10,8 @@ const { stripAnsiForPattern } = require('./utils/stripAnsi');
 // エージェントルーム（issue #58）の agent 名・state 検証を renderer 側と共有する。
 // canonicalizeState / isKnownAgent は DOM 非依存なので main プロセスから require して使える。
 const { canonicalizeState, isKnownAgent } = require('./renderer/agentRoom');
+// トークン使用量トラッカー（issue #69）。トランスクリプト集計＋整形はすべて usageTracker 側。
+const { createUsageTracker } = require('./usageTracker');
 const execFileAsync = promisify(execFile);
 
 let win;
@@ -70,6 +72,40 @@ function loadUserConfig() {
   }
 
   return {};
+}
+
+// ─── トークン使用量（issue #69）────────────────────────────────────────────────
+// showUsage は opt-out（既定 ON）。config.json で明示的に false のときだけ無効化する。
+// （settings descriptor 側でも default:true を持たせ、GUI の未設定→false 化を防ぐ。）
+function usageEnabled() {
+  return loadUserConfig().showUsage !== false;
+}
+
+// 集計対象の Claude projects ディレクトリ。複数アカウントは config.claudeProjectsDirs で
+// 複数指定できる。未指定なら usageTracker 側の既定（~/.claude/projects）を使う。
+function usageProjectsDirs() {
+  const raw = loadUserConfig().claudeProjectsDirs;
+  if (Array.isArray(raw)) {
+    const dirs = raw.filter((d) => typeof d === 'string' && d.trim());
+    if (dirs.length) return dirs;
+  }
+  return null; // null → usageTracker のデフォルト
+}
+
+// トラッカーは 1 個だけ生成し、差分読み・SWR キャッシュを内包させる。
+const usageTracker = createUsageTracker({
+  getDirs: () => usageProjectsDirs(),
+});
+
+// 表示用に整形したスナップショットを返す。無効時・失敗時は null（アプリ本体に影響させない）。
+function getUsageForDisplay() {
+  try {
+    if (!usageEnabled()) return null;
+    return usageTracker.getDescribed();
+  } catch (e) {
+    console.error(`${LOG_PREFIX} usage snapshot failed:`, e && e.message);
+    return null;
+  }
 }
 
 /**
@@ -191,6 +227,8 @@ app.whenReady().then(async () => {
   createWindow();
   await checkAndUpdate();
   startHttpApi();
+  // 使用量スナップショットを起動時に温めておく（初回ポーリングで null が返るのを避ける）。
+  if (usageEnabled()) usageTracker.warmup().catch(() => {});
 });
 
 app.on('window-all-closed', () => {
@@ -214,6 +252,10 @@ app.on('before-quit', () => {
 ipcMain.handle('app:get-config', () => {
   return { agentroom: false };
 });
+
+// タイトルバーのトークン使用量インジケータ（issue #69）が 15 秒ごとにポーリングする。
+// 無効時・データ無し・失敗時は null を返し、renderer 側はインジケータを隠す。
+ipcMain.handle('usage:get', () => getUsageForDisplay());
 
 // ─── 設定パネル（汎用）────────────────────────────────────────────────────────
 // 呼び出し側（例: vk-orchestrator）が環境変数 VK_TERMINALS_SETTINGS に「設定ディスク
@@ -254,6 +296,9 @@ function builtinSettingsDescriptor() {
         fields: [
           { key: 'apiHost',        label: 'API ホスト',            type: 'text',    help: '既定 127.0.0.1' },
           { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: '1 ペイン目で claude 起動直後に自動実行させたいコマンドがあれば記入してください。' },
+          // showUsage（issue #69）は opt-out（既定 ON）。default:true で「未設定 boolean が
+          // 保存時に false になる」問題を避ける（settings:describe / settings:save が default 尊重）。
+          { key: 'showUsage',      label: 'トークン使用量を表示',   type: 'boolean', default: true, help: 'Claude の 5 時間ブロックの消費状況をタイトルバー・モバイルページに表示します。' },
           // issue #70 でエージェントルーム（β）を一旦無効化するため設定項目を非表示にする。
           // 復帰時は下記コメントを解除する。
           // { key: 'agentroom',      label: 'エージェントルーム（β）表示', type: 'boolean' },
@@ -333,7 +378,12 @@ ipcMain.handle('settings:describe', () => {
   const values = {};
   for (const f of descriptorFields(descriptor)) {
     const v = deepGet(current, f.key);
-    values[f.key] = v === undefined ? null : v;
+    // 未設定（undefined）のフィールドは descriptor の default を尊重する。
+    // これがないと boolean（例: showUsage=opt-out）が GUI 上で未チェック表示になり、
+    // ユーザーが何も触らず保存しただけで false に固定されてしまう（issue #69 で同時修正）。
+    values[f.key] = v === undefined
+      ? (f.default !== undefined ? f.default : null)
+      : v;
   }
   return {
     available: true,
@@ -380,7 +430,12 @@ ipcMain.handle('settings:save', (event, incoming) => {
         break;
       }
       case 'boolean':
-        coerced = !!raw;
+        // 値が来ていない（null/undefined）場合は default を尊重する。
+        // checkbox は通常 true/false を送るが、未描画・欠損時に !!undefined=false へ
+        // 落として opt-out 既定を潰さないための保険（settings:describe の default 尊重と対）。
+        coerced = (raw === null || raw === undefined)
+          ? (f.default !== undefined ? !!f.default : false)
+          : !!raw;
         break;
       case 'json': {
         if (raw === '' || raw === null || raw === undefined) {
@@ -698,7 +753,12 @@ function startHttpApi() {
     // GET /api/states
     if (req.method === 'GET' && url.pathname === '/api/states') {
       res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
-      res.end(JSON.stringify({ updatedAt: new Date().toISOString(), terminals: cachedStates }));
+      // usage（issue #69）はモバイルページの既存ポーリングに相乗りで additive に追加する。
+      res.end(JSON.stringify({
+        updatedAt: new Date().toISOString(),
+        terminals: cachedStates,
+        usage: getUsageForDisplay(),
+      }));
       return;
     }
 

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1542,8 +1542,9 @@ function setupUsageIndicator() {
     try {
       const u = await ipcRenderer.invoke('usage:get');
       if (u && u.titleText) {
+        // 重要度順（トークン量 → ピーク比 → リセット時刻）で、狭幅では末尾から欠ける。
+        // ツールチップ（title）には頼らない（ドラッグ領域の関係で hover が出ないため）。
         el.textContent = u.titleText;
-        el.title = u.mobileText || u.titleText;
         el.hidden = false;
       } else {
         el.textContent = '';

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1532,6 +1532,31 @@ async function setupSettingsPanel() {
   btn.addEventListener('click', () => openSettingsModal());
 }
 
+// ─── トークン使用量インジケータ（issue #69）──────────────────────────────────
+// main の usage:get を 15 秒ごとにポーリングし、タイトルバー左端に表示する。
+// 無効・データ無し・取得失敗のときは要素ごと隠す（アプリ本体に影響を与えない）。
+function setupUsageIndicator() {
+  const el = document.getElementById('usage-indicator');
+  if (!el) return;
+  const refresh = async () => {
+    try {
+      const u = await ipcRenderer.invoke('usage:get');
+      if (u && u.titleText) {
+        el.textContent = u.titleText;
+        el.title = u.mobileText || u.titleText;
+        el.hidden = false;
+      } else {
+        el.textContent = '';
+        el.hidden = true;
+      }
+    } catch (_e) {
+      el.hidden = true;
+    }
+  };
+  refresh();
+  setInterval(refresh, 15000);
+}
+
 // 1 フィールド分の入力 HTML を組み立てる。
 // id は描画順で採番したユニークな値を呼び出し側から受け取る（キーから id を導出すると
 // "a.b" と "a_b" のような別キーがサニタイズ後に衝突しうるため、キー由来にしない）。
@@ -1710,6 +1735,9 @@ initApp().then(() => {
 
 // 設定パネル（汎用）の有効/無効を判定してボタンを出す。
 setupSettingsPanel();
+
+// タイトルバーのトークン使用量インジケータ（issue #69）を配線する。
+setupUsageIndicator();
 
 // ─── State reporting to main process ─────────────────────────────────────────
 setInterval(() => {

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
   <div class="titlebar">
+    <span id="usage-indicator" class="usage-indicator" title="Claude の 5 時間ブロックの消費状況" hidden></span>
     <span class="app-title">VK Terminals</span>
     <button id="settings-btn" class="titlebar-btn" title="設定" hidden>⚙</button>
   </div>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="titlebar">
-    <span id="usage-indicator" class="usage-indicator" title="Claude の 5 時間ブロックの消費状況" hidden></span>
+    <span id="usage-indicator" class="usage-indicator" hidden></span>
     <span class="app-title">VK Terminals</span>
     <button id="settings-btn" class="titlebar-btn" title="設定" hidden>⚙</button>
   </div>

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -90,6 +90,17 @@
   .nl-toggle { font-size: 11px; color: var(--muted); display: flex; align-items: center; gap: 5px;
     padding: 2px; }
   #err { display: none; background: #4a1e1e; color: #ffb4b4; font-size: 12px; padding: 6px 12px; }
+  /* トークン使用量カード（issue #69）。data.usage があるときだけ #list の先頭に表示する。 */
+  #usage-card { display: none; margin: 10px 10px 0; padding: 11px 13px; background: var(--card);
+    border: 1px solid var(--card-border); border-radius: 12px; }
+  #usage-card.show { display: block; }
+  #usage-card .u-line { font-size: 12px; color: var(--fg); font-weight: 600;
+    display: flex; align-items: center; gap: 6px; }
+  #usage-card .u-line .u-bolt { font-size: 13px; }
+  #usage-card .u-bar { margin-top: 6px; font-size: 12px; color: var(--muted);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 1px;
+    display: flex; align-items: center; gap: 8px; }
+  #usage-card .u-bar .u-marks { color: var(--running); letter-spacing: 2px; }
 </style>
 </head>
 <body>
@@ -98,6 +109,10 @@
   <span class="meta" id="meta">接続中…</span>
 </header>
 <div id="err"></div>
+<div id="usage-card">
+  <div class="u-line"><span class="u-bolt">⚡</span><span id="usage-text"></span></div>
+  <div class="u-bar"><span class="u-marks" id="usage-marks"></span><span id="usage-percent"></span></div>
+</div>
 <div id="list"></div>
 
 <script>
@@ -354,7 +369,23 @@ function ensureCard(termId) {
   return cards[termId];
 }
 
+// 使用量カード（issue #69）。data.usage（main が整形済みの文字列群）があれば表示する。
+// 無い（無効・データ無し）ときは隠す。文字列は textContent で入れるので XSS 面も安全。
+var usageCard = document.getElementById("usage-card");
+function renderUsage(usage) {
+  if (!usageCard) return;
+  if (!usage || !usage.mobileText) {
+    usageCard.classList.remove("show");
+    return;
+  }
+  document.getElementById("usage-text").textContent = usage.mobileText;
+  document.getElementById("usage-marks").textContent = usage.bar || "";
+  document.getElementById("usage-percent").textContent = usage.barText || "";
+  usageCard.classList.add("show");
+}
+
 function render(data) {
+  renderUsage(data.usage);
   var terms = data.terminals || {};
   var keys = Object.keys(terms);
   // 並び順: waiting > running > idle、その中は termId 昇順

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -100,7 +100,11 @@
   #usage-card .u-bar { margin-top: 6px; font-size: 12px; color: var(--muted);
     font-family: ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 1px;
     display: flex; align-items: center; gap: 8px; }
+  #usage-card .u-bar[hidden] { display: none; }
   #usage-card .u-bar .u-marks { color: var(--running); letter-spacing: 2px; }
+  /* ピーク比の意味をモバイルにだけ一度添える補足（UX-1）。 */
+  #usage-card .u-note { margin-top: 4px; font-size: 10px; color: var(--muted); }
+  #usage-card .u-note[hidden] { display: none; }
 </style>
 </head>
 <body>
@@ -111,7 +115,8 @@
 <div id="err"></div>
 <div id="usage-card">
   <div class="u-line"><span class="u-bolt">⚡</span><span id="usage-text"></span></div>
-  <div class="u-bar"><span class="u-marks" id="usage-marks"></span><span id="usage-percent"></span></div>
+  <div class="u-bar" id="usage-bar"><span class="u-marks" id="usage-marks"></span><span id="usage-percent"></span></div>
+  <div class="u-note" id="usage-note"></div>
 </div>
 <div id="list"></div>
 
@@ -379,8 +384,19 @@ function renderUsage(usage) {
     return;
   }
   document.getElementById("usage-text").textContent = usage.mobileText;
-  document.getElementById("usage-marks").textContent = usage.bar || "";
-  document.getElementById("usage-percent").textContent = usage.barText || "";
+  // ピーク比（バー）行は utilization がある時だけ表示。無い時は 0% 誤読を避けて行ごと隠す。
+  var barRow = document.getElementById("usage-bar");
+  var noteRow = document.getElementById("usage-note");
+  if (usage.barText) {
+    document.getElementById("usage-marks").textContent = usage.bar || "";
+    document.getElementById("usage-percent").textContent = usage.barText;
+    noteRow.textContent = usage.peakNote || "";
+    barRow.hidden = false;
+    noteRow.hidden = !usage.peakNote;
+  } else {
+    barRow.hidden = true;
+    noteRow.hidden = true;
+  }
   usageCard.classList.add("show");
 }
 

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -39,6 +39,27 @@ html, body {
   -webkit-user-select: none;
 }
 
+/* タイトルバー左端のトークン使用量インジケータ（issue #69）。
+   app-title は中央寄せなので、これは絶対配置で左端に置く（ドラッグ領域からは除外しない
+   ＝クリックは特に無いのでウィンドウドラッグを妨げない）。狭幅では省略記号で切る。 */
+.usage-indicator {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #7d8590;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  -webkit-user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 40vw;
+  pointer-events: none;
+}
+.usage-indicator[hidden] { display: none; }
+
 /* タイトルバー右端の設定ボタン（ドラッグ領域から除外する） */
 .titlebar-btn {
   position: absolute;

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -24,29 +24,37 @@ html, body {
   -webkit-app-region: drag;
   background: #0d1117;
   border-bottom: 1px solid #21262d;
-  display: flex;
+  /* 左（使用量）/ 中央（アプリ名）/ 右（設定ボタン）の 3 レーン。中央は auto 幅で
+     常に中央寄せになり、左右の 1fr が均等に押し合うので、使用量とアプリ名が
+     狭幅でも別セルに分かれて重ならない（UX-3）。設定ボタンは右セルに絶対配置で載る。 */
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: center;
   z-index: 1000;
   flex-shrink: 0;
 }
 
 .app-title {
+  grid-column: 2;
   color: #6e7681;
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0.02em;
   -webkit-user-select: none;
+  white-space: nowrap;
 }
 
-/* タイトルバー左端のトークン使用量インジケータ（issue #69）。
-   app-title は中央寄せなので、これは絶対配置で左端に置く（ドラッグ領域からは除外しない
-   ＝クリックは特に無いのでウィンドウドラッグを妨げない）。狭幅では省略記号で切る。 */
+/* タイトルバー左レーンのトークン使用量インジケータ（issue #69）。
+   グリッドの左セル（1fr）に収まり、狭幅ではセル幅を超えた分を省略記号で切る。
+   重要度順（トークン量 → ピーク比 → リセット時刻）で並び、末尾から欠ける（UX-2）。
+   ツールチップには頼らない設計なので pointer-events は無効化し、ウィンドウドラッグを妨げない。 */
 .usage-indicator {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
+  grid-column: 1;
+  justify-self: start;
+  min-width: 0;         /* grid セル内で ellipsis を効かせるため */
+  max-width: 100%;
+  padding-left: 12px;
+  box-sizing: border-box;
   color: #7d8590;
   font-size: 11px;
   font-weight: 500;
@@ -55,7 +63,6 @@ html, body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 40vw;
   pointer-events: none;
 }
 .usage-indicator[hidden] { display: none; }

--- a/tests/usageTracker.test.js
+++ b/tests/usageTracker.test.js
@@ -21,6 +21,7 @@ const {
   formatDuration,
   progressBar,
   describeUsage,
+  createTtlMemo,
   clampReadStart,
   readSliceComplete,
   SESSION_DURATION_MS,
@@ -271,6 +272,25 @@ test('describeUsage: utilization が null なら ピーク比・バーを伏せ�
   assert.ok(!d.titleText.includes('ピーク比'));
   // リセット時刻は残る（トークン量とリセットのみ）。
   assert.ok(d.titleText.includes('リセット'));
+});
+
+// ── createTtlMemo（CR-1: usage 判定ホットパスの短TTLメモ化） ─────────────────
+test('createTtlMemo: TTL 内は再読込せず、TTL 経過で再読込する', () => {
+  let calls = 0;
+  let clock = 1000;
+  const memo = createTtlMemo(() => { calls++; return `v${calls}`; }, 5000, () => clock);
+
+  assert.equal(memo(), 'v1'); // 初回ロード
+  assert.equal(calls, 1);
+  clock = 3000;               // +2s（TTL 内）
+  assert.equal(memo(), 'v1'); // 再利用
+  assert.equal(calls, 1);
+  clock = 6001;               // 初回から 5001ms（TTL 経過）
+  assert.equal(memo(), 'v2'); // 再ロード
+  assert.equal(calls, 2);
+  clock = 6002;               // 直後（TTL 内）
+  assert.equal(memo(), 'v2'); // 再利用
+  assert.equal(calls, 2);
 });
 
 // ── clampReadStart（SEC-1: 1 回の読取上限） ──────────────────────────────────

--- a/tests/usageTracker.test.js
+++ b/tests/usageTracker.test.js
@@ -6,6 +6,9 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   tokensFromUsage,
@@ -18,6 +21,8 @@ const {
   formatDuration,
   progressBar,
   describeUsage,
+  clampReadStart,
+  readSliceComplete,
   SESSION_DURATION_MS,
 } = require('../usageTracker');
 
@@ -40,6 +45,11 @@ test('tokensFromUsage: 欠損フィールドは 0 扱い / 非オブジェクト
   assert.equal(tokensFromUsage(null), 0);
   assert.equal(tokensFromUsage(undefined), 0);
   assert.equal(tokensFromUsage('x'), 0);
+});
+
+test('tokensFromUsage: 負値は 0 にクランプする（破損 usage 対策・SEC-2）', () => {
+  assert.equal(tokensFromUsage({ input_tokens: -100, output_tokens: 50 }), 50);
+  assert.equal(tokensFromUsage({ input_tokens: -5, cache_read_input_tokens: -5 }), 0);
 });
 
 // ── parseRecord ──────────────────────────────────────────────────────────────
@@ -238,17 +248,70 @@ test('describeUsage: タイトル / モバイル / バー文字列を組み立�
   assert.equal(d.remainingText, '1h27m');
   assert.equal(d.percentText, '43%');
   assert.equal(d.bar, '▰▰▱▱▱');
+  // ラベルはタイトル・モバイル・バーで「ピーク比」に統一（UX-1）。
   assert.ok(d.titleText.includes('12.3M tok'));
-  assert.ok(d.titleText.includes('目安43%'));
+  assert.ok(d.titleText.includes('ピーク比43%'));
+  assert.equal(d.barText, 'ピーク比43%');
+  assert.ok(!d.titleText.includes('目安'));
+  assert.ok(!d.barText.includes('過去最大比'));
+  // タイトルは重要度順（トークン量 → ピーク比 → リセット時刻）。ピーク比がリセットより前（UX-2）。
+  assert.ok(d.titleText.indexOf('ピーク比') < d.titleText.indexOf('リセット'));
+  // モバイルは「トークン」明示・残り時間つき。
+  assert.ok(d.mobileText.includes('12.3M トークン'));
   assert.ok(d.mobileText.includes('残り1h27m'));
-  assert.ok(d.barText.includes('過去最大比43%'));
 });
 
-test('describeUsage: utilization が null なら 目安/過去最大比を伏せる', () => {
+test('describeUsage: utilization が null なら ピーク比・バーを伏せる', () => {
   const now = Date.parse('2026-07-06T05:00:00.000Z');
   const snap = { source: 'transcript', utilization: null, totalTokens: 1000, resetAtMs: now + HOUR, isActive: true };
   const d = describeUsage(snap, now);
   assert.equal(d.percentText, null);
-  assert.ok(!d.titleText.includes('目安'));
-  assert.equal(d.barText, '過去最大比—');
+  assert.equal(d.barText, null);
+  assert.equal(d.bar, null);
+  assert.ok(!d.titleText.includes('ピーク比'));
+  // リセット時刻は残る（トークン量とリセットのみ）。
+  assert.ok(d.titleText.includes('リセット'));
+});
+
+// ── clampReadStart（SEC-1: 1 回の読取上限） ──────────────────────────────────
+test('clampReadStart: 上限内はそのまま / 超過なら末尾 maxBytes に切り詰める', () => {
+  assert.equal(clampReadStart(0, 100, 1000), 0);        // 上限内
+  assert.equal(clampReadStart(0, 5000, 1000), 4000);    // 末尾 1000 のみ → start=end-max
+  assert.equal(clampReadStart(200, 1200, 1000), 200);   // ちょうど上限
+  assert.equal(clampReadStart(200, 1300, 1000), 300);   // 超過 → 前進
+});
+
+// ── readSliceComplete（fs: 差分読み・改行境界・上限） ──────────────────────────
+test('readSliceComplete: 完全な行だけ返し consumed が改行直後を指す', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vkt-usage-'));
+  const file = path.join(dir, 'a.jsonl');
+  try {
+    // 2 行完結 + 改行未満の書き込み途中行
+    const content = 'line1\nline2\npartial';
+    fs.writeFileSync(file, content);
+    const size = fs.statSync(file).size;
+    const { text, consumed } = await readSliceComplete(file, 0, size);
+    assert.equal(text, 'line1\nline2\n');            // partial は含まない
+    assert.equal(consumed, Buffer.byteLength('line1\nline2\n')); // 改行直後
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readSliceComplete: maxBytes 超過時は末尾のみ読む（Buffer 確保を上限内に抑える）', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vkt-usage-'));
+  const file = path.join(dir, 'big.jsonl');
+  try {
+    // "AAAA\n" を多数 + 末尾に "TAIL\n"。maxBytes を小さくして末尾だけ拾えることを確認。
+    const body = 'AAAA\n'.repeat(100) + 'TAIL\n';
+    fs.writeFileSync(file, body);
+    const size = fs.statSync(file).size;
+    const { text, consumed } = await readSliceComplete(file, 0, size, 12); // 末尾 12 バイトのみ
+    // 読取は maxBytes 以内に収まり（＝Buffer 確保も上限内）、末尾の完全行は取れる。
+    assert.ok(Buffer.byteLength(text) <= 12);
+    assert.ok(text.includes('TAIL'));
+    assert.equal(consumed, size); // 末尾まで消費（改行で終わっているため）
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/usageTracker.test.js
+++ b/tests/usageTracker.test.js
@@ -1,0 +1,254 @@
+'use strict';
+// usageTracker（issue #69）の純粋関数コアのテスト。
+// トランスクリプト（~/.claude/projects/**/*.jsonl）の message.usage を集計して
+// 5h ブロックの消費状況を求める部分を、fixture JSONL / エントリで固定時刻検証する。
+// fs/IO 層（差分読み・SWR キャッシュ）は副作用を持つためここでは扱わない。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  tokensFromUsage,
+  parseRecord,
+  parseJsonl,
+  floorToHourUtc,
+  buildBlocks,
+  summarize,
+  formatTokens,
+  formatDuration,
+  progressBar,
+  describeUsage,
+  SESSION_DURATION_MS,
+} = require('../usageTracker');
+
+const HOUR = 60 * 60 * 1000;
+
+// ── tokensFromUsage ──────────────────────────────────────────────────────────
+test('tokensFromUsage: input/output/cache 作成/cache 読取 を合算する', () => {
+  const usage = {
+    input_tokens: 100,
+    output_tokens: 50,
+    cache_creation_input_tokens: 200,
+    cache_read_input_tokens: 300,
+  };
+  assert.equal(tokensFromUsage(usage), 650);
+});
+
+test('tokensFromUsage: 欠損フィールドは 0 扱い / 非オブジェクトは 0', () => {
+  assert.equal(tokensFromUsage({ input_tokens: 10 }), 10);
+  assert.equal(tokensFromUsage({}), 0);
+  assert.equal(tokensFromUsage(null), 0);
+  assert.equal(tokensFromUsage(undefined), 0);
+  assert.equal(tokensFromUsage('x'), 0);
+});
+
+// ── parseRecord ──────────────────────────────────────────────────────────────
+test('parseRecord: assistant+usage 行から ts/tokens/dedupKey を取り出す', () => {
+  const obj = {
+    timestamp: '2026-07-06T05:00:00.000Z',
+    requestId: 'req_1',
+    message: { id: 'msg_1', role: 'assistant', usage: { input_tokens: 10, output_tokens: 5 } },
+  };
+  const e = parseRecord(obj);
+  assert.equal(e.ts, Date.parse('2026-07-06T05:00:00.000Z'));
+  assert.equal(e.tokens, 15);
+  assert.equal(e.dedupKey, 'msg_1:req_1');
+});
+
+test('parseRecord: usage 無し・timestamp 無し・不正時刻は null', () => {
+  assert.equal(parseRecord({ timestamp: '2026-07-06T05:00:00Z', message: { role: 'user' } }), null);
+  assert.equal(parseRecord({ message: { usage: { input_tokens: 1 } } }), null);
+  assert.equal(parseRecord({ timestamp: 'not-a-date', message: { usage: {} } }), null);
+  assert.equal(parseRecord(null), null);
+});
+
+test('parseRecord: message.id か requestId が欠けると dedupKey は null', () => {
+  const base = { timestamp: '2026-07-06T05:00:00.000Z', message: { usage: { input_tokens: 1 } } };
+  assert.equal(parseRecord({ ...base, requestId: 'req_1' }).dedupKey, null); // id 無し
+  assert.equal(parseRecord({ ...base, message: { id: 'msg_1', usage: { input_tokens: 1 } } }).dedupKey, null); // requestId 無し
+});
+
+// ── parseJsonl ───────────────────────────────────────────────────────────────
+test('parseJsonl: 壊れた行・空行はスキップし有効行だけ返す', () => {
+  const text = [
+    '{"timestamp":"2026-07-06T05:00:00.000Z","requestId":"r1","message":{"id":"m1","usage":{"input_tokens":10}}}',
+    '',
+    'これは壊れたJSON行',
+    '{"timestamp":"2026-07-06T05:01:00.000Z","message":{"role":"user"}}',
+    '{"timestamp":"2026-07-06T05:02:00.000Z","requestId":"r2","message":{"id":"m2","usage":{"output_tokens":20}}}',
+  ].join('\n');
+  const entries = parseJsonl(text);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].tokens, 10);
+  assert.equal(entries[1].tokens, 20);
+});
+
+// ── floorToHourUtc ───────────────────────────────────────────────────────────
+test('floorToHourUtc: UTC 正時に切り捨てる', () => {
+  const ms = Date.parse('2026-07-06T05:39:38.924Z');
+  assert.equal(floorToHourUtc(ms), Date.parse('2026-07-06T05:00:00.000Z'));
+});
+
+// ── buildBlocks ──────────────────────────────────────────────────────────────
+test('buildBlocks: 5h 以内の連続活動は 1 ブロックに集約（開始は正時 floor）', () => {
+  const t0 = Date.parse('2026-07-06T05:30:00.000Z');
+  const entries = [
+    { ts: t0, tokens: 100 },
+    { ts: t0 + HOUR, tokens: 200 },
+    { ts: t0 + 2 * HOUR, tokens: 300 },
+  ];
+  const blocks = buildBlocks(entries);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0].startMs, Date.parse('2026-07-06T05:00:00.000Z'));
+  assert.equal(blocks[0].endMs, Date.parse('2026-07-06T05:00:00.000Z') + SESSION_DURATION_MS);
+  assert.equal(blocks[0].tokens, 600);
+  assert.equal(blocks[0].count, 3);
+});
+
+test('buildBlocks: 5h 超の gap で新しいブロックに分かれる', () => {
+  const t0 = Date.parse('2026-07-06T00:00:00.000Z');
+  const entries = [
+    { ts: t0, tokens: 100 },
+    { ts: t0 + 6 * HOUR, tokens: 200 }, // gap 6h > 5h → 新ブロック
+  ];
+  const blocks = buildBlocks(entries);
+  assert.equal(blocks.length, 2);
+  assert.equal(blocks[0].tokens, 100);
+  assert.equal(blocks[1].tokens, 200);
+});
+
+test('buildBlocks: ブロック開始から 5h 超のエントリは gap が無くても新ブロック', () => {
+  const start = Date.parse('2026-07-06T00:00:00.000Z');
+  const entries = [
+    { ts: start + 10 * 60 * 1000, tokens: 100 }, // 00:10（開始 floor は 00:00）
+    { ts: start + 3 * HOUR, tokens: 100 },        // 同ブロック
+    { ts: start + 5 * HOUR + 30 * 60 * 1000, tokens: 100 }, // 開始から 5.5h → 新ブロック
+  ];
+  const blocks = buildBlocks(entries);
+  assert.equal(blocks.length, 2);
+  assert.equal(blocks[0].count, 2);
+  assert.equal(blocks[1].count, 1);
+});
+
+// ── summarize ────────────────────────────────────────────────────────────────
+test('summarize: アクティブブロックのトークン・リセット時刻・過去最大比を返す', () => {
+  const blockStart = Date.parse('2026-07-06T05:00:00.000Z');
+  // 過去ブロック（最大 1000）＋ 現ブロック（合計 430）
+  const past = Date.parse('2026-07-05T00:00:00.000Z');
+  const entries = [
+    { ts: past, tokens: 1000, dedupKey: 'a 1' },
+    { ts: blockStart + 5 * 60 * 1000, tokens: 200, dedupKey: 'b 1' },
+    { ts: blockStart + 30 * 60 * 1000, tokens: 230, dedupKey: 'c 1' },
+  ];
+  const now = blockStart + 60 * 60 * 1000; // 開始から 1h 後
+  const snap = summarize(entries, now);
+  assert.equal(snap.source, 'transcript');
+  assert.equal(snap.totalTokens, 430);
+  assert.equal(snap.maxBlockTokens, 1000);
+  assert.equal(snap.resetAtMs, blockStart + SESSION_DURATION_MS);
+  assert.equal(snap.remainingMs, snap.resetAtMs - now);
+  assert.ok(Math.abs(snap.utilization - 0.43) < 1e-9);
+  assert.equal(snap.isActive, true);
+});
+
+test('summarize: 重複エントリ（同一 message.id+requestId）は集計されない', () => {
+  const t = Date.parse('2026-07-06T05:00:00.000Z');
+  const entries = [
+    { ts: t, tokens: 100, dedupKey: 'dup 1' },
+    { ts: t + 1000, tokens: 100, dedupKey: 'dup 1' }, // 重複 → 無視
+    { ts: t + 2000, tokens: 50, dedupKey: 'uniq 1' },
+  ];
+  const snap = summarize(entries, t + 3000);
+  assert.equal(snap.totalTokens, 150);
+});
+
+test('summarize: dedupKey が null のエントリは重複除外されない', () => {
+  const t = Date.parse('2026-07-06T05:00:00.000Z');
+  const entries = [
+    { ts: t, tokens: 100, dedupKey: null },
+    { ts: t + 1000, tokens: 100, dedupKey: null },
+  ];
+  const snap = summarize(entries, t + 2000);
+  assert.equal(snap.totalTokens, 200);
+});
+
+test('summarize: 未来（now+skew 超）のタイムスタンプは除外する', () => {
+  const now = Date.parse('2026-07-06T05:00:00.000Z');
+  const entries = [
+    { ts: now - 60 * 1000, tokens: 100, dedupKey: 'a 1' },
+    { ts: now + 60 * 60 * 1000, tokens: 999, dedupKey: 'future 1' }, // 1h 未来 → 除外
+  ];
+  const snap = summarize(entries, now);
+  assert.equal(snap.totalTokens, 100);
+});
+
+test('summarize: 最終活動から 5h 超（非アクティブ）なら null', () => {
+  const t = Date.parse('2026-07-06T00:00:00.000Z');
+  const entries = [{ ts: t, tokens: 100, dedupKey: 'a 1' }];
+  const now = t + 6 * HOUR; // 最終活動から 6h → もう current block ではない
+  assert.equal(summarize(entries, now), null);
+});
+
+test('summarize: 空配列・全除外は null', () => {
+  assert.equal(summarize([], Date.now()), null);
+  const now = Date.parse('2026-07-06T05:00:00.000Z');
+  assert.equal(summarize([{ ts: now + 10 * HOUR, tokens: 10, dedupKey: null }], now), null);
+});
+
+// ── 整形ヘルパ ───────────────────────────────────────────────────────────────
+test('formatTokens: M / k / 素の数値', () => {
+  assert.equal(formatTokens(12_300_000), '12.3M');
+  assert.equal(formatTokens(2_000_000), '2M');
+  assert.equal(formatTokens(820_000), '820k');
+  assert.equal(formatTokens(500), '500');
+  assert.equal(formatTokens(0), '0');
+});
+
+test('formatDuration: 時分 / 分のみ / まもなく', () => {
+  assert.equal(formatDuration(87 * 60 * 1000), '1h27m');
+  assert.equal(formatDuration(27 * 60 * 1000), '27m');
+  assert.equal(formatDuration(0), 'まもなく');
+  assert.equal(formatDuration(-100), 'まもなく');
+});
+
+test('progressBar: 比率を 5 マスの ▰▱ にする', () => {
+  assert.equal(progressBar(0), '▱▱▱▱▱');
+  assert.equal(progressBar(0.43), '▰▰▱▱▱'); // round(2.15)=2
+  assert.equal(progressBar(1), '▰▰▰▰▰');
+  assert.equal(progressBar(2), '▰▰▰▰▰'); // クランプ
+});
+
+// ── describeUsage ────────────────────────────────────────────────────────────
+test('describeUsage: null スナップショットは null', () => {
+  assert.equal(describeUsage(null, Date.now()), null);
+});
+
+test('describeUsage: タイトル / モバイル / バー文字列を組み立てる', () => {
+  const now = Date.parse('2026-07-06T05:00:00.000Z');
+  const snap = {
+    source: 'transcript',
+    utilization: 0.43,
+    totalTokens: 12_300_000,
+    resetAtMs: now + 87 * 60 * 1000,
+    remainingMs: 87 * 60 * 1000,
+    isActive: true,
+  };
+  const d = describeUsage(snap, now);
+  assert.equal(d.tokensText, '12.3M');
+  assert.equal(d.remainingText, '1h27m');
+  assert.equal(d.percentText, '43%');
+  assert.equal(d.bar, '▰▰▱▱▱');
+  assert.ok(d.titleText.includes('12.3M tok'));
+  assert.ok(d.titleText.includes('目安43%'));
+  assert.ok(d.mobileText.includes('残り1h27m'));
+  assert.ok(d.barText.includes('過去最大比43%'));
+});
+
+test('describeUsage: utilization が null なら 目安/過去最大比を伏せる', () => {
+  const now = Date.parse('2026-07-06T05:00:00.000Z');
+  const snap = { source: 'transcript', utilization: null, totalTokens: 1000, resetAtMs: now + HOUR, isActive: true };
+  const d = describeUsage(snap, now);
+  assert.equal(d.percentText, null);
+  assert.ok(!d.titleText.includes('目安'));
+  assert.equal(d.barText, '過去最大比—');
+});

--- a/usageTracker.js
+++ b/usageTracker.js
@@ -1,0 +1,479 @@
+'use strict';
+// Claude のトークン使用量（5 時間レートリミットブロックの消費状況）を、
+// ~/.claude/projects/**/*.jsonl のトランスクリプト（message.usage）から集計する（issue #69）。
+//
+// 設計方針:
+//   - 純粋関数コア（トークン集計・ブロック算出・dedup・整形）と fs/IO 層を分離する。
+//     純粋関数は `now` を引数で受け取り、時刻をテストで固定できるようにする（node --test 対象）。
+//   - fs 層は mtime 6h 窓でファイルを絞り、byte offset 差分読みで巨大 JSONL のフルパースを
+//     初回のみに抑え、stale-while-revalidate キャッシュで呼び出しを軽くする。
+//   - スナップショットは `source` / `utilization` フィールドを持ち、将来 OAuth usage API へ
+//     差し替えられる構造にする（今回 source は 'transcript' 固定）。
+//   - 認証情報には一切触れず、失敗時は null を返してアプリ本体に影響を与えない。
+//
+// ブロック算出は ccusage の blocks アルゴリズム準拠:
+//   - 開始 = そのブロック最初の活動タイムスタンプを UTC 正時に floor
+//   - 長さ 5h
+//   - 直前エントリからの gap が 5h 以上、またはブロック開始から 5h 以上経過で新ブロック
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+
+const HOUR_MS = 60 * 60 * 1000;
+const SESSION_DURATION_MS = 5 * HOUR_MS; // 5 時間ブロック
+const CLOCK_SKEW_MS = 5 * 60 * 1000;     // 未来方向の許容（これを超える未来 ts は除外）
+const RECENT_WINDOW_MS = 6 * HOUR_MS;    // mtime でファイルを絞る窓（ブロック 5h + 余裕 1h）
+const SWR_STALE_MS = 10 * 1000;          // これより新しいスナップショットはそのまま返す
+
+// ─── 純粋関数コア ────────────────────────────────────────────────────────────
+
+/**
+ * message.usage から「そのメッセージで消費した総トークン数」を求める。
+ * ccusage と同様に input / output / cache 作成 / cache 読取 を合算する。
+ * @param {object|null|undefined} usage
+ * @returns {number}
+ */
+function tokensFromUsage(usage) {
+  if (!usage || typeof usage !== 'object') return 0;
+  const n = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  return (
+    n(usage.input_tokens) +
+    n(usage.output_tokens) +
+    n(usage.cache_creation_input_tokens) +
+    n(usage.cache_read_input_tokens)
+  );
+}
+
+/**
+ * トランスクリプト 1 レコード（JSON.parse 済みオブジェクト）から集計用エントリを取り出す。
+ * message.usage を持つ assistant メッセージのみ対象。該当しなければ null。
+ * @param {object} obj
+ * @returns {{ ts: number, tokens: number, dedupKey: string|null }|null}
+ */
+function parseRecord(obj) {
+  if (!obj || typeof obj !== 'object') return null;
+  const msg = obj.message;
+  if (!msg || typeof msg !== 'object' || !msg.usage) return null;
+
+  const tsRaw = obj.timestamp;
+  if (typeof tsRaw !== 'string') return null;
+  const ts = Date.parse(tsRaw);
+  if (!Number.isFinite(ts)) return null;
+
+  const tokens = tokensFromUsage(msg.usage);
+
+  // resume による行重複は message.id + requestId で除外する。
+  // どちらか欠ける場合は dedup できないので null（＝毎回ユニーク扱い）。
+  const id = typeof msg.id === 'string' ? msg.id : '';
+  const requestId = typeof obj.requestId === 'string' ? obj.requestId : '';
+  const dedupKey = id && requestId ? `${id}:${requestId}` : null;
+
+  return { ts, tokens, dedupKey };
+}
+
+/**
+ * JSONL テキストをパースして集計用エントリ配列にする。壊れた行はスキップする。
+ * @param {string} text
+ * @returns {Array<{ts:number,tokens:number,dedupKey:string|null}>}
+ */
+function parseJsonl(text) {
+  if (!text) return [];
+  const out = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch (_e) {
+      continue; // 壊れた行・書き込み途中の行は無視
+    }
+    const entry = parseRecord(obj);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+/** タイムスタンプ（ms）を UTC 正時に切り捨てる。 */
+function floorToHourUtc(ms) {
+  return Math.floor(ms / HOUR_MS) * HOUR_MS;
+}
+
+/**
+ * 昇順ソート・dedup 済みのエントリ配列から 5h ブロック列を構築する（ccusage 準拠）。
+ * @param {Array<{ts:number,tokens:number}>} entries ts 昇順であること
+ * @param {number} [sessionMs]
+ * @returns {Array<{startMs:number,endMs:number,tokens:number,lastEntryMs:number,count:number}>}
+ */
+function buildBlocks(entries, sessionMs = SESSION_DURATION_MS) {
+  const blocks = [];
+  let current = null;
+  for (const e of entries) {
+    if (!current) {
+      const startMs = floorToHourUtc(e.ts);
+      current = { startMs, endMs: startMs + sessionMs, tokens: e.tokens, lastEntryMs: e.ts, count: 1 };
+      blocks.push(current);
+      continue;
+    }
+    const sinceBlockStart = e.ts - current.startMs;
+    const sinceLastEntry = e.ts - current.lastEntryMs;
+    if (sinceBlockStart > sessionMs || sinceLastEntry > sessionMs) {
+      const startMs = floorToHourUtc(e.ts);
+      current = { startMs, endMs: startMs + sessionMs, tokens: e.tokens, lastEntryMs: e.ts, count: 1 };
+      blocks.push(current);
+    } else {
+      current.tokens += e.tokens;
+      current.lastEntryMs = e.ts;
+      current.count += 1;
+    }
+  }
+  return blocks;
+}
+
+/**
+ * 生エントリ配列から使用量スナップショットを作る（純粋）。
+ *   - 未来（now + skew 超）の ts を除外（clock skew 対策）
+ *   - ts 昇順ソート
+ *   - dedupKey で重複除外（先勝ち）
+ *   - 5h ブロック化 → 現在アクティブなブロックを特定
+ *   - 過去最大比（全ブロック中の最大トークンに対する現ブロックの比）を utilization に入れる
+ * アクティブなブロックが無い（無活動が 5h 超 / データ無し）場合は null を返す。
+ *
+ * @param {Array<{ts:number,tokens:number,dedupKey:string|null}>} rawEntries
+ * @param {number} nowMs
+ * @param {{ sessionMs?: number, skewMs?: number }} [opts]
+ * @returns {null | {
+ *   source: string, utilization: number|null, totalTokens: number,
+ *   blockStartMs: number, resetAtMs: number, remainingMs: number,
+ *   lastEntryMs: number, maxBlockTokens: number, isActive: boolean
+ * }}
+ */
+function summarize(rawEntries, nowMs, opts = {}) {
+  const sessionMs = opts.sessionMs || SESSION_DURATION_MS;
+  const skewMs = opts.skewMs != null ? opts.skewMs : CLOCK_SKEW_MS;
+
+  if (!Array.isArray(rawEntries) || rawEntries.length === 0) return null;
+
+  const limit = nowMs + skewMs;
+  const filtered = rawEntries.filter((e) => e && Number.isFinite(e.ts) && e.ts <= limit);
+  if (filtered.length === 0) return null;
+
+  filtered.sort((a, b) => a.ts - b.ts);
+
+  const seen = new Set();
+  const deduped = [];
+  for (const e of filtered) {
+    if (e.dedupKey) {
+      if (seen.has(e.dedupKey)) continue;
+      seen.add(e.dedupKey);
+    }
+    deduped.push(e);
+  }
+
+  const blocks = buildBlocks(deduped, sessionMs);
+  if (blocks.length === 0) return null;
+
+  const maxBlockTokens = blocks.reduce((m, b) => Math.max(m, b.tokens), 0);
+
+  // 直近のブロックがアクティブか判定（開始 5h 以内かつ最終活動から 5h 以内）。
+  const last = blocks[blocks.length - 1];
+  const isActive = nowMs < last.endMs && nowMs - last.lastEntryMs < sessionMs;
+  if (!isActive) return null;
+
+  const utilization = maxBlockTokens > 0 ? last.tokens / maxBlockTokens : null;
+
+  return {
+    source: 'transcript',
+    utilization,
+    totalTokens: last.tokens,
+    blockStartMs: last.startMs,
+    resetAtMs: last.endMs,
+    remainingMs: Math.max(0, last.endMs - nowMs),
+    lastEntryMs: last.lastEntryMs,
+    maxBlockTokens,
+    isActive: true,
+  };
+}
+
+// ─── 表示整形（純粋・tz 依存部は Date のローカル表現） ─────────────────────────
+
+/** トークン数を "12.3M" / "820k" / "500" 形式に整形する。 */
+function formatTokens(n) {
+  if (!Number.isFinite(n) || n < 0) n = 0;
+  if (n >= 1e6) {
+    const s = (n / 1e6).toFixed(1).replace(/\.0$/, '');
+    return `${s}M`;
+  }
+  if (n >= 1e3) {
+    return `${Math.round(n / 1e3)}k`;
+  }
+  return String(Math.round(n));
+}
+
+/** 残り時間（ms）を "1h27m" / "27m" / "まもなく" 形式に整形する。 */
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return 'まもなく';
+  const totalMin = Math.floor(ms / 60000);
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  if (h > 0) return `${h}h${m}m`;
+  if (m > 0) return `${m}m`;
+  return 'まもなく';
+}
+
+/** 比率（0..1）を n マス（既定 5）の ▰▱ バーにする。 */
+function progressBar(ratio, total = 5) {
+  const r = Number.isFinite(ratio) ? Math.min(1, Math.max(0, ratio)) : 0;
+  const filled = Math.round(r * total);
+  return '▰'.repeat(filled) + '▱'.repeat(Math.max(0, total - filled));
+}
+
+/** ローカル時刻の HH:MM 文字列。 */
+function formatClock(ms) {
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+/**
+ * スナップショットを UI 表示用の文字列群に整形する（タイトルバー / モバイル共通）。
+ * @param {ReturnType<typeof summarize>} snapshot
+ * @param {number} nowMs
+ * @returns {null | object}
+ */
+function describeUsage(snapshot, nowMs) {
+  if (!snapshot) return null;
+  const remainingMs = Math.max(0, snapshot.resetAtMs - nowMs);
+  const tokensText = formatTokens(snapshot.totalTokens);
+  const resetText = formatClock(snapshot.resetAtMs);
+  const remainingText = formatDuration(remainingMs);
+  const hasUtil = typeof snapshot.utilization === 'number' && Number.isFinite(snapshot.utilization);
+  const percent = hasUtil ? Math.round(snapshot.utilization * 100) : null;
+  const percentText = percent != null ? `${percent}%` : null;
+  const bar = progressBar(hasUtil ? snapshot.utilization : 0);
+
+  const titleText = percentText
+    ? `⚡ ${tokensText} tok · リセット ${resetText} · 目安${percentText}`
+    : `⚡ ${tokensText} tok · リセット ${resetText}`;
+  const mobileText = `5hブロック: ${tokensText} tok · リセット ${resetText}（残り${remainingText}）`;
+  const barText = percentText ? `過去最大比${percentText}` : '過去最大比—';
+
+  return {
+    source: snapshot.source,
+    isActive: snapshot.isActive,
+    utilization: snapshot.utilization,
+    totalTokens: snapshot.totalTokens,
+    resetAtMs: snapshot.resetAtMs,
+    remainingMs,
+    tokensText,
+    resetText,
+    remainingText,
+    percentText,
+    barRatio: hasUtil ? snapshot.utilization : 0,
+    bar,
+    titleText,
+    mobileText,
+    barText,
+  };
+}
+
+// ─── fs / IO 層（stale-while-revalidate キャッシュ付き） ──────────────────────
+
+/** 既定の Claude projects ディレクトリ。 */
+function defaultProjectsDirs() {
+  return [path.join(os.homedir(), '.claude', 'projects')];
+}
+
+/**
+ * dirs 配下（1〜数階層）の *.jsonl のうち、mtime が now-windowMs 以降のものを列挙する。
+ * @returns {Promise<Array<{path:string,size:number,mtimeMs:number}>>}
+ */
+async function listRecentFiles(dirs, nowMs, windowMs) {
+  const threshold = nowMs - windowMs;
+  const results = [];
+
+  async function walk(dir, depth) {
+    if (depth > 4) return; // 想定外に深い階層は打ち切り（projects/<encoded>/<uuid>.jsonl 相当）
+    let entries;
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch (_e) {
+      return; // dir 欠落・権限無し等は無視
+    }
+    for (const ent of entries) {
+      const full = path.join(dir, ent.name);
+      if (ent.isDirectory()) {
+        await walk(full, depth + 1);
+      } else if (ent.isFile() && ent.name.endsWith('.jsonl')) {
+        try {
+          const st = await fsp.stat(full);
+          if (st.mtimeMs >= threshold) {
+            results.push({ path: full, size: st.size, mtimeMs: st.mtimeMs });
+          }
+        } catch (_e) {
+          // stat 失敗は無視
+        }
+      }
+    }
+  }
+
+  for (const dir of dirs) {
+    await walk(dir, 0);
+  }
+  return results;
+}
+
+/**
+ * ファイルの [start, end) バイトを読み、最後の改行までの完全な行だけを返す。
+ * 書き込み途中の末尾（改行未満）は捨て、consumed に「確定した末尾オフセット」を返す。
+ * @returns {Promise<{text:string, consumed:number}>}
+ */
+async function readSliceComplete(filePath, start, end) {
+  const len = end - start;
+  if (len <= 0) return { text: '', consumed: start };
+  const fh = await fsp.open(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(len);
+    const { bytesRead } = await fh.read(buf, 0, len, start);
+    const chunk = buf.subarray(0, bytesRead);
+    const lastNl = chunk.lastIndexOf(0x0a); // '\n'
+    if (lastNl === -1) {
+      return { text: '', consumed: start }; // 完全な行がまだ無い
+    }
+    const consumedBytes = lastNl + 1;
+    return { text: chunk.subarray(0, consumedBytes).toString('utf8'), consumed: start + consumedBytes };
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * usageTracker のインスタンス。差分読みキャッシュとスナップショットを内包する。
+ * main プロセスから 1 個だけ生成して使う。
+ */
+function createUsageTracker(options = {}) {
+  const getDirs = typeof options.getDirs === 'function'
+    ? options.getDirs
+    : () => (Array.isArray(options.dirs) && options.dirs.length ? options.dirs : defaultProjectsDirs());
+  const sessionMs = options.sessionMs || SESSION_DURATION_MS;
+  const skewMs = options.skewMs != null ? options.skewMs : CLOCK_SKEW_MS;
+  const windowMs = options.windowMs || RECENT_WINDOW_MS;
+  const staleMs = options.staleMs != null ? options.staleMs : SWR_STALE_MS;
+
+  // path -> { offset: number, entries: Array }
+  const fileCache = new Map();
+  let lastSnapshot = null;
+  let lastSnapshotAt = 0;
+  let refreshing = null; // 進行中の refresh Promise（多重起動防止）
+
+  async function refresh() {
+    const now = Date.now();
+    let dirs;
+    try {
+      dirs = getDirs();
+    } catch (_e) {
+      dirs = defaultProjectsDirs();
+    }
+    if (!Array.isArray(dirs) || dirs.length === 0) dirs = defaultProjectsDirs();
+
+    const files = await listRecentFiles(dirs, now, windowMs);
+    const alive = new Set();
+    const allEntries = [];
+
+    for (const f of files) {
+      alive.add(f.path);
+      let cached = fileCache.get(f.path);
+      if (!cached || cached.offset > f.size) {
+        // 未読 or ローテーション/切り詰め → 先頭から読み直す
+        cached = { offset: 0, entries: [] };
+        fileCache.set(f.path, cached);
+      }
+      if (f.size > cached.offset) {
+        try {
+          const { text, consumed } = await readSliceComplete(f.path, cached.offset, f.size);
+          if (text) {
+            const newEntries = parseJsonl(text);
+            if (newEntries.length) cached.entries = cached.entries.concat(newEntries);
+          }
+          cached.offset = consumed;
+        } catch (_e) {
+          // 読み取り失敗はこのファイルをスキップ（次回再試行）
+        }
+      }
+      if (cached.entries.length) allEntries.push(...cached.entries);
+    }
+
+    // 窓から外れたファイルのキャッシュは破棄（メモリ肥大防止）
+    for (const key of fileCache.keys()) {
+      if (!alive.has(key)) fileCache.delete(key);
+    }
+
+    lastSnapshot = summarize(allEntries, now, { sessionMs, skewMs });
+    lastSnapshotAt = now;
+    return lastSnapshot;
+  }
+
+  function scheduleRefresh() {
+    if (refreshing) return refreshing;
+    refreshing = refresh()
+      .catch((_e) => { /* 失敗は無視（lastSnapshot は据え置き） */ })
+      .finally(() => { refreshing = null; });
+    return refreshing;
+  }
+
+  /**
+   * 現在のスナップショットを返す（stale-while-revalidate）。
+   * 十分に新しければ即返し、古ければバックグラウンドで再計算しつつ直近値を返す。
+   */
+  function getSnapshot() {
+    const now = Date.now();
+    if (lastSnapshot !== null && now - lastSnapshotAt < staleMs) {
+      return lastSnapshot;
+    }
+    scheduleRefresh();
+    return lastSnapshot; // 初回は null（warmup で埋める）
+  }
+
+  /** 起動時などに 1 度だけ同期的に温めるための await 可能な初期化。 */
+  async function warmup() {
+    try {
+      await refresh();
+    } catch (_e) {
+      // warmup 失敗は無視
+    }
+    return lastSnapshot;
+  }
+
+  /** 表示用に整形したスナップショットを返す。無ければ null。 */
+  function getDescribed() {
+    return describeUsage(getSnapshot(), Date.now());
+  }
+
+  return { getSnapshot, getDescribed, warmup, refresh, scheduleRefresh };
+}
+
+module.exports = {
+  // 純粋関数コア（テスト対象）
+  tokensFromUsage,
+  parseRecord,
+  parseJsonl,
+  floorToHourUtc,
+  buildBlocks,
+  summarize,
+  // 整形
+  formatTokens,
+  formatDuration,
+  progressBar,
+  describeUsage,
+  // fs 層
+  createUsageTracker,
+  listRecentFiles,
+  defaultProjectsDirs,
+  // 定数
+  SESSION_DURATION_MS,
+  RECENT_WINDOW_MS,
+  CLOCK_SKEW_MS,
+};

--- a/usageTracker.js
+++ b/usageTracker.js
@@ -26,6 +26,11 @@ const SESSION_DURATION_MS = 5 * HOUR_MS; // 5 時間ブロック
 const CLOCK_SKEW_MS = 5 * 60 * 1000;     // 未来方向の許容（これを超える未来 ts は除外）
 const RECENT_WINDOW_MS = 6 * HOUR_MS;    // mtime でファイルを絞る窓（ブロック 5h + 余裕 1h）
 const SWR_STALE_MS = 10 * 1000;          // これより新しいスナップショットはそのまま返す
+const MAX_READ_BYTES = 50 * 1024 * 1024; // 1 ファイル 1 回あたりの読取上限（巨大/破損 .jsonl 対策）
+
+// UI 表示ラベル（タイトルバー・モバイルで同一語に統一する。UX レビュー UX-1）。
+const PEAK_LABEL = 'ピーク比';
+const PEAK_NOTE = 'これまで最も使った5hブロックとの比';
 
 // ─── 純粋関数コア ────────────────────────────────────────────────────────────
 
@@ -37,7 +42,8 @@ const SWR_STALE_MS = 10 * 1000;          // これより新しいスナップシ
  */
 function tokensFromUsage(usage) {
   if (!usage || typeof usage !== 'object') return 0;
-  const n = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  // 破損した usage に負値が混じっても合計を過少にしないよう 0 でクランプする。
+  const n = (v) => (typeof v === 'number' && Number.isFinite(v) ? Math.max(0, v) : 0);
   return (
     n(usage.input_tokens) +
     n(usage.output_tokens) +
@@ -253,13 +259,19 @@ function describeUsage(snapshot, nowMs) {
   const hasUtil = typeof snapshot.utilization === 'number' && Number.isFinite(snapshot.utilization);
   const percent = hasUtil ? Math.round(snapshot.utilization * 100) : null;
   const percentText = percent != null ? `${percent}%` : null;
-  const bar = progressBar(hasUtil ? snapshot.utilization : 0);
+  const bar = hasUtil ? progressBar(snapshot.utilization) : null;
 
-  const titleText = percentText
-    ? `⚡ ${tokensText} tok · リセット ${resetText} · 目安${percentText}`
+  // 「ピーク比」ラベルは PEAK_LABEL に一元化し、タイトルバー・モバイル・バーで同一語にする（UX-1）。
+  // タイトルバーは重要度順（トークン量 → ピーク比 → リセット時刻）。狭幅では末尾（リセット）から
+  // 欠けるので、割合を時刻より前に置く（UX-2）。
+  const peakText = percentText ? `${PEAK_LABEL}${percentText}` : null;
+  const titleText = peakText
+    ? `⚡ ${tokensText} tok · ${peakText} · リセット ${resetText}`
     : `⚡ ${tokensText} tok · リセット ${resetText}`;
-  const mobileText = `5hブロック: ${tokensText} tok · リセット ${resetText}（残り${remainingText}）`;
-  const barText = percentText ? `過去最大比${percentText}` : '過去最大比—';
+  // モバイルは字数に余裕があるので「トークン」と明示する（任意対応）。
+  const mobileText = `5hブロック: ${tokensText} トークン · リセット ${resetText}（残り${remainingText}）`;
+  // バー行のラベル。utilization 無しのときは null（モバイル側で行ごと出さない）。
+  const barText = peakText;
 
   return {
     source: snapshot.source,
@@ -277,6 +289,8 @@ function describeUsage(snapshot, nowMs) {
     titleText,
     mobileText,
     barText,
+    peakLabel: PEAK_LABEL,
+    peakNote: PEAK_NOTE,
   };
 }
 
@@ -327,24 +341,38 @@ async function listRecentFiles(dirs, nowMs, windowMs) {
 }
 
 /**
+ * 読み取り開始位置を「1 回あたり maxBytes まで」にクランプする（純粋・SEC-1）。
+ * [start, end) が maxBytes を超える場合は末尾 maxBytes だけを読むよう start を前進させる。
+ * こうすることで巨大/破損 .jsonl でも Buffer 確保量が maxBytes を超えず、かつ現在ブロックに
+ * 効く最新行（末尾）を優先して取り込める。先頭が行途中になった分は JSON.parse 失敗で捨てられる。
+ * @returns {number} 実際に読み始めるバイトオフセット
+ */
+function clampReadStart(start, end, maxBytes = MAX_READ_BYTES) {
+  if (end - start > maxBytes) return end - maxBytes;
+  return start;
+}
+
+/**
  * ファイルの [start, end) バイトを読み、最後の改行までの完全な行だけを返す。
  * 書き込み途中の末尾（改行未満）は捨て、consumed に「確定した末尾オフセット」を返す。
+ * 1 回の読取は maxBytes までにクランプする（clampReadStart 参照）。
  * @returns {Promise<{text:string, consumed:number}>}
  */
-async function readSliceComplete(filePath, start, end) {
-  const len = end - start;
-  if (len <= 0) return { text: '', consumed: start };
+async function readSliceComplete(filePath, start, end, maxBytes = MAX_READ_BYTES) {
+  const effStart = clampReadStart(start, end, maxBytes);
+  const len = end - effStart;
+  if (len <= 0) return { text: '', consumed: end };
   const fh = await fsp.open(filePath, 'r');
   try {
     const buf = Buffer.alloc(len);
-    const { bytesRead } = await fh.read(buf, 0, len, start);
+    const { bytesRead } = await fh.read(buf, 0, len, effStart);
     const chunk = buf.subarray(0, bytesRead);
     const lastNl = chunk.lastIndexOf(0x0a); // '\n'
     if (lastNl === -1) {
-      return { text: '', consumed: start }; // 完全な行がまだ無い
+      return { text: '', consumed: effStart }; // 完全な行がまだ無い（読み始め位置は確定）
     }
     const consumedBytes = lastNl + 1;
-    return { text: chunk.subarray(0, consumedBytes).toString('utf8'), consumed: start + consumedBytes };
+    return { text: chunk.subarray(0, consumedBytes).toString('utf8'), consumed: effStart + consumedBytes };
   } finally {
     await fh.close();
   }
@@ -471,9 +499,14 @@ module.exports = {
   // fs 層
   createUsageTracker,
   listRecentFiles,
+  readSliceComplete,
+  clampReadStart,
   defaultProjectsDirs,
   // 定数
   SESSION_DURATION_MS,
   RECENT_WINDOW_MS,
   CLOCK_SKEW_MS,
+  MAX_READ_BYTES,
+  PEAK_LABEL,
+  PEAK_NOTE,
 };

--- a/usageTracker.js
+++ b/usageTracker.js
@@ -294,6 +294,28 @@ function describeUsage(snapshot, nowMs) {
   };
 }
 
+// ─── 短TTLメモ化（純粋・clock 注入可）────────────────────────────────────────
+/**
+ * loader() の結果を ttlMs だけメモ化する小さなラッパ（CR-1）。
+ * ホットパス（GET /api/states の ~2s ポーリング）で同期 I/O を繰り返さないために使う。
+ * clock を注入できるのでテストで時刻を固定できる。
+ * @param {() => any} loader 実際に値を読む関数（例: loadUserConfig）
+ * @param {number} ttlMs メモの有効期間（ms）
+ * @param {() => number} [clock] 現在時刻を返す関数（既定 Date.now）
+ * @returns {() => any} メモ化された取得関数
+ */
+function createTtlMemo(loader, ttlMs, clock = Date.now) {
+  let value;
+  let at = -Infinity;
+  return () => {
+    const now = clock();
+    if (now - at < ttlMs) return value;
+    value = loader();
+    at = now;
+    return value;
+  };
+}
+
 // ─── fs / IO 層（stale-while-revalidate キャッシュ付き） ──────────────────────
 
 /** 既定の Claude projects ディレクトリ。 */
@@ -496,6 +518,8 @@ module.exports = {
   formatDuration,
   progressBar,
   describeUsage,
+  // ユーティリティ
+  createTtlMemo,
   // fs 層
   createUsageTracker,
   listRecentFiles,


### PR DESCRIPTION
## 概要

Claude サブスクリプションの 5 時間レートリミットブロックの消費状況を、アプリのタイトルバーとモバイルステータスページ（`GET /` @ port 13847）に表示できるようにします。

close #69

## 表示イメージ

```
タイトルバー:  ⚡ 12.3M tok · ピーク比43% · リセット 14:05
モバイル:      5hブロック: 12.3M トークン · リセット 14:05（残り1h27m）
               ▰▰▱▱▱ ピーク比43%
               これまで最も使った5hブロックとの比
```

## 実装内容

- **新規モジュール `usageTracker.js`**（メインプロセス）: `~/.claude/projects/**/*.jsonl` の `message.usage` を集計（ccusage 方式）。純粋関数コア（5h ブロック算出・`message.id + requestId` による dedup・集計・整形）と fs 層（mtime 6h 窓での絞り込み・byte offset 差分読み・stale-while-revalidate キャッシュ）を分離。認証情報には触れず、外部依存の追加なし。
- **API**: `GET /api/states` のレスポンスに `usage` オブジェクトを additive に追加（モバイルページの既存ポーリングに相乗り。新エンドポイントは作らない）。
- **UI**: タイトルバーに使用量インジケータ（IPC `usage:get` を 15 秒ポーリング）／モバイルページ先頭に使用量カード。表示は全て `textContent` で描画。
- **設定**: `showUsage`（既定 ON, opt-out）。あわせて「未設定 boolean が保存時に false になる」既知の問題を descriptor の `default` 尊重で同時修正。
- **将来拡張**: スナップショットに `source` / `utilization` フィールドを持たせ、将来 OAuth usage API へ差し替え可能な構造に。

### レビュー指摘への対応

- **UX**: 指標ラベルを「ピーク比」に統一（タイトルバー・モバイル・バーで同一語）＋モバイルにのみ意味の補足を追加／タイトルバーを重要度順に並べ替え、title 依存を廃止（狭幅では末尾から欠ける）／タイトルバーを 3 レーン grid 化し狭幅での重なりを回避。
- **セキュリティ堅牢化**: 1 ファイル 1 回あたりの読取上限（50MB）を追加／`tokensFromUsage` で負値を 0 にクランプ。

### エッジケース対応

- トランスクリプト無し / dir 欠落 → 非表示・クラッシュしない（usage 取得失敗はアプリ本体に波及させない）
- 巨大 JSONL → mtime 窓＋差分読み＋読取上限でフルパースを抑制
- ブロック境界跨ぎ → 毎リフレッシュで now から再導出
- clock skew → 未来（now+5分超）のタイムスタンプを除外
- 複数アカウント → config `claudeProjectsDirs` で複数 dir 指定可

## テスト（確認手順）

### 自動テスト（ユニット）

1. リポジトリルートで `npm test` を実行する
   → `usageTracker.js` の純粋関数（集計・ブロック算出・dedup・整形・読取クランプ）のテストを含め **35 件すべて pass** する

### 手動確認（タイトルバー）

1. Claude Code を数回使ってトランスクリプト（`~/.claude/projects/**/*.jsonl`）に `message.usage` が記録されている状態にする
2. `npm start` でアプリを起動する
   → タイトルバー左端に `⚡ <トークン量> tok · ピーク比<％> · リセット <時刻>` が表示される
3. ウィンドウ幅を狭める
   → 使用量表示は中央のアプリ名（VK Terminals）と重ならず、幅が足りなければ末尾（リセット時刻）から省略記号で欠ける
4. 設定パネルで「トークン使用量を表示」を OFF にして保存 → 再起動
   → タイトルバーの使用量インジケータが表示されない
5. 何も設定を触らずに設定を保存
   → 「トークン使用量を表示」が OFF に固定されない（既定 ON が維持される）

### 手動確認（モバイルページ）

1. アプリ起動中に、同一 LAN 等から `http://<ホスト>:13847/` を開く
   → ページ先頭に使用量カード（`5hブロック: … トークン · リセット …（残り…）` と `▰▱` バー＋`ピーク比%`＋補足文）が表示される
2. トランスクリプトが無い（or 直近 5h に活動が無い）状態で開く
   → 使用量カードは表示されない（アプリ本体・端末一覧は正常）

### デグレ確認

- `GET /api/states` のレスポンスに `usage` が **追加** されているだけで、既存の `updatedAt` / `terminals` は従来どおり返る
- ターミナル（ペイン）機能・設定パネルの既存動作に変化がない

> **スクリーンショットについて**: 本 PR は Electron タイトルバー／モバイルページの表示変更を含みますが、実データ（Claude 使用量）を伴う起動が必要なため自動環境でのキャプチャを省略しています。上記手順で Before/After（設定 ON/OFF・狭幅時の省略）を確認できます。必要であればレビュー時にキャプチャを追加します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * タイトルバーに、トークン使用量のステータス表示を追加しました。
  * モバイル画面に、使用量カードと進捗バーを追加しました。
  * 起動時に最新の使用状況を読み込み、表示をすばやく更新できるようになりました。

* **不具合修正**
  * 使用状況の表示設定で、未入力時に既定値が正しく反映されるよう改善しました。
  * 表示データがない場合は、使用量インジケータやカードを自動で非表示にするようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->