### PR TITLE
[ 機能追加 ] GPU 起動モード選択と Windows / WSLg での起動対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- [ 機能追加 ] 環境変数 `VK_TERMINALS_GPU` で GUI の GPU 起動モード（`off` / `hardware` / `default`）を選択可能に。`hardware` は WSLg の d3d12 ドライバ経由で HW OpenGL を使う（GPU サンドボックス無効化・ブロックリスト無視を伴う）
+- [ 機能追加 ] 環境変数 `VK_TERMINALS_GPU` または `config.json` の `gpu` で GUI の GPU 起動モード（`off` / `hardware` / `default`）を選択可能に。`hardware` は WSLg の d3d12 ドライバ経由で HW OpenGL を使う（GPU サンドボックス無効化・ブロックリスト無視を伴う）
 - [ 機能追加 ] 設定パネルのフィールドに選択式（`select`）型を追加し、許可された値のみ選べる制約付きピッカーに対応
 - [ 不具合修正 ] macOS 以外（WSLg 等）で Chromium の GPU 初期化失敗により起動時に `Exiting GPU process` / `kTransientFailure` 等のエラーログが大量に出る不具合を修正（既定で GPU を無効化して抑制）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [ 機能追加 ] GUI の GPU 起動モード（`off` / `default`）を環境変数 `VK_TERMINALS_GPU`・`config.json` の `gpu`・設定パネルのいずれからも選択可能に（既定は非 macOS で `off`＝エラー抑制）
 - [ 機能追加 ] 設定パネルのフィールドに選択式（`select`）型を追加し、許可された値のみ選べる制約付きピッカーに対応
 - [ 不具合修正 ] macOS 以外（WSLg 等）で Chromium の GPU 初期化失敗により起動時に `Exiting GPU process` / `kTransientFailure` 等のエラーログが大量に出る不具合を修正（既定で GPU を無効化して抑制）
+- [ 機能追加 ] Windows でのデフォルトシェル（`/bin/zsh` 固定）フォールバックに対応し、Windows / WSLg 環境向けのセットアップ手順を README に追記
 
 ## 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- [ 機能追加 ] 環境変数 `VK_TERMINALS_GPU` で GUI の GPU 起動モード（`off` / `hardware` / `default`）を選択可能に。`hardware` は WSLg の d3d12 ドライバ経由で HW OpenGL を使う（GPU サンドボックス無効化・ブロックリスト無視を伴う）
+- [ 機能追加 ] 設定パネルのフィールドに選択式（`select`）型を追加し、許可された値のみ選べる制約付きピッカーに対応
+- [ 不具合修正 ] macOS 以外（WSLg 等）で Chromium の GPU 初期化失敗により起動時に `Exiting GPU process` / `kTransientFailure` 等のエラーログが大量に出る不具合を修正（既定で GPU を無効化して抑制）
+
 ## 1.7.0
 
 - [ 機能追加 ] Claude の利用状況（セッション%・週間制限%・リセット時刻）を公式 usage API から取得し、設定モーダルの「Claude使用状況」タブに表示。取得不可時は従来のトランスクリプト集計表示へ自動フォールバック（[#73](https://github.com/vektor-inc/vk-terminals/issues/73)）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- [ 機能追加 ] 環境変数 `VK_TERMINALS_GPU` または `config.json` の `gpu` で GUI の GPU 起動モード（`off` / `hardware` / `default`）を選択可能に。`hardware` は WSLg の d3d12 ドライバ経由で HW OpenGL を使う（GPU サンドボックス無効化・ブロックリスト無視を伴う）
+- [ 機能追加 ] GUI の GPU 起動モード（`off` / `hardware` / `default`）を環境変数 `VK_TERMINALS_GPU`・`config.json` の `gpu`・設定パネルのいずれからも選択可能に。`hardware` は WSLg の d3d12 ドライバ経由で HW OpenGL を使う（GPU サンドボックス無効化・ブロックリスト無視を伴う）
 - [ 機能追加 ] 設定パネルのフィールドに選択式（`select`）型を追加し、許可された値のみ選べる制約付きピッカーに対応
 - [ 不具合修正 ] macOS 以外（WSLg 等）で Chromium の GPU 初期化失敗により起動時に `Exiting GPU process` / `kTransientFailure` 等のエラーログが大量に出る不具合を修正（既定で GPU を無効化して抑制）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- [ 機能追加 ] GUI の GPU 起動モード（`off` / `hardware` / `default`）を環境変数 `VK_TERMINALS_GPU`・`config.json` の `gpu`・設定パネルのいずれからも選択可能に。`hardware` は WSLg の d3d12 ドライバ経由で HW OpenGL を使う（GPU サンドボックス無効化・ブロックリスト無視を伴う）
+- [ 機能追加 ] GUI の GPU 起動モード（`off` / `default`）を環境変数 `VK_TERMINALS_GPU`・`config.json` の `gpu`・設定パネルのいずれからも選択可能に（既定は非 macOS で `off`＝エラー抑制）
 - [ 機能追加 ] 設定パネルのフィールドに選択式（`select`）型を追加し、許可された値のみ選べる制約付きピッカーに対応
 - [ 不具合修正 ] macOS 以外（WSLg 等）で Chromium の GPU 初期化失敗により起動時に `Exiting GPU process` / `kTransientFailure` 等のエラーログが大量に出る不具合を修正（既定で GPU を無効化して抑制）
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ VK_TERMINALS_GPU=hardware npm start
 { "gpu": "hardware" }
 ```
 
-モードの優先順位は **環境変数 `VK_TERMINALS_GPU` > `config.json` の `gpu` > プラットフォーム既定** です（環境変数がその場の上書きとして config を上回ります）。
+設定パネル（歯車 → 「設定」タブ → 「GPU 起動モード」）からも選択できます（保存後の再起動で反映）。
+
+モードの優先順位は **環境変数 `VK_TERMINALS_GPU` > `config.json` の `gpu`（＝設定パネル） > プラットフォーム既定** です（環境変数がその場の上書きとして config を上回ります）。
 
 > `electron . --disable-gpu` のように GPU 関連スイッチを直接指定して起動した場合は、そちらを尊重して `VK_TERMINALS_GPU` / `config.json` の自動適用は行いません（呼び出し側の指定を優先。VK Orchestrator 経由の起動もこの経路）。
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ electron . --no-claude
 
 HTTP API（`POST /api/new-pane`）でも `noClaude: true` を指定可能です（後述）。
 
+### GPU 起動モード（`VK_TERMINALS_GPU`）
+
+VK Terminals は Electron アプリのため、macOS 以外（WSLg などの Linux）では Chromium の GPU 初期化が失敗し、起動時に `Exiting GPU process` / `kTransientFailure` などのエラーログが大量に出ます（利用可能な Vulkan ICD がソフトウェア実装のみで SwiftShader へフォールバックするため）。環境変数 `VK_TERMINALS_GPU` で挙動を選べます。
+
+| 値 | 挙動 |
+|---|---|
+| 未設定（自動） | macOS は通常起動、それ以外は `off` 相当 |
+| `off` | GPU を無効化してエラーログを抑制（描画はソフトウェア。ターミナル用途で実害なし） |
+| `hardware` | HW OpenGL を使う（WSLg では Mesa の d3d12 ドライバ経由で Windows 側 GPU に届く）。⚠ `/dev/dxg` アクセスのため **GPU サンドボックスを無効化**し **GPU ブロックリストを無視**するため保護が下がる。Vulkan は HW ICD が無いため対象外 |
+| `default` | フラグを足さず Chromium 任せ（元の挙動） |
+
+```bash
+VK_TERMINALS_GPU=hardware npm start
+```
+
+> `electron . --disable-gpu` のように GPU 関連スイッチを直接指定して起動した場合は、そちらを尊重して `VK_TERMINALS_GPU` の自動適用は行いません（呼び出し側の指定を優先。VK Orchestrator 経由の起動もこの経路）。
+
 ## 使い方
 
 ### ペインの追加・並べ替え

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ VK Terminals は Electron アプリのため、macOS 以外（WSLg などの Lin
 |---|---|
 | 未設定（自動） | macOS は通常起動、それ以外は `off` 相当 |
 | `off` | GPU を無効化してエラーログを抑制（描画はソフトウェア。ターミナル用途で実害なし） |
-| `hardware` | HW OpenGL を使う（WSLg では Mesa の d3d12 ドライバ経由で Windows 側 GPU に届く）。⚠ `/dev/dxg` アクセスのため **GPU サンドボックスを無効化**し **GPU ブロックリストを無視**するため保護が下がる。Vulkan は HW ICD が無いため対象外。あわせて未対応の Vulkan / WebGPU 探索を無効化し WSLg の警告（asahi ICD / Dawn robustness）を抑制 |
+| `hardware` | HW OpenGL を使う（WSLg では Mesa の d3d12 ドライバ経由で Windows 側 GPU に届く）。⚠ `/dev/dxg` アクセスのため **GPU サンドボックスを無効化**し **GPU ブロックリストを無視**するため保護が下がる。Vulkan は HW ICD が無いため対象外 |
 | `default` | フラグを足さず Chromium 任せ（元の挙動） |
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ npm start
 
 Windows では各ペインのデフォルトシェルとして `%COMSPEC%`（通常 `cmd.exe`）または `powershell.exe` が、デフォルト作業ディレクトリとして `%USERPROFILE%` が使われます（`SHELL` / `HOME` 環境変数が設定されていればそちらを優先）。
 
+### 5. パス指定の注意点
+
+- `config.json` の `additionalPanes[].cwd` に Windows パスを書く場合、JSON 文字列内の `\` はエスケープが必要です（例: `"C:\\Users\\you\\project"`）。エスケープ不要な `/` 区切り（例: `"C:/Users/you/project"`）でも Node.js 上では問題なく解決されます。
+- ユーザー名やインストール先にスペースを含むパス（例: `C:\Users\First Last\...`）は、コマンドラインから直接実行するツールやシムスクリプトで引用符の扱いが原因で正しく解決されないことがあります（実例: Volta の `.cmd` シムがスペース入りパスで壊れるケース）。PATH に追加するディレクトリや実行ファイルのパスにスペースが含まれる場合は注意してください。
+- ユーザー設定ファイルの探索先 `~/.vk-terminals/config.json` は、Windows では `os.homedir()`（`%USERPROFILE%`）配下、つまり `%USERPROFILE%\.vk-terminals\config.json` に読み替えられます。
+
 ## 使い方
 
 ### ペインの追加・並べ替え

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Windows では各ペインのデフォルトシェルとして `%COMSPEC%`（通
 - `config.json` の `additionalPanes[].cwd` に Windows パスを書く場合、JSON 文字列内の `\` はエスケープが必要です（例: `"C:\\Users\\you\\project"`）。エスケープ不要な `/` 区切り（例: `"C:/Users/you/project"`）でも Node.js 上では問題なく解決されます。
 - ユーザー名やインストール先にスペースを含むパス（例: `C:\Users\First Last\...`）は、コマンドラインから直接実行するツールやシムスクリプトで引用符の扱いが原因で正しく解決されないことがあります（実例: Volta の `.cmd` シムがスペース入りパスで壊れるケース）。PATH に追加するディレクトリや実行ファイルのパスにスペースが含まれる場合は注意してください。
 - ユーザー設定ファイルの探索先 `~/.vk-terminals/config.json` は、Windows では `os.homedir()`（`%USERPROFILE%`）配下、つまり `%USERPROFILE%\.vk-terminals\config.json` に読み替えられます。
+- `cwd`（`additionalPanes[].cwd` や HTTP API `/api/new-pane` の `cwd`）は必ず **Windows ネイティブ形式**（`C:\Users\you\project` または `C:/Users/you/project`）で指定してください。`node-pty` 内部で Node.js の `path.resolve()` を通すため、Git Bash / WSL 由来の POSIX 形式パス（`/c/Users/you/project` など）を渡すとドライブレターが正しく解決されず、意図しないディレクトリが開かれます。
+- リポジトリ自体は `C:\` 以外のドライブ（例: `D:\dev\vk-terminals`）に置いても問題なく動作します。ただし `C:\Program Files\...` のような管理者権限が必要なディレクトリや、OneDrive 同期対象フォルダ（既定の `ドキュメント` / `デスクトップ` が同期対象になっている場合あり）に置くと、`npm install` 時のネイティブビルド（`node-pty`）が権限エラーやファイルロックで失敗することがあります。`C:\dev\...` のような同期対象外の短いパスを推奨します。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,15 @@ VK Terminals は Electron アプリのため、macOS 以外（WSLg などの Lin
 VK_TERMINALS_GPU=hardware npm start
 ```
 
-> `electron . --disable-gpu` のように GPU 関連スイッチを直接指定して起動した場合は、そちらを尊重して `VK_TERMINALS_GPU` の自動適用は行いません（呼び出し側の指定を優先。VK Orchestrator 経由の起動もこの経路）。
+`config.json` の `gpu` キーでも同じ値を指定できます（永続設定向け）。
+
+```json
+{ "gpu": "hardware" }
+```
+
+モードの優先順位は **環境変数 `VK_TERMINALS_GPU` > `config.json` の `gpu` > プラットフォーム既定** です（環境変数がその場の上書きとして config を上回ります）。
+
+> `electron . --disable-gpu` のように GPU 関連スイッチを直接指定して起動した場合は、そちらを尊重して `VK_TERMINALS_GPU` / `config.json` の自動適用は行いません（呼び出し側の指定を優先。VK Orchestrator 経由の起動もこの経路）。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Windows では各ペインのデフォルトシェルとして `%COMSPEC%`（通
 - ユーザー設定ファイルの探索先 `~/.vk-terminals/config.json` は、Windows では `os.homedir()`（`%USERPROFILE%`）配下、つまり `%USERPROFILE%\.vk-terminals\config.json` に読み替えられます。
 - `cwd`（`additionalPanes[].cwd` や HTTP API `/api/new-pane` の `cwd`）は必ず **Windows ネイティブ形式**（`C:\Users\you\project` または `C:/Users/you/project`）で指定してください。`node-pty` 内部で Node.js の `path.resolve()` を通すため、Git Bash / WSL 由来の POSIX 形式パス（`/c/Users/you/project` など）を渡すとドライブレターが正しく解決されず、意図しないディレクトリが開かれます。
 - リポジトリ自体は `C:\` 以外のドライブ（例: `D:\dev\vk-terminals`）に置いても問題なく動作します。ただし `C:\Program Files\...` のような管理者権限が必要なディレクトリや、OneDrive 同期対象フォルダ（既定の `ドキュメント` / `デスクトップ` が同期対象になっている場合あり）に置くと、`npm install` 時のネイティブビルド（`node-pty`）が権限エラーやファイルロックで失敗することがあります。`C:\dev\...` のような同期対象外の短いパスを推奨します。
+- リポジトリを配置するディレクトリ自体にスペースが含まれる場合（例: `C:\Users\Taro Yamada\Documents\vk-terminals`）、`node-pty` の `node-gyp` 経由のネイティブビルドがパス中のスペースが原因で失敗することがあります（`npm install` / `electron-rebuild` がビルドツールへの引数展開でパスを分割してしまうケース）。ビルドエラーが出た場合は、まずスペースを含まないパス（例: `C:\dev\vk-terminals`）に配置し直して切り分けてください。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ VK Terminals は Electron アプリのため、macOS 以外（WSLg などの Lin
 |---|---|
 | 未設定（自動） | macOS は通常起動、それ以外は `off` 相当 |
 | `off` | GPU を無効化してエラーログを抑制（描画はソフトウェア。ターミナル用途で実害なし） |
-| `hardware` | HW OpenGL を使う（WSLg では Mesa の d3d12 ドライバ経由で Windows 側 GPU に届く）。⚠ `/dev/dxg` アクセスのため **GPU サンドボックスを無効化**し **GPU ブロックリストを無視**するため保護が下がる。Vulkan は HW ICD が無いため対象外 |
+| `hardware` | HW OpenGL を使う（WSLg では Mesa の d3d12 ドライバ経由で Windows 側 GPU に届く）。⚠ `/dev/dxg` アクセスのため **GPU サンドボックスを無効化**し **GPU ブロックリストを無視**するため保護が下がる。Vulkan は HW ICD が無いため対象外。あわせて未対応の Vulkan / WebGPU 探索を無効化し WSLg の警告（asahi ICD / Dawn robustness）を抑制 |
 | `default` | フラグを足さず Chromium 任せ（元の挙動） |
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Windows では各ペインのデフォルトシェルとして `%COMSPEC%`（通
 - `cwd`（`additionalPanes[].cwd` や HTTP API `/api/new-pane` の `cwd`）は必ず **Windows ネイティブ形式**（`C:\Users\you\project` または `C:/Users/you/project`）で指定してください。`node-pty` 内部で Node.js の `path.resolve()` を通すため、Git Bash / WSL 由来の POSIX 形式パス（`/c/Users/you/project` など）を渡すとドライブレターが正しく解決されず、意図しないディレクトリが開かれます。
 - リポジトリ自体は `C:\` 以外のドライブ（例: `D:\dev\vk-terminals`）に置いても問題なく動作します。ただし `C:\Program Files\...` のような管理者権限が必要なディレクトリや、OneDrive 同期対象フォルダ（既定の `ドキュメント` / `デスクトップ` が同期対象になっている場合あり）に置くと、`npm install` 時のネイティブビルド（`node-pty`）が権限エラーやファイルロックで失敗することがあります。`C:\dev\...` のような同期対象外の短いパスを推奨します。
 - リポジトリを配置するディレクトリ自体にスペースが含まれる場合（例: `C:\Users\Taro Yamada\Documents\vk-terminals`）、`node-pty` の `node-gyp` 経由のネイティブビルドがパス中のスペースが原因で失敗することがあります（`npm install` / `electron-rebuild` がビルドツールへの引数展開でパスを分割してしまうケース）。ビルドエラーが出た場合は、まずスペースを含まないパス（例: `C:\dev\vk-terminals`）に配置し直して切り分けてください。
+- （セキュリティ向け補足）Windows は既定で、実行ファイル名の解決時に **カレントディレクトリを PATH より先に検索**します。vk-terminals の各ペインは `cwd` を作業ディレクトリとしてシェルを起動するため、信頼できないリポジトリ（`cwd` に指定したフォルダ）に `claude.exe` など正規コマンドと同名の実行ファイルが紛れ込んでいると、そちらが誤って実行される恐れがあります。気になる場合は環境変数 `NoDefaultCurrentDirectoryInExePath=1` を設定すると、カレントディレクトリ検索を無効化し PATH のみから解決されるようになります（`setx NoDefaultCurrentDirectoryInExePath 1` 等）。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## 必要環境
 
 - Node.js 18 以上
-- macOS（`node-pty` のビルドが必要）
+- macOS / Windows（`node-pty` のネイティブビルドが必要。Windows でのセットアップは[後述](#windows-での起動)）
 
 ## セットアップ
 
@@ -65,6 +65,48 @@ VK_TERMINALS_GPU=off npm start
 モードの優先順位は **環境変数 `VK_TERMINALS_GPU` > `config.json` の `gpu`（＝設定パネル） > プラットフォーム既定** です（環境変数がその場の上書きとして config を上回ります）。
 
 > `electron . --disable-gpu` のように GPU 関連スイッチを直接指定して起動した場合は、そちらを尊重して `VK_TERMINALS_GPU` / `config.json` の自動適用は行いません（呼び出し側の指定を優先。VK Orchestrator 経由の起動もこの経路）。
+
+## Windows での起動
+
+macOS 前提の部分があるため、まっさらな Windows 環境でセットアップする場合は以下を確認してください。
+
+### 1. 前提ツール
+
+- Node.js 18 以上（[Volta](https://volta.sh/) や [nvm-windows](https://github.com/coreybutler/nvm-windows) 経由でも可）
+- `node-pty` のネイティブビルドに必要な C++ ビルドツール
+  - [Visual Studio Build Tools](https://visualstudio.microsoft.com/ja/downloads/)（「C++ によるデスクトップ開発」ワークロード）
+  - もしくは `npm install -g windows-build-tools`（環境によっては非推奨）
+- `npm install` 後、ビルドが必要な場合は `npx electron-rebuild -f -w node-pty` を実行
+
+### 2. `claude` コマンドの用意
+
+起動時に各ペインで自動実行される `claude` コマンド（Claude Code CLI）が必要です。
+
+```powershell
+npm install -g @anthropic-ai/claude-code
+```
+
+インストール後に `claude` が見つからない場合は、PATH の反映漏れが原因のことが多いです。
+
+- **PowerShell / コマンドプロンプトを開き直しても `claude` が見つからない場合**：VSCode などのエディタ内蔵ターミナルから `npm install -g` した場合、そのプロセスツリーは起動時点の古い PATH を引き継いだままのことがあります。**VSCode やターミナルアプリ自体を再起動**すると解消します。
+- Volta 環境でユーザー名にスペースが含まれる場合、Volta が生成する `.cmd` シムが正しく動かないことがあります。その場合は `volta list all` で実体パッケージの格納先を確認し、`bin/claude.exe` を直接 PATH に追加してください。
+
+### 3. VSCode 統合ターミナルから `npm start` する場合の注意
+
+VSCode 自体が Electron 製アプリであるため、その内蔵ターミナルには `ELECTRON_RUN_AS_NODE=1` が環境変数として設定されています。この変数を継承したまま `npm start`（内部的に `electron .`）を実行すると、Electron がプレーンな Node.js として起動してしまい `TypeError: Cannot read properties of undefined (reading 'whenReady')` で失敗します。
+
+回避策：
+
+```powershell
+Remove-Item Env:\ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
+npm start
+```
+
+もしくは VSCode ではなく通常の PowerShell / コマンドプロンプトから起動してください。
+
+### 4. デフォルトシェル・作業ディレクトリ
+
+Windows では各ペインのデフォルトシェルとして `%COMSPEC%`（通常 `cmd.exe`）または `powershell.exe` が、デフォルト作業ディレクトリとして `%USERPROFILE%` が使われます（`SHELL` / `HOME` 環境変数が設定されていればそちらを優先）。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,44 @@ VK_TERMINALS_GPU=off npm start
 
 > `electron . --disable-gpu` のように GPU 関連スイッチを直接指定して起動した場合は、そちらを尊重して `VK_TERMINALS_GPU` / `config.json` の自動適用は行いません（呼び出し側の指定を優先。VK Orchestrator 経由の起動もこの経路）。
 
+## WSLg での起動
+
+Windows 上の WSL2（WSLg）でも動作します。GUI が Windows 側にそのまま表示されます。
+
+### 1. 前提パッケージ
+
+WSL 側（Ubuntu 等）に以下が必要です。
+
+```bash
+sudo apt update
+sudo apt install -y build-essential python3
+```
+
+`node-pty` はネイティブモジュールのため、`npm install` 時に自動でビルドされます（上記ビルドツールが前提）。
+
+### 2. `claude` コマンドの用意
+
+WSL 側のシェルに `claude`（Claude Code CLI）をインストールしてください。Windows 側にインストールしたものは共有されません。
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+### 3. 起動
+
+```bash
+npm start
+```
+
+既定（`VK_TERMINALS_GPU` 未設定）では GPU を無効化して起動するため、`Exiting GPU process` / `kTransientFailure` / `VK_ERROR_INCOMPATIBLE_DRIVER` などのエラーログは出ません（詳細は[GPU 起動モード](#gpu-起動モードvk_terminals_gpu)を参照）。
+
+起動後、ログに `[vk-terminals] API server listening on http://127.0.0.1:13847` が出ていれば正常です。以下で疎通確認できます。
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:13847/
+# => 200
+```
+
 ## Windows での起動
 
 macOS 前提の部分があるため、まっさらな Windows 環境でセットアップする場合は以下を確認してください。

--- a/README.md
+++ b/README.md
@@ -46,17 +46,18 @@ VK Terminals は Electron アプリのため、macOS 以外（WSLg などの Lin
 |---|---|
 | 未設定（自動） | macOS は通常起動、それ以外は `off` 相当 |
 | `off` | GPU を無効化してエラーログを抑制（描画はソフトウェア。ターミナル用途で実害なし） |
-| `hardware` | HW OpenGL を使う（WSLg では Mesa の d3d12 ドライバ経由で Windows 側 GPU に届く）。⚠ `/dev/dxg` アクセスのため **GPU サンドボックスを無効化**し **GPU ブロックリストを無視**するため保護が下がる。Vulkan は HW ICD が無いため対象外 |
-| `default` | フラグを足さず Chromium 任せ（元の挙動） |
+| `default` | フラグを足さず Chromium 任せ（元の挙動。macOS 以外では GPU 初期化エラーが出る場合あり） |
+
+> WSLg での HW アクセラ（HW OpenGL / Vulkan）は対応しません。Vulkan は HW ICD（dzn 等）が WSLg に無く、OpenGL も体感差が無いうえ Mesa/Dawn 由来の警告が出るためです。
 
 ```bash
-VK_TERMINALS_GPU=hardware npm start
+VK_TERMINALS_GPU=off npm start
 ```
 
 `config.json` の `gpu` キーでも同じ値を指定できます（永続設定向け）。
 
 ```json
-{ "gpu": "hardware" }
+{ "gpu": "off" }
 ```
 
 設定パネル（歯車 → 「設定」タブ → 「GPU 起動モード」）からも選択できます（保存後の再起動で反映）。

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
   "apiHost": "127.0.0.1",
   "initialCommand": "",
+  "gpu": "off",
   "agentroom": false,
   "additionalPanes": [
     { "cwd": "/absolute/path/to/another/project" },

--- a/main.js
+++ b/main.js
@@ -16,15 +16,12 @@ const { createUsageTracker, createTtlMemo } = require('./usageTracker');
 // のみ扱い、ここから先へは正規化済みの数値（%・リセット時刻・source 種別）だけを渡す。
 const { createOauthUsageProvider } = require('./oauthUsage');
 // GUI(Electron) の GPU 起動モード。WSLg 等の Linux では Chromium の GPU 初期化が
-// 失敗して起動時にエラーが多発するため、既定で GPU を無効化する。VK_TERMINALS_GPU で
-// off/hardware/default を選べる。呼び出し側（VK Orchestrator 等）が argv で GPU
-// スイッチを明示している場合は介入しない。詳細は utils/gpu.js を参照。
+// 失敗して起動時にエラーが多発するため、既定で GPU を無効化する。モードは
+// VK_TERMINALS_GPU（環境変数）または config.json の gpu で off/hardware/default を
+// 選べる（優先順位は env > config > プラットフォーム既定）。呼び出し側（VK Orchestrator
+// 等）が argv で GPU スイッチを明示している場合は介入しない。詳細は utils/gpu.js を参照。
 const { applyGpuMode } = require('./utils/gpu');
 const execFileAsync = promisify(execFile);
-
-// app が ready になる前に GPU スイッチを適用する（appendSwitch は ready 前に呼ぶ必要がある）。
-const appliedGpuMode = applyGpuMode(app);
-if (appliedGpuMode) console.log(`[vk-terminals] GPU mode: ${appliedGpuMode}`);
 
 let win;
 const ptys = new Map();
@@ -85,6 +82,11 @@ function loadUserConfig() {
 
   return {};
 }
+
+// app が ready になる前に GPU スイッチを適用する（appendSwitch は ready 前に呼ぶ必要がある）。
+// config.json の gpu も見るため loadUserConfig 定義後に実行する（env 未指定時に config を採用）。
+const appliedGpuMode = applyGpuMode(app, { configMode: loadUserConfig().gpu });
+if (appliedGpuMode) console.log(`${LOG_PREFIX} GPU mode: ${appliedGpuMode}`);
 
 // ─── トークン使用量（issue #69）────────────────────────────────────────────────
 // GET /api/states（モバイルページが ~2s ごとにポーリング）のホットパスで usage 判定の

--- a/main.js
+++ b/main.js
@@ -349,6 +349,14 @@ function builtinSettingsDescriptor() {
           // showUsage（issue #69）は opt-out（既定 ON）。default:true で「未設定 boolean が
           // 保存時に false になる」問題を避ける（settings:describe / settings:save が default 尊重）。
           { key: 'showUsage',      label: 'トークン使用量を表示',   type: 'boolean', default: true, help: 'Claude の利用状況（セッション% / 週間制限%）を設定モーダルの「Claude使用状況」タブ・モバイルページに表示します。' },
+          // GPU 起動モード（utils/gpu.js）。環境変数 VK_TERMINALS_GPU を優先し、未指定時にこの値を使う。
+          // 空（自動）はプラットフォーム既定（macOS=default / それ以外=off）。反映には再起動が必要（note に記載）。
+          { key: 'gpu', label: 'GPU 起動モード', type: 'select', emptyToNull: true, default: '', help: 'GUI(Electron) の GPU 初期化方法。WSLg 等ではエラー抑制のため既定で無効化されます。hardware は実験的（GPU サンドボックス無効化・ブロックリスト無視を伴う）。環境変数 VK_TERMINALS_GPU 指定時はそちらが優先されます。', options: [
+            { value: '',         label: '自動（プラットフォーム既定）' },
+            { value: 'off',      label: 'GPU 無効（エラー抑制・推奨）' },
+            { value: 'hardware', label: 'HW アクセラ（WSLg 実験的）' },
+            { value: 'default',  label: 'Chromium 任せ' },
+          ] },
           // issue #70 でエージェントルーム（β）を一旦無効化するため設定項目を非表示にする。
           // 復帰時は下記コメントを解除する。
           // { key: 'agentroom',      label: 'エージェントルーム（β）表示', type: 'boolean' },

--- a/main.js
+++ b/main.js
@@ -534,8 +534,8 @@ ipcMain.handle('settings:save', (event, incoming) => {
 
 ipcMain.handle('terminal:create', (event, cwd, options = {}) => {
   const id = String(nextId++);
-  const shell = process.env.SHELL || '/bin/zsh';
-  const resolvedCwd = cwd || process.env.HOME || '/tmp';
+  const shell = process.env.SHELL || (process.platform === 'win32' ? (process.env.COMSPEC || 'powershell.exe') : '/bin/zsh');
+  const resolvedCwd = cwd || process.env.HOME || process.env.USERPROFILE || os.tmpdir();
 
   // `options.noClaude` が明示指定されていればそれを優先、未指定なら CLI フラグの値を継承。
   // `noClaude` が true の場合、claude を自動起動せず素のシェルとして開く。

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ const { createUsageTracker, createTtlMemo } = require('./usageTracker');
 const { createOauthUsageProvider } = require('./oauthUsage');
 // GUI(Electron) の GPU 起動モード。WSLg 等の Linux では Chromium の GPU 初期化が
 // 失敗して起動時にエラーが多発するため、既定で GPU を無効化する。モードは
-// VK_TERMINALS_GPU（環境変数）または config.json の gpu で off/hardware/default を
+// VK_TERMINALS_GPU（環境変数）または config.json の gpu で off/default を
 // 選べる（優先順位は env > config > プラットフォーム既定）。呼び出し側（VK Orchestrator
 // 等）が argv で GPU スイッチを明示している場合は介入しない。詳細は utils/gpu.js を参照。
 const { applyGpuMode } = require('./utils/gpu');
@@ -351,10 +351,9 @@ function builtinSettingsDescriptor() {
           { key: 'showUsage',      label: 'トークン使用量を表示',   type: 'boolean', default: true, help: 'Claude の利用状況（セッション% / 週間制限%）を設定モーダルの「Claude使用状況」タブ・モバイルページに表示します。' },
           // GPU 起動モード（utils/gpu.js）。環境変数 VK_TERMINALS_GPU を優先し、未指定時にこの値を使う。
           // 空（自動）はプラットフォーム既定（macOS=default / それ以外=off）。反映には再起動が必要（note に記載）。
-          { key: 'gpu', label: 'GPU 起動モード', type: 'select', emptyToNull: true, default: '', help: 'GUI(Electron) の GPU 初期化方法。WSLg 等ではエラー抑制のため既定で無効化されます。hardware は実験的（GPU サンドボックス無効化・ブロックリスト無視を伴う）。環境変数 VK_TERMINALS_GPU 指定時はそちらが優先されます。', options: [
+          { key: 'gpu', label: 'GPU 起動モード', type: 'select', emptyToNull: true, default: '', help: 'GUI(Electron) の GPU 初期化方法。WSLg 等ではエラー抑制のため既定で無効化されます。環境変数 VK_TERMINALS_GPU 指定時はそちらが優先されます。', options: [
             { value: '',         label: '自動（プラットフォーム既定）' },
             { value: 'off',      label: 'GPU 無効（エラー抑制・推奨）' },
-            { value: 'hardware', label: 'HW アクセラ（WSLg 実験的）' },
             { value: 'default',  label: 'Chromium 任せ' },
           ] },
           // issue #70 でエージェントルーム（β）を一旦無効化するため設定項目を非表示にする。

--- a/main.js
+++ b/main.js
@@ -15,7 +15,16 @@ const { createUsageTracker, createTtlMemo } = require('./usageTracker');
 // 公式 usage API（issue #73）。OAuth トークンは oauthUsage モジュール（main プロセス）内で
 // のみ扱い、ここから先へは正規化済みの数値（%・リセット時刻・source 種別）だけを渡す。
 const { createOauthUsageProvider } = require('./oauthUsage');
+// GUI(Electron) の GPU 起動モード。WSLg 等の Linux では Chromium の GPU 初期化が
+// 失敗して起動時にエラーが多発するため、既定で GPU を無効化する。VK_TERMINALS_GPU で
+// off/hardware/default を選べる。呼び出し側（VK Orchestrator 等）が argv で GPU
+// スイッチを明示している場合は介入しない。詳細は utils/gpu.js を参照。
+const { applyGpuMode } = require('./utils/gpu');
 const execFileAsync = promisify(execFile);
+
+// app が ready になる前に GPU スイッチを適用する（appendSwitch は ready 前に呼ぶ必要がある）。
+const appliedGpuMode = applyGpuMode(app);
+if (appliedGpuMode) console.log(`[vk-terminals] GPU mode: ${appliedGpuMode}`);
 
 let win;
 const ptys = new Map();
@@ -486,6 +495,16 @@ ipcMain.handle('settings:save', (event, incoming) => {
         } catch (e) {
           return { ok: false, error: `${label}: JSON として不正です（${e.message}）` };
         }
+        break;
+      }
+      case 'select': {
+        // 許可された値以外は保存させない（GUI の制約に加えた保険。API 直叩き対策）。
+        const allowed = (Array.isArray(f.options) ? f.options : []).map((o) => String(o.value ?? ''));
+        const s = raw == null ? '' : String(raw);
+        if (allowed.length && !allowed.includes(s)) {
+          return { ok: false, error: `${label}: 不正な値です（${allowed.join(' / ')} のいずれか）` };
+        }
+        coerced = (s === '' && f.emptyToNull) ? null : s;
         break;
       }
       default: { // text / password

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1763,6 +1763,23 @@ function renderSettingsField(f, value, id) {
     </div>`;
   }
 
+  if (f.type === 'select') {
+    // 許可された値だけを選べる制約付きピッカー。f.options は {value,label} の配列。
+    const cur = value === null || value === undefined ? '' : String(value);
+    const opts = (Array.isArray(f.options) ? f.options : [])
+      .map((o) => {
+        const ov = escAttr(String(o.value ?? ''));
+        const ol = escText(String(o.label ?? o.value ?? ''));
+        const sel = String(o.value ?? '') === cur ? ' selected' : '';
+        return `<option value="${ov}"${sel}>${ol}</option>`;
+      })
+      .join('');
+    return `<div class="settings-row">
+      <label class="settings-label" for="${id}">${label}</label>${help}
+      <select id="${id}">${opts}</select>
+    </div>`;
+  }
+
   const inputType = f.type === 'number' ? 'number' : 'text';
   const ph = f.placeholder ? ` placeholder="${escAttr(f.placeholder)}"` : '';
   return `<div class="settings-row">

--- a/tests/gpu.test.js
+++ b/tests/gpu.test.js
@@ -1,0 +1,109 @@
+'use strict';
+// utils/gpu.js（GUI の GPU 起動モード）のテスト。
+// - モード解決（env / プラットフォーム既定 / 未知値フォールバック）
+// - モード→Chromium スイッチ・追加 env の写像
+// - argv に明示スイッチがある場合は介入しないこと（orchestrator との競合回避）
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  GPU_MODES,
+  defaultGpuMode,
+  resolveGpuMode,
+  hasExplicitGpuSwitch,
+  gpuSwitches,
+  applyGpuMode,
+} = require('../utils/gpu');
+
+test('GPU_MODES: 取りうる値の一覧', () => {
+  assert.deepEqual(GPU_MODES, ['off', 'hardware', 'default']);
+});
+
+test('defaultGpuMode: macOS は default、それ以外は off', () => {
+  assert.equal(defaultGpuMode('darwin'), 'default');
+  assert.equal(defaultGpuMode('linux'), 'off');
+  assert.equal(defaultGpuMode('win32'), 'off');
+});
+
+test('resolveGpuMode: 未設定はプラットフォーム既定にフォールバック', () => {
+  assert.equal(resolveGpuMode({}, 'linux'), 'off');
+  assert.equal(resolveGpuMode({}, 'darwin'), 'default');
+});
+
+test('resolveGpuMode: VK_TERMINALS_GPU を採用し正規化する', () => {
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'hardware' }, 'linux'), 'hardware');
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: '  Default ' }, 'linux'), 'default');
+});
+
+test('resolveGpuMode: 未知値・空文字は既定にフォールバック', () => {
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'turbo' }, 'linux'), 'off');
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: '' }, 'darwin'), 'default');
+});
+
+test('hasExplicitGpuSwitch: GPU 関連スイッチの有無を検出する', () => {
+  assert.equal(hasExplicitGpuSwitch(['electron', '.', '--disable-gpu']), true);
+  assert.equal(hasExplicitGpuSwitch(['electron', '.', '--use-gl=angle']), true);
+  assert.equal(hasExplicitGpuSwitch(['electron', '.', '--ignore-gpu-blocklist']), true);
+  assert.equal(hasExplicitGpuSwitch(['electron', '.', '--disable-gpu-sandbox']), true);
+  assert.equal(hasExplicitGpuSwitch(['electron', '.', '--no-claude']), false);
+  assert.equal(hasExplicitGpuSwitch(['electron', '.']), false);
+});
+
+test('gpuSwitches: off は GPU 無効スイッチ、追加 env は無し', () => {
+  const { switches, env } = gpuSwitches('off');
+  assert.deepEqual(switches, [['disable-gpu'], ['disable-software-rasterizer']]);
+  assert.deepEqual(env, {});
+});
+
+test('gpuSwitches: hardware は ANGLE(GL)＋サンドボックス無効＋ブロックリスト無視、env に GALLIUM_DRIVER', () => {
+  const { switches, env } = gpuSwitches('hardware');
+  const names = switches.map((s) => s.join('='));
+  assert.ok(names.includes('use-gl=angle'));
+  assert.ok(names.includes('use-angle=gl'));
+  assert.ok(names.includes('ignore-gpu-blocklist'));
+  assert.ok(names.includes('disable-gpu-sandbox'));
+  assert.equal(env.GALLIUM_DRIVER, 'd3d12');
+});
+
+test('gpuSwitches: default はスイッチ・env とも空', () => {
+  assert.deepEqual(gpuSwitches('default'), { switches: [], env: {} });
+});
+
+test('applyGpuMode: off モードで appendSwitch を呼ぶ（env 追加なし）', () => {
+  const called = [];
+  const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };
+  const env = {};
+  const mode = applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'linux' });
+  assert.equal(mode, 'off');
+  assert.deepEqual(called, [['disable-gpu'], ['disable-software-rasterizer']]);
+});
+
+test('applyGpuMode: hardware で GALLIUM_DRIVER を設定し ANGLE スイッチを適用', () => {
+  const called = [];
+  const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };
+  const env = { VK_TERMINALS_GPU: 'hardware' };
+  const mode = applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'linux' });
+  assert.equal(mode, 'hardware');
+  assert.equal(env.GALLIUM_DRIVER, 'd3d12');
+  const names = called.map((s) => s.join('='));
+  assert.ok(names.includes('use-gl=angle'));
+  assert.ok(names.includes('ignore-gpu-blocklist'));
+  assert.ok(names.includes('disable-gpu-sandbox'));
+});
+
+test('applyGpuMode: argv に GPU スイッチがあれば介入しない（null 返し・appendSwitch 未呼び出し）', () => {
+  const called = [];
+  const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };
+  const env = {};
+  const mode = applyGpuMode(fakeApp, { argv: ['electron', '.', '--use-gl=angle'], env, platform: 'linux' });
+  assert.equal(mode, null);
+  assert.deepEqual(called, []);
+});
+
+test('applyGpuMode: 既存の GALLIUM_DRIVER は上書きしない', () => {
+  const fakeApp = { commandLine: { appendSwitch: () => {} } };
+  const env = { VK_TERMINALS_GPU: 'hardware', GALLIUM_DRIVER: 'zink' };
+  applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'linux' });
+  assert.equal(env.GALLIUM_DRIVER, 'zink');
+});

--- a/tests/gpu.test.js
+++ b/tests/gpu.test.js
@@ -86,6 +86,8 @@ test('gpuSwitches: hardware は ANGLE(GL)＋サンドボックス無効＋ブロ
   assert.ok(names.includes('use-angle=gl'));
   assert.ok(names.includes('ignore-gpu-blocklist'));
   assert.ok(names.includes('disable-gpu-sandbox'));
+  // 未対応の Vulkan / WebGPU 探索を無効化し WSLg の警告を抑制する
+  assert.ok(names.includes('disable-features=Vulkan,WebGPU'));
   assert.equal(env.GALLIUM_DRIVER, 'd3d12');
 });
 

--- a/tests/gpu.test.js
+++ b/tests/gpu.test.js
@@ -86,8 +86,6 @@ test('gpuSwitches: hardware は ANGLE(GL)＋サンドボックス無効＋ブロ
   assert.ok(names.includes('use-angle=gl'));
   assert.ok(names.includes('ignore-gpu-blocklist'));
   assert.ok(names.includes('disable-gpu-sandbox'));
-  // 未対応の Vulkan / WebGPU 探索を無効化し WSLg の警告を抑制する
-  assert.ok(names.includes('disable-features=Vulkan,WebGPU'));
   assert.equal(env.GALLIUM_DRIVER, 'd3d12');
 });
 

--- a/tests/gpu.test.js
+++ b/tests/gpu.test.js
@@ -16,8 +16,8 @@ const {
   applyGpuMode,
 } = require('../utils/gpu');
 
-test('GPU_MODES: 取りうる値の一覧', () => {
-  assert.deepEqual(GPU_MODES, ['off', 'hardware', 'default']);
+test('GPU_MODES: 取りうる値の一覧（off / default の2択）', () => {
+  assert.deepEqual(GPU_MODES, ['off', 'default']);
 });
 
 test('defaultGpuMode: macOS は default、それ以外は off', () => {
@@ -32,7 +32,7 @@ test('resolveGpuMode: 未設定はプラットフォーム既定にフォール�
 });
 
 test('resolveGpuMode: VK_TERMINALS_GPU を採用し正規化する', () => {
-  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'hardware' }, 'linux'), 'hardware');
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'off' }, 'darwin'), 'off');
   assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: '  Default ' }, 'linux'), 'default');
 });
 
@@ -42,12 +42,12 @@ test('resolveGpuMode: 未知値・空文字は既定にフォールバック', (
 });
 
 test('resolveGpuMode: config.json の gpu を採用し正規化する（env 未指定時）', () => {
-  assert.equal(resolveGpuMode({}, 'linux', 'hardware'), 'hardware');
-  assert.equal(resolveGpuMode({}, 'darwin', ' Off '), 'off');
+  assert.equal(resolveGpuMode({}, 'darwin', 'off'), 'off');
+  assert.equal(resolveGpuMode({}, 'linux', ' Default '), 'default');
 });
 
 test('resolveGpuMode: env が config を上回る', () => {
-  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'off' }, 'linux', 'hardware'), 'off');
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'default' }, 'linux', 'off'), 'default');
 });
 
 test('resolveGpuMode: config が未知値なら次候補（プラットフォーム既定）へ', () => {
@@ -55,13 +55,14 @@ test('resolveGpuMode: config が未知値なら次候補（プラットフォー
   assert.equal(resolveGpuMode({}, 'darwin', ''), 'default');
 });
 
-test('applyGpuMode: configMode を採用する（env 未指定時）', () => {
+test('applyGpuMode: configMode を採用する（env 未指定時・プラットフォーム既定を上書き）', () => {
   const called = [];
   const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };
   const env = {};
-  const mode = applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'linux', configMode: 'hardware' });
-  assert.equal(mode, 'hardware');
-  assert.equal(env.GALLIUM_DRIVER, 'd3d12');
+  // darwin の既定は 'default' だが、config で 'off' を指定すれば off になる
+  const mode = applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'darwin', configMode: 'off' });
+  assert.equal(mode, 'off');
+  assert.deepEqual(called, [['disable-gpu'], ['disable-software-rasterizer']]);
 });
 
 test('hasExplicitGpuSwitch: GPU 関連スイッチの有無を検出する', () => {
@@ -79,16 +80,6 @@ test('gpuSwitches: off は GPU 無効スイッチ、追加 env は無し', () =>
   assert.deepEqual(env, {});
 });
 
-test('gpuSwitches: hardware は ANGLE(GL)＋サンドボックス無効＋ブロックリスト無視、env に GALLIUM_DRIVER', () => {
-  const { switches, env } = gpuSwitches('hardware');
-  const names = switches.map((s) => s.join('='));
-  assert.ok(names.includes('use-gl=angle'));
-  assert.ok(names.includes('use-angle=gl'));
-  assert.ok(names.includes('ignore-gpu-blocklist'));
-  assert.ok(names.includes('disable-gpu-sandbox'));
-  assert.equal(env.GALLIUM_DRIVER, 'd3d12');
-});
-
 test('gpuSwitches: default はスイッチ・env とも空', () => {
   assert.deepEqual(gpuSwitches('default'), { switches: [], env: {} });
 });
@@ -102,19 +93,6 @@ test('applyGpuMode: off モードで appendSwitch を呼ぶ（env 追加なし�
   assert.deepEqual(called, [['disable-gpu'], ['disable-software-rasterizer']]);
 });
 
-test('applyGpuMode: hardware で GALLIUM_DRIVER を設定し ANGLE スイッチを適用', () => {
-  const called = [];
-  const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };
-  const env = { VK_TERMINALS_GPU: 'hardware' };
-  const mode = applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'linux' });
-  assert.equal(mode, 'hardware');
-  assert.equal(env.GALLIUM_DRIVER, 'd3d12');
-  const names = called.map((s) => s.join('='));
-  assert.ok(names.includes('use-gl=angle'));
-  assert.ok(names.includes('ignore-gpu-blocklist'));
-  assert.ok(names.includes('disable-gpu-sandbox'));
-});
-
 test('applyGpuMode: argv に GPU スイッチがあれば介入しない（null 返し・appendSwitch 未呼び出し）', () => {
   const called = [];
   const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };
@@ -122,11 +100,4 @@ test('applyGpuMode: argv に GPU スイッチがあれば介入しない（null 
   const mode = applyGpuMode(fakeApp, { argv: ['electron', '.', '--use-gl=angle'], env, platform: 'linux' });
   assert.equal(mode, null);
   assert.deepEqual(called, []);
-});
-
-test('applyGpuMode: 既存の GALLIUM_DRIVER は上書きしない', () => {
-  const fakeApp = { commandLine: { appendSwitch: () => {} } };
-  const env = { VK_TERMINALS_GPU: 'hardware', GALLIUM_DRIVER: 'zink' };
-  applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'linux' });
-  assert.equal(env.GALLIUM_DRIVER, 'zink');
 });

--- a/tests/gpu.test.js
+++ b/tests/gpu.test.js
@@ -41,6 +41,29 @@ test('resolveGpuMode: 未知値・空文字は既定にフォールバック', (
   assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: '' }, 'darwin'), 'default');
 });
 
+test('resolveGpuMode: config.json の gpu を採用し正規化する（env 未指定時）', () => {
+  assert.equal(resolveGpuMode({}, 'linux', 'hardware'), 'hardware');
+  assert.equal(resolveGpuMode({}, 'darwin', ' Off '), 'off');
+});
+
+test('resolveGpuMode: env が config を上回る', () => {
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'off' }, 'linux', 'hardware'), 'off');
+});
+
+test('resolveGpuMode: config が未知値なら次候補（プラットフォーム既定）へ', () => {
+  assert.equal(resolveGpuMode({}, 'linux', 'turbo'), 'off');
+  assert.equal(resolveGpuMode({}, 'darwin', ''), 'default');
+});
+
+test('applyGpuMode: configMode を採用する（env 未指定時）', () => {
+  const called = [];
+  const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };
+  const env = {};
+  const mode = applyGpuMode(fakeApp, { argv: ['electron', '.'], env, platform: 'linux', configMode: 'hardware' });
+  assert.equal(mode, 'hardware');
+  assert.equal(env.GALLIUM_DRIVER, 'd3d12');
+});
+
 test('hasExplicitGpuSwitch: GPU 関連スイッチの有無を検出する', () => {
   assert.equal(hasExplicitGpuSwitch(['electron', '.', '--disable-gpu']), true);
   assert.equal(hasExplicitGpuSwitch(['electron', '.', '--use-gl=angle']), true);

--- a/tests/gpu.test.js
+++ b/tests/gpu.test.js
@@ -55,6 +55,10 @@ test('resolveGpuMode: config が未知値なら次候補（プラットフォー
   assert.equal(resolveGpuMode({}, 'darwin', ''), 'default');
 });
 
+test('resolveGpuMode: env が未知値でも config に有効値があればそちらを採用する', () => {
+  assert.equal(resolveGpuMode({ VK_TERMINALS_GPU: 'turbo' }, 'linux', 'default'), 'default');
+});
+
 test('applyGpuMode: configMode を採用する（env 未指定時・プラットフォーム既定を上書き）', () => {
   const called = [];
   const fakeApp = { commandLine: { appendSwitch: (...a) => called.push(a) } };

--- a/utils/gpu.js
+++ b/utils/gpu.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// GUI(Electron) の GPU 起動モード。
+//
+// VK Terminals は Electron アプリで、Chromium が起動時に GPU を初期化する。
+// macOS では HW アクセラがそのまま効くが、WSLg 等の Linux では GPU 初期化に失敗し
+// `Exiting GPU process` / `kTransientFailure` などのエラーが多発する（利用可能な
+// Vulkan ICD がソフトウェア実装のみで SwiftShader へフォールバックするため）。
+// 起動モードを環境変数 VK_TERMINALS_GPU で選べるようにし、Chromium スイッチと
+// 追加環境変数へ写像する。
+//
+// 呼び出し側（VK Orchestrator など）が argv で GPU スイッチを明示している場合は、
+// そちらを尊重してこのモジュールは介入しない（二重指定による競合を避ける）。
+
+/** GPU 起動モードの取りうる値。 */
+const GPU_MODES = ['off', 'hardware', 'default'];
+
+/**
+ * GPU 起動モードのプラットフォーム既定値を返す。
+ * macOS は HW アクセラがそのまま効くためスイッチ不要（'default'）。
+ * それ以外（WSLg 等の Linux）は GPU 初期化失敗によるエラーを抑制するため 'off'。
+ * @param {string} [platform] process.platform 互換の値
+ * @returns {'off'|'default'}
+ */
+function defaultGpuMode(platform = process.platform) {
+  return platform === 'darwin' ? 'default' : 'off';
+}
+
+/**
+ * 環境変数から GPU 起動モードを解決する。
+ * 空文字・未知の値はプラットフォーム既定にフォールバックする。
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [platform]
+ * @returns {'off'|'hardware'|'default'}
+ */
+function resolveGpuMode(env = process.env, platform = process.platform) {
+  const raw = String(env.VK_TERMINALS_GPU ?? '').trim().toLowerCase();
+  return GPU_MODES.includes(raw) ? raw : defaultGpuMode(platform);
+}
+
+/**
+ * argv に GPU 関連スイッチが既に含まれているか判定する。
+ * 含まれていれば呼び出し側（orchestrator 等）が明示指定しているとみなし、
+ * このモジュールは介入しない。
+ * @param {string[]} [argv]
+ * @returns {boolean}
+ */
+function hasExplicitGpuSwitch(argv = process.argv) {
+  return argv.some((a) =>
+    /^--(disable-gpu|disable-gpu-sandbox|disable-software-rasterizer|use-gl|use-angle|ignore-gpu-blocklist|enable-gpu|in-process-gpu)(=|$)/.test(a),
+  );
+}
+
+/**
+ * GPU モードから、Chromium スイッチと追加環境変数を組み立てる。
+ * switches は [name] または [name, value] の配列で返す（appendSwitch にそのまま渡せる形）。
+ *  - 'off'      : GPU を無効化してエラーログを抑制する（描画はソフトウェア。
+ *                 ターミナル用途では実害なし）。
+ *  - 'hardware' : ANGLE(GL) 経由で HW OpenGL を使う。WSLg では Mesa の d3d12 ドライバ
+ *                 （GALLIUM_DRIVER=d3d12）経由で Windows 側 GPU に届く。/dev/dxg への
+ *                 アクセスのため GPU サンドボックスを外し、GPU ブロックリストを無視する
+ *                 （その分 GPU プロセスの保護は下がる）。Vulkan は HW ICD が無いため対象外。
+ *  - 'default'  : スイッチ・env を足さず Chromium 任せ（macOS 既定 / 明示的に素の挙動）。
+ * @param {string} mode 'off'|'hardware'|'default'
+ * @returns {{ switches: string[][], env: Record<string,string> }}
+ */
+function gpuSwitches(mode) {
+  switch (mode) {
+    case 'off':
+      return { switches: [['disable-gpu'], ['disable-software-rasterizer']], env: {} };
+    case 'hardware':
+      return {
+        switches: [['use-gl', 'angle'], ['use-angle', 'gl'], ['ignore-gpu-blocklist'], ['disable-gpu-sandbox']],
+        env: { GALLIUM_DRIVER: 'd3d12' },
+      };
+    case 'default':
+    default:
+      return { switches: [], env: {} };
+  }
+}
+
+/**
+ * 解決した GPU モードに従って Electron の app.commandLine へスイッチを適用し、
+ * 追加環境変数を設定する。呼び出し側が argv で GPU スイッチを明示している場合は
+ * 何もしない（競合回避）。app が ready になる前に呼ぶこと。
+ * @param {import('electron').App} app Electron の app オブジェクト
+ * @param {object} [opts]
+ * @param {string[]} [opts.argv]
+ * @param {NodeJS.ProcessEnv} [opts.env]
+ * @param {string} [opts.platform]
+ * @returns {string|null} 適用したモード（介入しなかった場合は null）
+ */
+function applyGpuMode(app, { argv = process.argv, env = process.env, platform = process.platform } = {}) {
+  if (hasExplicitGpuSwitch(argv)) return null;
+  const mode = resolveGpuMode(env, platform);
+  const { switches, env: extraEnv } = gpuSwitches(mode);
+  // 追加 env は未設定のときだけ入れる（利用者が明示した値を尊重する）。
+  for (const [k, v] of Object.entries(extraEnv)) {
+    if (env[k] === undefined || env[k] === '') env[k] = v;
+  }
+  for (const sw of switches) {
+    if (sw.length === 1) app.commandLine.appendSwitch(sw[0]);
+    else app.commandLine.appendSwitch(sw[0], sw[1]);
+  }
+  return mode;
+}
+
+module.exports = {
+  GPU_MODES,
+  defaultGpuMode,
+  resolveGpuMode,
+  hasExplicitGpuSwitch,
+  gpuSwitches,
+  applyGpuMode,
+};

--- a/utils/gpu.js
+++ b/utils/gpu.js
@@ -18,7 +18,8 @@ const GPU_MODES = ['off', 'hardware', 'default'];
 /**
  * GPU 起動モードのプラットフォーム既定値を返す。
  * macOS は HW アクセラがそのまま効くためスイッチ不要（'default'）。
- * それ以外（WSLg 等の Linux）は GPU 初期化失敗によるエラーを抑制するため 'off'。
+ * それ以外（WSLg 等の Linux、およびネイティブ Windows を含む darwin 以外の全て）は
+ * GPU 初期化失敗によるエラーを抑制するため 'off'。
  * @param {string} [platform] process.platform 互換の値
  * @returns {'off'|'default'}
  */
@@ -27,15 +28,20 @@ function defaultGpuMode(platform = process.platform) {
 }
 
 /**
- * 環境変数から GPU 起動モードを解決する。
- * 空文字・未知の値はプラットフォーム既定にフォールバックする。
+ * GPU 起動モードを解決する。
+ * 優先順位: 環境変数 VK_TERMINALS_GPU > config.json の gpu > プラットフォーム既定。
+ * いずれも空文字・未知の値の場合は次の候補へフォールバックする。
  * @param {NodeJS.ProcessEnv} [env]
  * @param {string} [platform]
+ * @param {string} [configMode] config.json 由来の gpu 値（任意）
  * @returns {'off'|'hardware'|'default'}
  */
-function resolveGpuMode(env = process.env, platform = process.platform) {
-  const raw = String(env.VK_TERMINALS_GPU ?? '').trim().toLowerCase();
-  return GPU_MODES.includes(raw) ? raw : defaultGpuMode(platform);
+function resolveGpuMode(env = process.env, platform = process.platform, configMode) {
+  const fromEnv = String(env.VK_TERMINALS_GPU ?? '').trim().toLowerCase();
+  if (GPU_MODES.includes(fromEnv)) return fromEnv;
+  const fromConfig = String(configMode ?? '').trim().toLowerCase();
+  if (GPU_MODES.includes(fromConfig)) return fromConfig;
+  return defaultGpuMode(platform);
 }
 
 /**
@@ -88,11 +94,12 @@ function gpuSwitches(mode) {
  * @param {string[]} [opts.argv]
  * @param {NodeJS.ProcessEnv} [opts.env]
  * @param {string} [opts.platform]
+ * @param {string} [opts.configMode] config.json 由来の gpu 値（env 未指定時に採用）
  * @returns {string|null} 適用したモード（介入しなかった場合は null）
  */
-function applyGpuMode(app, { argv = process.argv, env = process.env, platform = process.platform } = {}) {
+function applyGpuMode(app, { argv = process.argv, env = process.env, platform = process.platform, configMode } = {}) {
   if (hasExplicitGpuSwitch(argv)) return null;
-  const mode = resolveGpuMode(env, platform);
+  const mode = resolveGpuMode(env, platform, configMode);
   const { switches, env: extraEnv } = gpuSwitches(mode);
   // 追加 env は未設定のときだけ入れる（利用者が明示した値を尊重する）。
   for (const [k, v] of Object.entries(extraEnv)) {

--- a/utils/gpu.js
+++ b/utils/gpu.js
@@ -66,10 +66,6 @@ function hasExplicitGpuSwitch(argv = process.argv) {
  *                 （GALLIUM_DRIVER=d3d12）経由で Windows 側 GPU に届く。/dev/dxg への
  *                 アクセスのため GPU サンドボックスを外し、GPU ブロックリストを無視する
  *                 （その分 GPU プロセスの保護は下がる）。Vulkan は HW ICD が無いため対象外。
- *                 加えて Vulkan / WebGPU(Dawn) のバックエンド探索を無効化する
- *                 （WSLg では未対応で、asahi ICD の `VK_ERROR_INCOMPATIBLE_DRIVER` や
- *                 Dawn の `EGL_EXT_create_context_robustness` 警告を吐くだけのため。
- *                 OpenGL 描画には不要）。
  *  - 'default'  : スイッチ・env を足さず Chromium 任せ（macOS 既定 / 明示的に素の挙動）。
  * @param {string} mode 'off'|'hardware'|'default'
  * @returns {{ switches: string[][], env: Record<string,string> }}
@@ -80,13 +76,7 @@ function gpuSwitches(mode) {
       return { switches: [['disable-gpu'], ['disable-software-rasterizer']], env: {} };
     case 'hardware':
       return {
-        switches: [
-          ['use-gl', 'angle'],
-          ['use-angle', 'gl'],
-          ['ignore-gpu-blocklist'],
-          ['disable-gpu-sandbox'],
-          ['disable-features', 'Vulkan,WebGPU'],
-        ],
+        switches: [['use-gl', 'angle'], ['use-angle', 'gl'], ['ignore-gpu-blocklist'], ['disable-gpu-sandbox']],
         env: { GALLIUM_DRIVER: 'd3d12' },
       };
     case 'default':

--- a/utils/gpu.js
+++ b/utils/gpu.js
@@ -31,10 +31,26 @@ function defaultGpuMode(platform = process.platform) {
 let warnedUnknownGpuMode = false;
 
 /**
+ * 非空の未知値（例: 撤去した旧 'hardware'）が来た場合、挙動変更に気づけるよう
+ * 一度だけ警告する（起動は止めない）。
+ * @param {string} value 未知の値
+ * @param {string} platform process.platform 互換の値
+ */
+function warnUnknownGpuMode(value, platform) {
+  if (warnedUnknownGpuMode) return;
+  warnedUnknownGpuMode = true;
+  console.warn(
+    `[vk-terminals] 未知の GPU モード "${value}" は無視し、既定 "${defaultGpuMode(platform)}" を使用します` +
+    `（有効値: ${GPU_MODES.join(' / ')}、空=自動）。`,
+  );
+}
+
+/**
  * GPU 起動モードを解決する。
  * 優先順位: 環境変数 VK_TERMINALS_GPU > config.json の gpu > プラットフォーム既定。
- * いずれも空文字・未知の値の場合は次の候補へフォールバックする。撤去した 'hardware' など
- * 非空の未知値が来た場合は、挙動変更に気づけるよう一度だけ警告する（起動は止めない）。
+ * いずれも空文字・未知の値の場合は次の候補へフォールバックする。環境変数が非空の未知値
+ * （例: 旧 'hardware'）の場合は、config に有効な値があって上書き解決されても気づけるよう
+ * その場で警告する（config 側が未知値の場合も同様）。
  * @param {NodeJS.ProcessEnv} [env]
  * @param {string} [platform]
  * @param {string} [configMode] config.json 由来の gpu 値（任意）
@@ -42,18 +58,13 @@ let warnedUnknownGpuMode = false;
  */
 function resolveGpuMode(env = process.env, platform = process.platform, configMode) {
   const fromEnv = String(env.VK_TERMINALS_GPU ?? '').trim().toLowerCase();
+  if (fromEnv !== '' && !GPU_MODES.includes(fromEnv)) warnUnknownGpuMode(fromEnv, platform);
   if (GPU_MODES.includes(fromEnv)) return fromEnv;
+
   const fromConfig = String(configMode ?? '').trim().toLowerCase();
+  if (fromConfig !== '' && !GPU_MODES.includes(fromConfig)) warnUnknownGpuMode(fromConfig, platform);
   if (GPU_MODES.includes(fromConfig)) return fromConfig;
-  // 空（＝自動）以外の未知値（例: 旧 'hardware'）は既定にフォールバック。一度だけ警告。
-  const unknown = fromEnv || fromConfig;
-  if (unknown !== '' && !warnedUnknownGpuMode) {
-    warnedUnknownGpuMode = true;
-    console.warn(
-      `[vk-terminals] 未知の GPU モード "${unknown}" は無視し、既定 "${defaultGpuMode(platform)}" を使用します` +
-      `（有効値: ${GPU_MODES.join(' / ')}、空=自動）。`,
-    );
-  }
+
   return defaultGpuMode(platform);
 }
 

--- a/utils/gpu.js
+++ b/utils/gpu.js
@@ -13,7 +13,7 @@
 // そちらを尊重してこのモジュールは介入しない（二重指定による競合を避ける）。
 
 /** GPU 起動モードの取りうる値。 */
-const GPU_MODES = ['off', 'hardware', 'default'];
+const GPU_MODES = ['off', 'default'];
 
 /**
  * GPU 起動モードのプラットフォーム既定値を返す。
@@ -34,7 +34,7 @@ function defaultGpuMode(platform = process.platform) {
  * @param {NodeJS.ProcessEnv} [env]
  * @param {string} [platform]
  * @param {string} [configMode] config.json 由来の gpu 値（任意）
- * @returns {'off'|'hardware'|'default'}
+ * @returns {'off'|'default'}
  */
 function resolveGpuMode(env = process.env, platform = process.platform, configMode) {
   const fromEnv = String(env.VK_TERMINALS_GPU ?? '').trim().toLowerCase();
@@ -62,23 +62,18 @@ function hasExplicitGpuSwitch(argv = process.argv) {
  * switches は [name] または [name, value] の配列で返す（appendSwitch にそのまま渡せる形）。
  *  - 'off'      : GPU を無効化してエラーログを抑制する（描画はソフトウェア。
  *                 ターミナル用途では実害なし）。
- *  - 'hardware' : ANGLE(GL) 経由で HW OpenGL を使う。WSLg では Mesa の d3d12 ドライバ
- *                 （GALLIUM_DRIVER=d3d12）経由で Windows 側 GPU に届く。/dev/dxg への
- *                 アクセスのため GPU サンドボックスを外し、GPU ブロックリストを無視する
- *                 （その分 GPU プロセスの保護は下がる）。Vulkan は HW ICD が無いため対象外。
  *  - 'default'  : スイッチ・env を足さず Chromium 任せ（macOS 既定 / 明示的に素の挙動）。
- * @param {string} mode 'off'|'hardware'|'default'
+ *
+ * ※ WSLg での HW アクセラ（HW OpenGL / Vulkan）は対応しない。Vulkan は HW ICD
+ *    （dzn 等）が WSLg に無く、OpenGL も体感差が無いうえ Mesa/Dawn 由来の警告が出るため。
+ *    env フィールドは将来のモード拡張用に残してある（現状はどのモードも空）。
+ * @param {string} mode 'off'|'default'
  * @returns {{ switches: string[][], env: Record<string,string> }}
  */
 function gpuSwitches(mode) {
   switch (mode) {
     case 'off':
       return { switches: [['disable-gpu'], ['disable-software-rasterizer']], env: {} };
-    case 'hardware':
-      return {
-        switches: [['use-gl', 'angle'], ['use-angle', 'gl'], ['ignore-gpu-blocklist'], ['disable-gpu-sandbox']],
-        env: { GALLIUM_DRIVER: 'd3d12' },
-      };
     case 'default':
     default:
       return { switches: [], env: {} };

--- a/utils/gpu.js
+++ b/utils/gpu.js
@@ -66,6 +66,10 @@ function hasExplicitGpuSwitch(argv = process.argv) {
  *                 （GALLIUM_DRIVER=d3d12）経由で Windows 側 GPU に届く。/dev/dxg への
  *                 アクセスのため GPU サンドボックスを外し、GPU ブロックリストを無視する
  *                 （その分 GPU プロセスの保護は下がる）。Vulkan は HW ICD が無いため対象外。
+ *                 加えて Vulkan / WebGPU(Dawn) のバックエンド探索を無効化する
+ *                 （WSLg では未対応で、asahi ICD の `VK_ERROR_INCOMPATIBLE_DRIVER` や
+ *                 Dawn の `EGL_EXT_create_context_robustness` 警告を吐くだけのため。
+ *                 OpenGL 描画には不要）。
  *  - 'default'  : スイッチ・env を足さず Chromium 任せ（macOS 既定 / 明示的に素の挙動）。
  * @param {string} mode 'off'|'hardware'|'default'
  * @returns {{ switches: string[][], env: Record<string,string> }}
@@ -76,7 +80,13 @@ function gpuSwitches(mode) {
       return { switches: [['disable-gpu'], ['disable-software-rasterizer']], env: {} };
     case 'hardware':
       return {
-        switches: [['use-gl', 'angle'], ['use-angle', 'gl'], ['ignore-gpu-blocklist'], ['disable-gpu-sandbox']],
+        switches: [
+          ['use-gl', 'angle'],
+          ['use-angle', 'gl'],
+          ['ignore-gpu-blocklist'],
+          ['disable-gpu-sandbox'],
+          ['disable-features', 'Vulkan,WebGPU'],
+        ],
         env: { GALLIUM_DRIVER: 'd3d12' },
       };
     case 'default':

--- a/utils/gpu.js
+++ b/utils/gpu.js
@@ -27,10 +27,14 @@ function defaultGpuMode(platform = process.platform) {
   return platform === 'darwin' ? 'default' : 'off';
 }
 
+// 未知の GPU モードを警告済みか（プロセス内で一度だけ通知するためのフラグ）。
+let warnedUnknownGpuMode = false;
+
 /**
  * GPU 起動モードを解決する。
  * 優先順位: 環境変数 VK_TERMINALS_GPU > config.json の gpu > プラットフォーム既定。
- * いずれも空文字・未知の値の場合は次の候補へフォールバックする。
+ * いずれも空文字・未知の値の場合は次の候補へフォールバックする。撤去した 'hardware' など
+ * 非空の未知値が来た場合は、挙動変更に気づけるよう一度だけ警告する（起動は止めない）。
  * @param {NodeJS.ProcessEnv} [env]
  * @param {string} [platform]
  * @param {string} [configMode] config.json 由来の gpu 値（任意）
@@ -41,6 +45,15 @@ function resolveGpuMode(env = process.env, platform = process.platform, configMo
   if (GPU_MODES.includes(fromEnv)) return fromEnv;
   const fromConfig = String(configMode ?? '').trim().toLowerCase();
   if (GPU_MODES.includes(fromConfig)) return fromConfig;
+  // 空（＝自動）以外の未知値（例: 旧 'hardware'）は既定にフォールバック。一度だけ警告。
+  const unknown = fromEnv || fromConfig;
+  if (unknown !== '' && !warnedUnknownGpuMode) {
+    warnedUnknownGpuMode = true;
+    console.warn(
+      `[vk-terminals] 未知の GPU モード "${unknown}" は無視し、既定 "${defaultGpuMode(platform)}" を使用します` +
+      `（有効値: ${GPU_MODES.join(' / ')}、空=自動）。`,
+    );
+  }
   return defaultGpuMode(platform);
 }
 


### PR DESCRIPTION
## 概要

VK Terminals は Electron アプリのため、macOS 以外（WSLg などの Linux）では Chromium の GPU 初期化が失敗し、起動時に `Exiting GPU process` / `kTransientFailure` / `VK_ERROR_INCOMPATIBLE_DRIVER` などのエラーログが大量に出ます（利用可能な Vulkan ICD がソフトウェア実装のみで SwiftShader へフォールバックするため）。

本 PR で GUI 自身が GPU 起動モードを扱えるようにし、単体起動（`npm start`）でも WSLg でクリーンに起動できるようにします。あわせて、Windows（WSLg を含まないネイティブ Windows）でも起動できなかった問題を修正し、Windows / WSLg それぞれのセットアップ手順を README に追記しました。

> 関連: VK Orchestrator 側でも同等の GPU モード設定を追加済み（[vektor-inc/vk-orchestrator#17](https://github.com/vektor-inc/vk-orchestrator/pull/17)）。Orchestrator は `up` で GUI を spawn する際に argv フラグを渡すため、本 PR の自動適用はその場合は介入しません（下記「呼び出し側の尊重」）。

## GPU モード（環境変数 `VK_TERMINALS_GPU`）

| 値 | 挙動 |
|---|---|
| 未設定（自動） | macOS は通常起動 / それ以外は `off` 相当 |
| `off` | GPU 無効・エラーログ抑制（描画はソフト。ターミナル用途で実害なし） |
| `default` | フラグを足さず Chromium 任せ（元の挙動） |

- 未設定・空文字・未知値はプラットフォーム既定（mac=`default` / その他=`off`）にフォールバック。未知値指定時は一度だけ警告ログを出す。
- **呼び出し側の尊重**: `electron . --disable-gpu` のように argv で GPU スイッチが明示されている場合は自動適用しない（Orchestrator 経由の起動もこの経路。二重指定の競合を防ぐ）。
- 当初あった `hardware`（HW OpenGL）モードは撤去し、`off` / `default` の2択に簡素化（Vulkan は HW ICD が無く対象外、OpenGL も体感差が薄くサンドボックス無効化のトレードオフに見合わないため）。

## Windows ネイティブ環境への対応

- `main.js` の PTY 起動でシェルが `/bin/zsh` 固定・作業ディレクトリが `process.env.HOME` 固定だったため、Windows では `node-pty` が起動時に `File not found` で落ちていた。`process.platform === 'win32'` のとき `COMSPEC`（既定 `cmd.exe`）または `powershell.exe`、作業ディレクトリは `USERPROFILE` にフォールバックするよう修正。
- README に Windows 固有のはまりどころ（`node-pty` のネイティブビルド、`claude` CLI インストール後の PATH 反映漏れ、VSCode 統合ターミナルの `ELECTRON_RUN_AS_NODE` 継承問題）をまとめた「Windows での起動」セクションを追加。

## WSLg での起動手順

README に「WSLg での起動」セクションを新設し、前提パッケージ（`build-essential` / `python3`）・`claude` CLI のインストール・起動確認手順（`/api/health` への疎通確認）をまとめました。

## 変更ファイル

- `utils/gpu.js`（新規） — `VK_TERMINALS_GPU` からモード解決 → Chromium スイッチ／追加 env へ写像する純関数群
- `main.js` — `app` ready 前に `applyGpuMode(app)` を呼ぶ。設定パネルの値検証に `select` 型を追加。PTY 起動時のシェル／作業ディレクトリの Windows 対応
- `renderer/app.js` — 設定パネルに選択式（`select`）フィールドの描画を追加
- `tests/gpu.test.js`（新規） — モード解決・スイッチ写像・argv 尊重・env 非上書きのユニットテスト
- `README.md` / `CHANGELOG.md` — GPU モード・Windows・WSLg 起動手順の説明を追記

## 確認手順

### 1. WSLg / Linux で既定（off）でエラーが出ないこと

1. `npm start` で起動する
   → 起動ログに `[vk-terminals] GPU mode: off` が出る
   → `Exiting GPU process` 等の GPU エラーが出ない
   → `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:13847/` が `200`

### 2. 呼び出し側フラグの尊重

1. `electron . --disable-gpu` で起動する
   → `[vk-terminals] GPU mode:` の行が出ない（自動適用しない）

### 3. Windows ネイティブでの起動

1. `npm install` → `npm start`（または `electron .`）で起動し、ペインで PTY が正常に立ち上がることを確認
2. VSCode 統合ターミナルから `npm start` した場合に `ELECTRON_RUN_AS_NODE` 起因のエラーが出ないこと（環境変数を明示的に外して起動、または README 記載の回避策で確認）

### デグレ確認

- ユニットテスト: `node --test tests/*.test.js` → 全件パス
- macOS では既定が `default` のため GUI 起動挙動は従来どおり

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GPU 起動モード（自動 / off / default）を GUI、`config.json`（`gpu`）、環境変数（`VK_TERMINALS_GPU`）から選択できるようにしました。
  * 設定画面に、許可値のみ選べる選択式（select）を追加しました。
* **Bug Fixes**
  * macOS 以外で Chromium の GPU 初期化失敗により大量ログが出る問題を、既定で GPU 無効化して抑制しました。
* **ドキュメント**
  * GPU モードの挙動・優先順位、WSLg の注意、Windows/WSLg 向け手順、シェル/既定 cwd のフォールバックを追記しました。
* **テスト**
  * GPU モード解決・適用、GPU 関連スイッチが既にある場合の挙動を追加で検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
