### PR TITLE
[ 不具合修正 ] Claude使用状況の公式表示が一時取得失敗のたびにトークン集計へ切り替わり不安定になる問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 不具合修正 ] Claude使用状況の公式表示が一時的な取得失敗のたびにトークン集計表示へ切り替わり不安定になる問題を修正（直近の公式値を一定時間保持してフォールバックへの頻繁な切替を防止）（[vektor-inc/vk-orchestrator#31](https://github.com/vektor-inc/vk-orchestrator/issues/31)）
+
 ## 1.8.1
 
 - [ その他 ] WSLg で `off` でも出る Dawn(WebGPU) 由来の `vkCreateInstance: Found no drivers` / `Failed to load libEGL.so` 警告が無害である旨の説明を README に追記

--- a/oauthUsage.js
+++ b/oauthUsage.js
@@ -39,6 +39,9 @@ const USAGE_API_URL = 'https://api.anthropic.com/api/oauth/usage';
 const FETCH_TIMEOUT_MS = 8000;    // API 応答待ちの上限（仕様: 5〜10 秒）
 const KEYCHAIN_TIMEOUT_MS = 5000; // security コマンドの応答待ち上限
 const USAGE_TTL_MS = 60 * 1000;   // main 側キャッシュ TTL（API 問い合わせの抑制）
+// 公式取得が一時失敗しても、直近成功値をこの時間だけ出し続けて
+// トランスクリプト集計への切替（パタパタ）を防ぐ。
+const STICKY_MAX_MS = 15 * 60 * 1000;
 
 // ─── 純粋関数コア（node --test 対象）────────────────────────────────────────────
 
@@ -156,6 +159,22 @@ function parseUsageResponse(json, nowMs) {
   return { source: 'oauth', session, weekly, fetchedAtMs: nowMs };
 }
 
+/**
+ * 直近成功した公式 usage スナップショットを表示継続してよいか判定する（純粋）。
+ * source: 'oauth' かつ fetchedAtMs を持つ値だけを対象にし、未来時刻や期限超過は使わない。
+ * @param {*} snapshot 直近成功した正規化済み usage スナップショット
+ * @param {number} nowMs 現在時刻（epoch ms）
+ * @param {number} maxMs スティッキー表示を許容する最大時間（ms）
+ * @returns {boolean}
+ */
+function isStickyUsable(snapshot, nowMs, maxMs) {
+  if (!snapshot || typeof snapshot !== 'object' || snapshot.source !== 'oauth') return false;
+  if (!Number.isFinite(snapshot.fetchedAtMs)) return false;
+  if (!Number.isFinite(nowMs) || !Number.isFinite(maxMs)) return false;
+  const elapsed = nowMs - snapshot.fetchedAtMs;
+  return elapsed >= 0 && elapsed <= maxMs;
+}
+
 // ─── IO 層（main プロセス専用・トークンはこの層の外に出さない）──────────────────
 
 /**
@@ -249,17 +268,33 @@ async function loadUsageSnapshot() {
  * Keychain / API への問い合わせを抑制する。取得失敗（null）も TTL の間はキャッシュし、
  * 失敗のたびに Keychain へアクセスして許可ダイアログを乱発しないようにする。
  * main プロセスから 1 個だけ生成して使う。
- * @param {{ ttlMs?: number, clock?: () => number, load?: () => Promise<any> }} [options]
+ * @param {{ ttlMs?: number, stickyMaxMs?: number, clock?: () => number, load?: () => Promise<any> }} [options]
  * @returns {{ get: () => Promise<ReturnType<typeof parseUsageResponse>> }}
  */
 function createOauthUsageProvider(options = {}) {
   const ttlMs = options.ttlMs != null ? options.ttlMs : USAGE_TTL_MS;
+  const stickyMaxMs = options.stickyMaxMs != null ? options.stickyMaxMs : STICKY_MAX_MS;
   const clock = options.clock || Date.now;
   const load = typeof options.load === 'function' ? options.load : loadUsageSnapshot;
+  let lastGood = null;
+  // memo は API / Keychain 問い合わせを 60s に抑えるスロットル。
   // createTtlMemo は Promise をそのままメモ化する。同時呼び出しは同じ Promise を共有し、
   // reject は load 側で握りつぶして null 解決にしているため rejection は漏れない。
   const memo = createTtlMemo(() => Promise.resolve(load()).catch(() => null), ttlMs, clock);
-  return { get: () => memo() };
+  return {
+    get: async () => {
+      const fresh = await memo();
+      if (fresh) {
+        lastGood = fresh;
+        return fresh;
+      }
+      // lastGood は表示安定化用の直近成功スナップショット。
+      if (isStickyUsable(lastGood, clock(), stickyMaxMs)) {
+        return { ...lastGood, stale: true };
+      }
+      return null;
+    },
+  };
 }
 
 module.exports = {
@@ -269,6 +304,7 @@ module.exports = {
   normalizePercent,
   parseResetAt,
   parseUsageResponse,
+  isStickyUsable,
   // IO 層
   // NOTE: readCredentialsFileRaw は refreshToken を含む生 JSON を返すため export しない
   //       （モジュール内部専用。トークンをこのモジュールの外に出さない設計の徹底）。
@@ -276,5 +312,6 @@ module.exports = {
   createOauthUsageProvider,
   // 定数
   USAGE_TTL_MS,
+  STICKY_MAX_MS,
   FETCH_TIMEOUT_MS,
 };

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1681,6 +1681,12 @@ function renderUsageView(container, usage) {
     if (usage.weekly) {
       container.appendChild(buildOauthUsageSection('週間制限（すべてのモデル）', usage.weekly, 'datetime'));
     }
+    if (usage.stale === true) {
+      const note = document.createElement('div');
+      note.className = 'usage-note';
+      note.textContent = '直近に取得した値を表示しています（最新の取得に一時的に失敗しました）';
+      container.appendChild(note);
+    }
     return;
   }
   // フォールバック（トランスクリプト集計）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1675,17 +1675,19 @@ function renderUsageView(container, usage) {
     return;
   }
   if (usage.source === 'oauth') {
-    if (usage.session) {
-      container.appendChild(buildOauthUsageSection('現在のセッション', usage.session, 'remaining'));
-    }
-    if (usage.weekly) {
-      container.appendChild(buildOauthUsageSection('週間制限（すべてのモデル）', usage.weekly, 'datetime'));
-    }
+    // スクリーンリーダーが「直近取得値（古い可能性あり）」の前置きを数値より先に
+    // 読み上げられるよう、stale 注記はブロック先頭に置く（a11y 改善）。
     if (usage.stale === true) {
       const note = document.createElement('div');
       note.className = 'usage-note';
       note.textContent = '直近に取得した値を表示しています（最新の取得に一時的に失敗しました）';
       container.appendChild(note);
+    }
+    if (usage.session) {
+      container.appendChild(buildOauthUsageSection('現在のセッション', usage.session, 'remaining'));
+    }
+    if (usage.weekly) {
+      container.appendChild(buildOauthUsageSection('週間制限（すべてのモデル）', usage.weekly, 'datetime'));
     }
     return;
   }

--- a/tests/oauthUsage.test.js
+++ b/tests/oauthUsage.test.js
@@ -13,6 +13,7 @@ const {
   normalizePercent,
   parseResetAt,
   parseUsageResponse,
+  isStickyUsable,
   createOauthUsageProvider,
 } = require('../oauthUsage');
 
@@ -190,6 +191,20 @@ test('parseUsageResponse: セッションのみ・週間のみでも成立する
   assert.equal(wOnly.weekly.percent, 70.0);
 });
 
+// ── isStickyUsable（直近成功値のスティッキー表示判定）────────────────────────
+test('isStickyUsable: 有効な oauth スナップショットが期限内なら true', () => {
+  const snapshot = { source: 'oauth', session: { percent: 12, resetAtMs: null }, weekly: null, fetchedAtMs: NOW };
+  assert.equal(isStickyUsable(snapshot, NOW + 1000, 5000), true);
+});
+
+test('isStickyUsable: 期限超過・null・fetchedAtMs 欠落/非数値は false', () => {
+  const base = { source: 'oauth', session: { percent: 12, resetAtMs: null }, weekly: null, fetchedAtMs: NOW };
+  assert.equal(isStickyUsable(base, NOW + 5001, 5000), false);
+  assert.equal(isStickyUsable(null, NOW, 5000), false);
+  assert.equal(isStickyUsable({ source: 'oauth', session: null, weekly: null }, NOW, 5000), false);
+  assert.equal(isStickyUsable({ source: 'oauth', session: null, weekly: null, fetchedAtMs: '1000' }, NOW, 5000), false);
+});
+
 // ── createOauthUsageProvider（60s TTL キャッシュ・load 注入）─────────────────
 test('createOauthUsageProvider: TTL 内は load を 1 回しか呼ばず、TTL 超過で再取得する', async () => {
   let now = NOW;
@@ -221,4 +236,41 @@ test('createOauthUsageProvider: load の失敗（reject）は null に落ち、�
     load: async () => { throw new Error('network down'); },
   });
   assert.equal(await provider.get(), null);
+});
+
+test('createOauthUsageProvider: 一時失敗時は stickyMaxMs 以内だけ直近成功値を stale として返す', async () => {
+  let now = NOW;
+  let calls = 0;
+  const firstSnapshot = {
+    source: 'oauth',
+    session: { percent: 25, resetAtMs: NOW + 60 * 60 * 1000 },
+    weekly: null,
+    fetchedAtMs: NOW,
+  };
+  const provider = createOauthUsageProvider({
+    ttlMs: 1000,
+    stickyMaxMs: 5000,
+    clock: () => now,
+    load: async () => {
+      calls += 1;
+      return calls === 1 ? firstSnapshot : null;
+    },
+  });
+
+  const fresh = await provider.get();
+  assert.equal(fresh.source, 'oauth');
+  assert.equal(fresh.session.percent, 25);
+  assert.equal(fresh.stale, undefined);
+
+  now += 1001; // TTL 超過後の再取得が null でも stickyMaxMs 以内なら直近成功値を使う
+  const stale = await provider.get();
+  assert.equal(calls, 2);
+  assert.equal(stale.source, 'oauth');
+  assert.equal(stale.session.percent, 25);
+  assert.equal(stale.stale, true);
+
+  now = NOW + 5001; // stickyMaxMs 超過後はフォールバックへ渡すため null
+  const expired = await provider.get();
+  assert.equal(calls, 3);
+  assert.equal(expired, null);
 });


### PR DESCRIPTION
## 概要

設定モーダル「Claude使用状況」タブが、公式 usage API 由来の表示（現在のセッション% / 週間制限%）と、トランスクリプト集計のフォールバック表示（現在の5時間ブロック・ピーク比）の間で頻繁に切り替わり、表示が不安定になる問題を修正します。

公式取得が一時的に失敗しても、**直近に取得成功した公式スナップショットを最大15分だけ表示し続ける（スティッキー化）**ことで、フォールバックへの頻繁な切替（パタパタ）を防ぎます。

関連 issue: vektor-inc/vk-orchestrator#31 （https://github.com/vektor-inc/vk-orchestrator/issues/31 ）
※ issue は別リポジトリ（vk-orchestrator）のため、自動クローズはされません。マージ後に手動でクローズします。

## 原因

`main.js` の `getUsageUnified()` は `oauthUsage.get()` が非 null なら公式表示（`source:'oauth'`）を返し、null なら即トランスクリプト集計（`source:'transcript'`）へフォールバックします。`oauthUsage.js` の `createOauthUsageProvider` は 60 秒 TTL の `createTtlMemo` を使い**取得失敗（null）も 60 秒キャッシュ**するため、次のような一時的失敗が 1 回起きるだけで表示が最低 60 秒フォールバックへ落ち、パタパタしていました。

- アクセストークンの一時的な期限切れ（本モジュールは refreshToken を意図的に触らないため、Claude Code 本体が更新するまでの隙間で null になる）
- Keychain 許可ダイアログの拒否／未応答（未署名 Electron のため）
- オフライン・API タイムアウト（8s）・API 仕様変更

## 変更内容

- **`oauthUsage.js`**
  - 純粋関数 `isStickyUsable(snapshot, nowMs, maxMs)` を追加。`source:'oauth'` かつ `fetchedAtMs` を持つスナップショットで、経過時間が `[0, maxMs]` の範囲のときだけ `true`（未来時刻・巻き戻りクロック・期限超過は `false` で fail-closed）。
  - 定数 `STICKY_MAX_MS = 15 * 60 * 1000`（15分）を追加。
  - `createOauthUsageProvider` に直近成功スナップショット `lastGood` を保持。`get()` は「新規取得成功 → それを返して `lastGood` 更新」／「取得失敗かつ `isStickyUsable` → `{...lastGood, stale:true}` を返す」／「それ以外 → null（＝従来どおりトランスクリプト集計へフォールバック）」。
  - **refreshToken には一切触れません。** スティッキー化が保持するのは `parseUsageResponse` の正規化済み値（% / リセット時刻 ms / source）のみで、トークンをモジュール外に出さない既存のセキュリティ設計を維持しています。
- **`renderer/app.js`**
  - スティッキー表示中（`usage.stale === true`）は、oauth ブロックの**先頭**に注記を1行表示: 「直近に取得した値を表示しています（最新の取得に一時的に失敗しました）」。既存の `.usage-note` スタイルを流用（新規 CSS なし）。スクリーンリーダーが数値より先に前置きを読むよう、あえてブロック先頭に配置しています（a11y）。
- **`tests/oauthUsage.test.js`**: `isStickyUsable` と provider のスティッキー挙動のテストを追加。
- **`CHANGELOG.md`**: 不具合修正を1行追記。

## テスト（確認手順）

### 自動テスト

```bash
node --test tests/*.test.js
```
→ **pass 72 / fail 0**（うち `oauthUsage.test.js` は 21 件）。新規テストで次を検証:
- `isStickyUsable`: 期限内 `true` / `maxMs` 超過 `false` / `null` `false` / `fetchedAtMs` 欠落・非数値 `false`
- provider: 初回取得は非 stale の公式値 → 以降の取得が null でも `stickyMaxMs` 以内は `{...lastGood, stale:true}`（`source:'oauth'` 維持） → `stickyMaxMs` 超過で `null`

### 挙動の Before / After

- **Before**: 公式取得が一時失敗するたびに、表示が「現在のセッション% / 週間制限%」から「現在の5時間ブロック・ピーク比」へ切り替わり、失敗のたびにパタパタする（最低60秒フォールバックが固定）。
- **After**: 一時失敗時も直近の公式値を最大15分維持し、その間は「直近に取得した値を表示しています…」の注記を添える。15分を超えて失敗が続く場合のみ従来のトランスクリプト集計へフォールバックする。

### 手動確認の目安

このタブは公式 API の一時失敗時にのみフォールバックへ切り替わるため、通常操作では再現が難しい挙動です。動作は上記の自動テスト（注入した `clock` / `load` で成功→失敗→復帰を再現）で確認しています。実機で確認する場合は、一時的にネットワークを遮断（オフライン）→ 設定モーダルの「Claude使用状況」を開き、**表示が5時間ブロック表示へ切り替わらず、直近の公式% + 注記のまま**であること、オンライン復帰後に注記が消えることを確認してください。

理想の表示イメージは vektor-inc/vk-orchestrator#31 の添付画像（現在のセッション% / 週間制限%）を参照。

## 補足（このPR外の follow-up）

- 本修正は vk-terminals 側です。リリース後、`vk-orchestrator` の `npm run bump:terminals` で参照バージョンを更新する PR が別途必要です。
- 植草（UX）レビューの提案のうち「取得時刻（◯分前）の表示」は、経過時間のライブ更新が必要でスコープが広がるため今回は見送り、follow-up 候補としています（現注記で staleness は定性的に伝わるため）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 使用状況の表示が一時的な取得失敗で不安定に切り替わる問題を修正し、直近の取得値を一定時間維持して表示を安定化しました。
  * フォールバック中は、最新値ではないことが分かる注記を表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->