### PR TITLE
[ その他 ] WSLg で off でも出る Dawn/Vulkan の無害な警告についての説明を README に追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ その他 ] WSLg で `off` でも出る Dawn(WebGPU) 由来の `vkCreateInstance: Found no drivers` / `Failed to load libEGL.so` 警告が無害である旨の説明を README に追記
+
 ## 1.8.0
 
 - [ 機能追加 ] GUI の GPU 起動モード（`off` / `default`）を環境変数 `VK_TERMINALS_GPU`・`config.json` の `gpu`・設定パネルのいずれからも選択可能に（既定は非 macOS で `off`＝エラー抑制）

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ VK Terminals は Electron アプリのため、macOS 以外（WSLg などの Lin
 
 > WSLg での HW アクセラ（HW OpenGL / Vulkan）は対応しません。Vulkan は HW ICD（dzn 等）が WSLg に無く、OpenGL も体感差が無いうえ Mesa/Dawn 由来の警告が出るためです。
 
+#### WSLg で出る `vkCreateInstance` / `libEGL.so` 警告について（無害）
+
+`off` で起動しても、claude 起動後（起動から数分後のこともある）に次のような警告が stderr に出ることがあります。
+
+```
+Warning: loader_get_json: Failed to open JSON file lvp_icd.json
+（他の *_icd.json も同様）
+Warning: vkCreateInstance: Found no drivers!
+Warning: vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER
+    at ... third_party/dawn/src/dawn/native/vulkan/BackendVk.cpp ...
+Warning: Failed to load libEGL.so
+    at DiscoverPhysicalDevices (../../third_party/dawn/src/dawn/native/opengl/BackendGL.cpp:74)
+```
+
+これは Chromium がバックグラウンドで行う GPU 情報収集で、**WebGPU 実装の Dawn が Vulkan / OpenGL アダプタを探索**した際のログです。WSLg では次の理由で探索に失敗しますが、**いずれも完全に無害**で、描画はソフトウェアにフォールバックしてアプリは正常動作します（`--disable-gpu` とは別経路のため `off` でも出ます）。
+
+- **Vulkan**: ICD マニフェスト（`/usr/share/vulkan/icd.d/*.json`）や実ドライバ（例: lavapipe の `libvulkan_lvp.so`）自体は存在するが、サンドボックス化された GPU プロセスからは読めず「ドライバ無し」となる。
+- **OpenGL**: Dawn が `libEGL.so`（バージョン無し）を `dlopen` するが、WSLg には `libEGL.so.1` しか無く symlink が無いため失敗する。
+
+このアプリは WebGPU を使わないため実害はありません。`VK_TERMINALS_GPU`・`config.json`・設定パネルのどのモードでも、また `--disable-features=Vulkan,WebGPU` 等の Chromium フラグでもこのバックグラウンド探索は止められない（この Electron/Chromium バージョンの挙動）ため、**この警告は無視して問題ありません**。
+
 ```bash
 VK_TERMINALS_GPU=off npm start
 ```


### PR DESCRIPTION
## 概要

WSLg で `VK_TERMINALS_GPU=off`（既定）で起動しても、claude 起動後（起動から数分後のこともある）に次の警告が stderr に出ることがあります。

```
Warning: loader_get_json: Failed to open JSON file lvp_icd.json（他の *_icd.json も同様）
Warning: vkCreateInstance: Found no drivers!
Warning: vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER
    at ... third_party/dawn/src/dawn/native/vulkan/BackendVk.cpp ...
Warning: Failed to load libEGL.so
    at DiscoverPhysicalDevices (../../third_party/dawn/src/dawn/native/opengl/BackendGL.cpp:74)
```

これは Chromium のバックグラウンド GPU 情報収集で **WebGPU 実装 Dawn が Vulkan/GL アダプタを探索**した際のログで、**完全に無害**（描画はソフトウェアにフォールバックし正常動作）です。ユーザーが不具合と誤認しないよう README に説明を追記します。

### 調査で判明した原因（実機 WSLg で確認）

- ドライバ実体（`libvulkan_lvp.so` / `libEGL.so.1` / `mesa-vulkan-drivers`）は**存在する**。
- **Vulkan**: サンドボックス化された GPU プロセスから `/usr/share/vulkan/icd.d/*.json` を読めず「Found no drivers」になる。
- **OpenGL**: Dawn が `libEGL.so`（バージョン無し）を `dlopen` するが、WSLg には `libEGL.so.1` しか無く symlink が無いため失敗する。
- `--disable-gpu`（off モード）とは別経路のため off でも出る。`--disable-features=Vulkan,WebGPU,SkiaGraphite` 等でも抑制できないことを実機で 2 回確認済み（この Electron/Chromium バージョンの挙動）。

コード変更はなく、`--disable-features` のような効かないフラグは追加していません（ドキュメントのみ）。

## 変更内容

- `README.md`: GPU 起動モードの節に「WSLg で出る `vkCreateInstance` / `libEGL.so` 警告について（無害）」の説明を追記。
- `CHANGELOG.md`: `[ その他 ]` として追記。

## 確認手順

1. `README.md` の「GPU 起動モード（`VK_TERMINALS_GPU`）」節を開く。
   → `#### WSLg で出る vkCreateInstance / libEGL.so 警告について（無害）` の見出しと説明が追加されている。
2. 記載内容が、警告の実サンプル・原因（サンドボックス／未バージョン libEGL）・無害である旨・フラグでは止められない旨を含む。
   → いずれも記載されていること。
3. デグレ確認: 変更は `README.md` / `CHANGELOG.md` のみでコード変更なし。`node --test tests/gpu.test.js` が引き続き pass する。
   → 15/15 pass。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * WSLg 環境で GPU 無効化時に表示される `vkCreateInstance` や `libEGL.so` 関連の警告について、無害であることを README に追記しました。
  * 警告の例と、描画がソフトウェアへ切り替わって通常どおり動作する旨を明記しました。
  * 関連する注意事項を changelog にも追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->