### PR TITLE
[ 機能追加 ] Claude Desktop 風のサイドバーメニューを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] Claude Desktop 風のサイドバーメニューを追加。設定項目・config.json の `menuItems`・HTTP API `POST /api/menu` から外部リンクや設定モーダル起動項目を表示可能に（[#80](https://github.com/vektor-inc/vk-terminals/issues/80)）
 - [ 不具合修正 ] Claude使用状況の公式表示が一時的な取得失敗のたびにトークン集計表示へ切り替わり不安定になる問題を修正（直近の公式値を一定時間保持してフォールバックへの頻繁な切替を防止）（[vektor-inc/vk-orchestrator#31](https://github.com/vektor-inc/vk-orchestrator/issues/31)）
 
 ## 1.8.1

--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,25 @@
   "initialCommand": "",
   "gpu": "off",
   "agentroom": false,
+  "_menuItemsNote": "menuItems に section 配列を入れるとサイドバーへ追加表示できます。action.type は open-url / open-settings のみ対応です。",
+  "menuItems": [],
+  "_menuItemsExample": [
+    {
+      "source": "config",
+      "title": "VK Orchestrator",
+      "items": [
+        {
+          "id": "task-queue",
+          "label": "task-queue",
+          "icon": "📋",
+          "action": {
+            "type": "open-url",
+            "url": "https://github.com/vektor-inc/task-queue/issues"
+          }
+        }
+      ]
+    }
+  ],
   "additionalPanes": [
     { "cwd": "/absolute/path/to/another/project" },
     { "cwd": "/absolute/path/to/plain/dir", "noClaude": true }

--- a/main.js
+++ b/main.js
@@ -1307,6 +1307,11 @@ function startHttpApi() {
           if (items.length === 0) {
             menuSources.delete(source);
           } else {
+            if (!menuSources.has(source) && menuSources.size >= MENU_MAX_SECTIONS) {
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: `too many menu sources (max ${MENU_MAX_SECTIONS})` }));
+              return;
+            }
             menuSources.set(source, r.section);
           }
           pushMenuUpdate();

--- a/main.js
+++ b/main.js
@@ -52,6 +52,204 @@ const SEND_ENTER_SPLIT_DELAY_MS = 150;
 let cachedStates = {};  // renderer から受け取った状態キャッシュ
 let httpServer = null;
 
+const MENU_ACTION_TYPES = new Set(['open-settings', 'open-url']);
+const MENU_MAX_SECTIONS = 20;
+const MENU_MAX_ITEMS = 50;
+const MENU_MAX_CHILDREN = 20;
+const MENU_MAX_TEXT = 200;
+const MENU_MAX_SOURCE = 100;
+const MENU_MAX_ICON = 8;
+const menuSources = new Map();
+
+function validateUrlField(raw, fieldName) {
+  if (raw === '' || raw == null) {
+    return { ok: true, value: '' };
+  }
+  if (typeof raw !== 'string') {
+    return { ok: false, error: `${fieldName} must be a string` };
+  }
+  if (raw.length > 2048) {
+    return { ok: false, error: `${fieldName} too long (max 2048 chars)` };
+  }
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(raw);
+  } catch (_e) {
+    return { ok: false, error: `invalid ${fieldName}` };
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    return { ok: false, error: `${fieldName} must be http(s)` };
+  }
+  return { ok: true, value: raw };
+}
+
+function isSafeMenuIcon(icon) {
+  if (typeof icon !== 'string') return false;
+  const value = icon.trim();
+  if (!value || value.length > MENU_MAX_ICON || /[<>&]/.test(value)) return false;
+  return /^(?:\p{Extended_Pictographic}(?:\uFE0F|\uFE0E)?)(?:\s?(?:\p{Extended_Pictographic}(?:\uFE0F|\uFE0E)?))?$/u.test(value);
+}
+
+function validateMenuItem(raw, source, depth, seenIds) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'menu item must be an object' };
+  }
+  if (typeof raw.id !== 'string' || !raw.id.trim()) {
+    return { ok: false, error: 'menu item id required' };
+  }
+  if (raw.id.length > MENU_MAX_TEXT) {
+    return { ok: false, error: 'menu item id too long' };
+  }
+  const itemKey = `${source}:${raw.id}`;
+  if (seenIds.has(itemKey)) {
+    return { ok: false, error: `duplicate menu item id "${raw.id}"` };
+  }
+  seenIds.add(itemKey);
+
+  if (typeof raw.label !== 'string' || !raw.label.trim()) {
+    return { ok: false, error: 'menu item label required' };
+  }
+  if (raw.label.length > MENU_MAX_TEXT) {
+    return { ok: false, error: 'menu item label too long' };
+  }
+
+  const item = {
+    id: raw.id.trim(),
+    label: raw.label,
+  };
+  if (raw.icon != null && raw.icon !== '') {
+    if (!isSafeMenuIcon(raw.icon)) {
+      return { ok: false, error: 'menu item icon must be emoji only' };
+    }
+    item.icon = raw.icon.trim();
+  }
+
+  if (raw.action != null) {
+    if (!raw.action || typeof raw.action !== 'object' || Array.isArray(raw.action)) {
+      return { ok: false, error: 'menu item action must be an object' };
+    }
+    if (!MENU_ACTION_TYPES.has(raw.action.type)) {
+      return { ok: false, error: `unsupported menu action "${raw.action.type}"` };
+    }
+    if (raw.action.type === 'open-settings') {
+      item.action = { type: 'open-settings' };
+    } else if (raw.action.type === 'open-url') {
+      const r = validateUrlField(raw.action.url, 'action.url');
+      if (!r.ok || !r.value) {
+        return { ok: false, error: r.error || 'action.url required' };
+      }
+      item.action = { type: 'open-url', url: r.value };
+    }
+  }
+
+  if (raw.children != null) {
+    if (!Array.isArray(raw.children)) {
+      return { ok: false, error: 'menu item children must be an array' };
+    }
+    if (depth >= 1) {
+      return { ok: false, error: 'menu item children depth exceeded' };
+    }
+    if (raw.children.length > MENU_MAX_CHILDREN) {
+      return { ok: false, error: `menu item children too many (max ${MENU_MAX_CHILDREN})` };
+    }
+    const children = [];
+    for (const child of raw.children) {
+      const r = validateMenuItem(child, source, depth + 1, seenIds);
+      if (!r.ok) return r;
+      children.push(r.item);
+    }
+    item.children = children;
+  }
+
+  return { ok: true, item };
+}
+
+function validateMenuSection(raw, options = {}) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'menu section must be an object' };
+  }
+  const sourceRaw = typeof raw.source === 'string' ? raw.source : options.defaultSource;
+  if (typeof sourceRaw !== 'string' || !sourceRaw.trim()) {
+    return { ok: false, error: 'source required' };
+  }
+  if (sourceRaw.length > MENU_MAX_SOURCE) {
+    return { ok: false, error: `source too long (max ${MENU_MAX_SOURCE} chars)` };
+  }
+  if (!Array.isArray(raw.items)) {
+    return { ok: false, error: 'items array required' };
+  }
+  if (raw.items.length > MENU_MAX_ITEMS) {
+    return { ok: false, error: `items too many (max ${MENU_MAX_ITEMS})` };
+  }
+  const source = sourceRaw.trim();
+  const section = { source, items: [] };
+  if (raw.title != null) {
+    if (typeof raw.title !== 'string') {
+      return { ok: false, error: 'title must be a string' };
+    }
+    if (raw.title.length > MENU_MAX_TEXT) {
+      return { ok: false, error: 'title too long' };
+    }
+    section.title = raw.title;
+  }
+
+  const seenIds = new Set();
+  for (const item of raw.items) {
+    const r = validateMenuItem(item, source, 0, seenIds);
+    if (!r.ok) return r;
+    section.items.push(r.item);
+  }
+  return { ok: true, section };
+}
+
+function getConfigMenuSections() {
+  const config = loadUserConfig();
+  const rawSections = Array.isArray(config.menuItems) ? config.menuItems : [];
+  if (!rawSections.length) return [];
+  if (rawSections.length > MENU_MAX_SECTIONS) {
+    console.error(`${LOG_PREFIX} config menuItems too many (max ${MENU_MAX_SECTIONS})`);
+    return [];
+  }
+  const sections = [];
+  for (const raw of rawSections) {
+    const r = validateMenuSection(raw, { defaultSource: 'config' });
+    if (!r.ok) {
+      console.error(`${LOG_PREFIX} invalid config menu item: ${r.error}`);
+      return [];
+    }
+    sections.push(r.section);
+  }
+  return sections;
+}
+
+function builtinMenuSection() {
+  return {
+    source: 'builtin',
+    items: [
+      {
+        id: 'settings',
+        label: '設定',
+        icon: '⚙',
+        action: { type: 'open-settings' },
+      },
+    ],
+  };
+}
+
+function mergedMenuSections() {
+  return [
+    ...getConfigMenuSections(),
+    ...Array.from(menuSources.values()),
+    builtinMenuSection(),
+  ];
+}
+
+function pushMenuUpdate() {
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('menu:update', mergedMenuSections());
+  }
+}
+
 /**
  * ユーザー設定を読み込む。
  * 読み込み順:
@@ -267,6 +465,9 @@ function createWindow() {
     title: 'VK Terminals',
   });
 
+  win.webContents.on('did-finish-load', () => {
+    pushMenuUpdate();
+  });
   win.loadFile('renderer/index.html');
   // win.webContents.openDevTools(); // uncomment to debug
 }
@@ -359,6 +560,7 @@ function builtinSettingsDescriptor() {
           // issue #70 でエージェントルーム（β）を一旦無効化するため設定項目を非表示にする。
           // 復帰時は下記コメントを解除する。
           // { key: 'agentroom',      label: 'エージェントルーム（β）表示', type: 'boolean' },
+          { key: 'menuItems', label: 'サイドバーメニュー (JSON 配列)', type: 'json', help: '例: [{"source":"config","title":"Links","items":[{"id":"issues","label":"Issues","icon":"📋","action":{"type":"open-url","url":"https://github.com/"}}]}]' },
           { key: 'additionalPanes', label: '追加ペイン (JSON 配列)', type: 'json',   help: '例: [{"cwd":"/path"}]' },
         ],
       },
@@ -720,6 +922,7 @@ function createAdditionalPane(cwd, options = {}) {
 // renderer 初期化完了 → config.additionalPanes に従って追加ペインを順次作成
 let additionalPanesCreated = false;
 ipcMain.on('terminal:renderer-ready', async () => {
+  pushMenuUpdate();
   if (additionalPanesCreated) return; // closePane で最後のペインを閉じて再 initApp された場合は再生成しない
   additionalPanesCreated = true;
   const config = loadUserConfig();
@@ -1082,6 +1285,41 @@ function startHttpApi() {
       return;
     }
 
+    // POST /api/menu  { source: "vk-orchestrator", title?: "...", items: [...] }
+    //   — サイドバーメニューを source 単位で置換する。items: [] は該当 source のクリア。
+    if (req.method === 'POST' && url.pathname === '/api/menu') {
+      if (isForbiddenOrigin(req)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'forbidden origin' }));
+        return;
+      }
+      const MAX_BODY = 10 * 1024;
+      readJsonBody(req, res, MAX_BODY, (body) => {
+        try {
+          const parsed = JSON.parse(body);
+          const r = validateMenuSection(parsed);
+          if (!r.ok) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: r.error }));
+            return;
+          }
+          const { source, items } = r.section;
+          if (items.length === 0) {
+            menuSources.delete(source);
+          } else {
+            menuSources.set(source, r.section);
+          }
+          pushMenuUpdate();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, source }));
+        } catch (e) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid JSON' }));
+        }
+      });
+      return;
+    }
+
     // POST /api/new-pane  { cwd?: "/path/to/dir", noClaude?: boolean } — 新規ペインを作成して termId を返す
     //   cwd を指定すればそのディレクトリで開く。未指定なら HOME で開く。
     //   noClaude: true を指定すると、新規ペインで claude を自動起動せず素のシェルとして開く。
@@ -1177,4 +1415,3 @@ function startHttpApi() {
 
   listen(apiHost);
 }
-

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -492,6 +492,7 @@ function openExternalUrlSafe(url) {
 // ─── Sidebar menu ────────────────────────────────────────────────────────────
 let sidebarMenuSections = [];
 let sidebarOpen = false;
+let sidebarTransitionCleanup = null;
 
 function isReducedMotion() {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
@@ -515,7 +516,9 @@ function createMenuIcon(icon) {
 function createMenuLabel(label) {
   const el = document.createElement('span');
   el.className = 'sidebar-menu-label';
-  el.textContent = typeof label === 'string' ? label : '';
+  const text = typeof label === 'string' ? label : '';
+  el.textContent = text;
+  if (text) el.title = text;
   return el;
 }
 
@@ -588,23 +591,36 @@ function renderSidebarMenu() {
   nav.replaceChildren();
   const inner = document.createElement('div');
   inner.className = 'sidebar-menu-inner';
-  const list = document.createElement('ul');
-  list.className = 'sidebar-menu-list';
 
-  for (const section of sidebarMenuSections) {
-    if (section?.title) {
-      const title = document.createElement('li');
-      title.className = 'sidebar-section-title';
-      title.textContent = section.title;
-      list.appendChild(title);
-    }
+  for (let sectionIndex = 0; sectionIndex < sidebarMenuSections.length; sectionIndex++) {
+    const section = sidebarMenuSections[sectionIndex];
+    const list = document.createElement('ul');
+    list.className = 'sidebar-menu-list';
     const items = Array.isArray(section?.items) ? section.items : [];
-    for (const item of items) {
-      list.appendChild(createMenuItem(item));
+
+    if (section?.title) {
+      const sectionEl = document.createElement('div');
+      sectionEl.className = 'sidebar-section';
+      const title = document.createElement('div');
+      const titleId = `sidebar-section-title-${sectionIndex}`;
+      title.className = 'sidebar-section-title';
+      title.id = titleId;
+      title.textContent = section.title;
+      list.setAttribute('aria-labelledby', titleId);
+      sectionEl.appendChild(title);
+      for (const item of items) {
+        list.appendChild(createMenuItem(item));
+      }
+      sectionEl.appendChild(list);
+      inner.appendChild(sectionEl);
+    } else {
+      for (const item of items) {
+        list.appendChild(createMenuItem(item));
+      }
+      inner.appendChild(list);
     }
   }
 
-  inner.appendChild(list);
   nav.appendChild(inner);
 }
 
@@ -633,6 +649,10 @@ function setSidebarOpen(open, options = {}) {
   const root = document.getElementById('root');
   const btn = document.getElementById('menu-btn');
   const nav = root ? ensureSidebarMenu(root) : null;
+  if (sidebarTransitionCleanup) {
+    sidebarTransitionCleanup();
+    sidebarTransitionCleanup = null;
+  }
   sidebarOpen = !!open;
   root?.classList.toggle('sidebar-open', sidebarOpen);
   btn?.setAttribute('aria-expanded', sidebarOpen ? 'true' : 'false');
@@ -652,14 +672,25 @@ function setSidebarOpen(open, options = {}) {
   }
 
   let done = false;
-  const onEnd = (event) => {
-    if (event.target !== nav || event.propertyName !== 'transform') return;
-    if (done) return;
+  let timeoutId = null;
+  const cleanup = () => {
     done = true;
     nav.removeEventListener('transitionend', onEnd);
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    if (sidebarTransitionCleanup === cleanup) sidebarTransitionCleanup = null;
+  };
+  const finish = () => {
+    if (done) return;
+    cleanup();
     afterLayout();
   };
+  const onEnd = (event) => {
+    if (event.target !== nav || event.propertyName !== 'transform') return;
+    finish();
+  };
+  sidebarTransitionCleanup = cleanup;
   nav.addEventListener('transitionend', onEnd);
+  timeoutId = setTimeout(finish, 220);
 }
 
 function setupSidebarMenu() {

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -489,6 +489,197 @@ function openExternalUrlSafe(url) {
   }
 }
 
+// ─── Sidebar menu ────────────────────────────────────────────────────────────
+let sidebarMenuSections = [];
+let sidebarOpen = false;
+
+function isReducedMotion() {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+}
+
+function isSafeMenuIcon(icon) {
+  if (typeof icon !== 'string') return false;
+  const value = icon.trim();
+  if (!value || value.length > 8 || /[<>&]/.test(value)) return false;
+  return /^(?:\p{Extended_Pictographic}(?:\uFE0F|\uFE0E)?)(?:\s?(?:\p{Extended_Pictographic}(?:\uFE0F|\uFE0E)?))?$/u.test(value);
+}
+
+function createMenuIcon(icon) {
+  const el = document.createElement('span');
+  el.className = 'sidebar-menu-icon';
+  el.setAttribute('aria-hidden', 'true');
+  el.textContent = isSafeMenuIcon(icon) ? icon.trim() : '';
+  return el;
+}
+
+function createMenuLabel(label) {
+  const el = document.createElement('span');
+  el.className = 'sidebar-menu-label';
+  el.textContent = typeof label === 'string' ? label : '';
+  return el;
+}
+
+function runMenuAction(action) {
+  if (!action || typeof action !== 'object') return;
+  if (action.type === 'open-settings') {
+    openSettingsModal();
+    return;
+  }
+  if (action.type === 'open-url') {
+    openExternalUrlSafe(action.url);
+  }
+}
+
+function createMenuActionElement(item) {
+  const action = item && typeof item.action === 'object' ? item.action : null;
+  let el;
+  if (action?.type === 'open-url' && isSafeExternalUrl(action.url)) {
+    el = document.createElement('a');
+    el.className = 'sidebar-menu-link';
+    el.href = '#';
+    el.addEventListener('click', (event) => {
+      event.preventDefault();
+      runMenuAction(action);
+    });
+  } else if (action?.type === 'open-settings') {
+    el = document.createElement('button');
+    el.className = 'sidebar-menu-button';
+    el.type = 'button';
+    el.addEventListener('click', () => runMenuAction(action));
+  } else {
+    el = document.createElement('span');
+    el.className = 'sidebar-menu-text';
+  }
+  el.appendChild(createMenuIcon(item.icon));
+  el.appendChild(createMenuLabel(item.label));
+  return el;
+}
+
+function createMenuItem(item) {
+  const li = document.createElement('li');
+  li.className = 'sidebar-menu-item';
+  const children = Array.isArray(item?.children) ? item.children : [];
+  if (children.length) {
+    const details = document.createElement('details');
+    details.className = 'sidebar-submenu';
+    const summary = document.createElement('summary');
+    summary.className = 'sidebar-menu-summary';
+    summary.appendChild(createMenuIcon(item.icon));
+    summary.appendChild(createMenuLabel(item.label));
+    details.appendChild(summary);
+
+    const childList = document.createElement('ul');
+    childList.className = 'sidebar-submenu-list';
+    for (const child of children) {
+      childList.appendChild(createMenuItem(child));
+    }
+    details.appendChild(childList);
+    li.appendChild(details);
+    return li;
+  }
+
+  li.appendChild(createMenuActionElement(item || {}));
+  return li;
+}
+
+function renderSidebarMenu() {
+  const nav = document.getElementById('sidebar-menu');
+  if (!nav) return;
+  nav.replaceChildren();
+  const inner = document.createElement('div');
+  inner.className = 'sidebar-menu-inner';
+  const list = document.createElement('ul');
+  list.className = 'sidebar-menu-list';
+
+  for (const section of sidebarMenuSections) {
+    if (section?.title) {
+      const title = document.createElement('li');
+      title.className = 'sidebar-section-title';
+      title.textContent = section.title;
+      list.appendChild(title);
+    }
+    const items = Array.isArray(section?.items) ? section.items : [];
+    for (const item of items) {
+      list.appendChild(createMenuItem(item));
+    }
+  }
+
+  inner.appendChild(list);
+  nav.appendChild(inner);
+}
+
+function createSidebarMenu() {
+  const nav = document.createElement('nav');
+  nav.id = 'sidebar-menu';
+  nav.className = 'sidebar-menu';
+  nav.setAttribute('aria-label', 'メインメニュー');
+  return nav;
+}
+
+function ensureSidebarMenu(root) {
+  const existing = root.querySelector('#sidebar-menu');
+  const nav = existing || createSidebarMenu();
+  if (!existing) renderSidebarMenu();
+  return nav;
+}
+
+function focusFirstSidebarItem() {
+  const nav = document.getElementById('sidebar-menu');
+  const first = nav?.querySelector('a, button, summary');
+  if (first && typeof first.focus === 'function') first.focus();
+}
+
+function setSidebarOpen(open, options = {}) {
+  const root = document.getElementById('root');
+  const btn = document.getElementById('menu-btn');
+  const nav = root ? ensureSidebarMenu(root) : null;
+  sidebarOpen = !!open;
+  root?.classList.toggle('sidebar-open', sidebarOpen);
+  btn?.setAttribute('aria-expanded', sidebarOpen ? 'true' : 'false');
+
+  const afterLayout = () => {
+    fitAll();
+    if (sidebarOpen && options.focusFirst !== false) {
+      focusFirstSidebarItem();
+    } else if (!sidebarOpen && options.focusToggle) {
+      btn?.focus();
+    }
+  };
+
+  if (!nav || isReducedMotion()) {
+    requestAnimationFrame(afterLayout);
+    return;
+  }
+
+  let done = false;
+  const onEnd = (event) => {
+    if (event.target !== nav || event.propertyName !== 'transform') return;
+    if (done) return;
+    done = true;
+    nav.removeEventListener('transitionend', onEnd);
+    afterLayout();
+  };
+  nav.addEventListener('transitionend', onEnd);
+}
+
+function setupSidebarMenu() {
+  const root = document.getElementById('root');
+  if (root) ensureSidebarMenu(root);
+  const btn = document.getElementById('menu-btn');
+  if (btn) {
+    btn.addEventListener('click', () => setSidebarOpen(!sidebarOpen, { focusFirst: true }));
+  }
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape' || !sidebarOpen) return;
+    event.preventDefault();
+    setSidebarOpen(false, { focusToggle: true });
+  });
+  ipcRenderer.on('menu:update', (_event, sections) => {
+    sidebarMenuSections = Array.isArray(sections) ? sections : [];
+    renderSidebarMenu();
+  });
+}
+
 // .pane-task-title 要素の中身を、URL の有無に応じて
 // プレーンテキスト or <a>（外部リンクマーク付き）で再構築する。
 //   - URL 無し: テキストノードのみ（従来通り、見た目は完全互換）
@@ -941,9 +1132,10 @@ function fitAll() {
 // ─── Rendering ────────────────────────────────────────────────────────────────
 function render() {
   const root = document.getElementById('root');
+  const sidebar = ensureSidebarMenu(root);
   const newContent = renderGrid(tree);
-  root.innerHTML = '';
-  root.appendChild(newContent);
+  root.replaceChildren(sidebar, newContent);
+  root.classList.toggle('sidebar-open', sidebarOpen);
 
   // Reattach terminal elements (moved, not recreated)
   getAllLeafIds(tree).forEach(paneId => {
@@ -1984,6 +2176,9 @@ async function initApp() {
     terminals[paneId]?.term.focus();
   });
 }
+
+// サイドバーは root の flex 子として常駐させるため、初回 render 前に配線する。
+setupSidebarMenu();
 
 initApp().then(() => {
   // 起動完了を main プロセスに通知（main 側で additionalPanes を順次作成する）

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
   <div class="titlebar">
+    <button id="menu-btn" class="titlebar-menu-btn" type="button" aria-label="メニュー" aria-expanded="false" aria-controls="sidebar-menu" title="メニュー">☰</button>
     <span class="app-title">VK Terminals</span>
     <!-- 歯車は常時表示（issue #73）。使用状況ビューは設定ディスクリプタの有無に
          かかわらず開けるため、hidden にしない。使用率 80% 超過時は app.js が

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -66,6 +66,31 @@ html, body {
   color: #e6edf3;
 }
 
+.titlebar-menu-btn {
+  grid-column: 1;
+  justify-self: start;
+  -webkit-app-region: no-drag;
+  width: 32px;
+  height: 32px;
+  margin-left: 76px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #8b949e;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+.titlebar-menu-btn:hover,
+.titlebar-menu-btn:focus-visible {
+  background: #21262d;
+  color: #e6edf3;
+}
+.titlebar-menu-btn:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+
 /* 歯車ボタンの警告ドットバッジ（issue #73）。
    公式の使用率（セッション・週間のいずれか）が 80% を超えたときだけ app.js が
    .usage-alert-warn（80〜90%: アンバー）/ .usage-alert-crit（90%〜: 赤）を付与する。
@@ -369,6 +394,103 @@ html, body {
   right: 0;
   bottom: 0;
   display: flex;
+  overflow: hidden;
+}
+
+/* ─── Sidebar menu ─────────────────────────────────────────────────────────── */
+.sidebar-menu {
+  flex: 0 0 0;
+  width: 252px;
+  min-width: 0;
+  height: 100%;
+  overflow: hidden auto;
+  transform: translateX(-100%);
+  transition: flex-basis 0.18s ease, transform 0.18s ease;
+  z-index: 900;
+  background: #0d1117;
+  border-right: 1px solid #21262d;
+  color: #e6edf3;
+}
+#root.sidebar-open .sidebar-menu {
+  flex-basis: 252px;
+  transform: translateX(0);
+}
+.sidebar-menu-inner {
+  width: 252px;
+  padding: 10px 8px;
+}
+.sidebar-menu-list,
+.sidebar-submenu-list {
+  list-style: none;
+}
+.sidebar-section-title {
+  padding: 10px 8px 5px;
+  color: #8b949e;
+  font-size: 11px;
+  font-weight: 600;
+}
+.sidebar-menu-item {
+  margin: 2px 0;
+}
+.sidebar-menu-link,
+.sidebar-menu-button,
+.sidebar-menu-text,
+.sidebar-menu-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #c9d1d9;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: left;
+  text-decoration: none;
+}
+.sidebar-menu-link,
+.sidebar-menu-button,
+.sidebar-menu-summary {
+  cursor: pointer;
+}
+.sidebar-menu-link:hover,
+.sidebar-menu-button:hover,
+.sidebar-menu-summary:hover {
+  background: #21262d;
+  color: #e6edf3;
+}
+.sidebar-menu-link:focus-visible,
+.sidebar-menu-button:focus-visible,
+.sidebar-menu-summary:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+.sidebar-menu-icon {
+  flex: 0 0 20px;
+  width: 20px;
+  text-align: center;
+}
+.sidebar-menu-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sidebar-submenu {
+  margin: 2px 0;
+}
+.sidebar-submenu-list {
+  margin-left: 20px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-menu {
+    transition: none;
+  }
 }
 
 /* ─── Grid container ───────────────────────────────────────────────────────── */


### PR DESCRIPTION
## 概要

Claude Desktop のようなサイドバーメニューを追加します（issue #80）。タイトルバー左端のトグルボタン `☰` で開閉でき、開くとターミナルを右に押し出すプッシュ型 Drawer です。メニュー項目は JSON で受け渡し、次の3系統からマージして表示します。

- **ビルトイン**: 「設定」項目（既存の設定モーダルを開く）
- **`config.json` の `menuItems`**: ユーザーが静的に定義する外部リンク等
- **HTTP API `POST /api/menu`**: VK Orchestrator など外部プロセスからの動的注入（`source` 単位で置換、空 `items` でクリア）

Close #80

## 主な変更

- `renderer/index.html`: タイトルバー左レーンにトグルボタン `☰` を追加（`aria-expanded` / `aria-controls`）
- `renderer/app.js`: サイドバー描画・開閉状態管理・アクション実行（`open-settings` / `open-url`）・`menu:update` 受信。外部由来のラベル/アイコンは `createElement`+`textContent` で描画（XSS 対策）
- `renderer/style.css`: プッシュ型 Drawer のスタイル（`flex-basis` 0↔252px + `transform`、`prefers-reduced-motion` 対応）
- `main.js`: `POST /api/menu` エンドポイントとメニュー検証群（CSRF・サイズ上限・action.type allowlist・URL の http/https 検証・件数/深さ/長さ上限・source 数上限）、3系統のマージと `menu:update` push
- `config.example.json`: `menuItems` の記述例を追記
- `CHANGELOG.md`: 機能追加を追記

## メニュー項目 JSON スキーマ

```jsonc
{
  "source": "vk-orchestrator",   // 注入元の識別子（置換・クリアの単位）
  "title": "VK Orchestrator",    // セクション見出し（任意）
  "items": [
    {
      "id": "task-queue",
      "label": "task-queue",
      "icon": "📋",               // 絵文字のみ（HTML/SVG 不可）
      "action": { "type": "open-url", "url": "https://github.com/vektor-inc/task-queue/issues" }
    }
  ]
}
```

- `action.type` は `open-settings`（設定モーダルを開く）と `open-url`（http/https のみ、外部ブラウザで開く）の2種のみ。それ以外は 400 で拒否
- `children` で1階層のサブメニュー（`<details>/<summary>`）まで

## テスト（確認手順）

前提: リポジトリのルートで `npm install` 済み。macOS を想定。

### 1. サイドバーの開閉（プッシュ型 Drawer）
1. `npm start` でアプリを起動する
2. タイトルバー左端の `☰` ボタンをクリックする
   → 左からサイドバーがスライドして開き、**ターミナルグリッドが右に押し出される**（重ならない）。サイドバーには「⚙ 設定」項目が表示される
3. もう一度 `☰` をクリックする
   → サイドバーが閉じ、**幅0**になってターミナルが全幅を取り戻す。開閉後もターミナルの表示が崩れない（再フィットされる）
4. サイドバーを開いた状態で `Esc` キーを押す
   → サイドバーが閉じ、フォーカスが `☰` ボタンに戻る

### 2. 「設定」項目
1. サイドバーを開き「設定」項目をクリックする
   → 既存の設定モーダル（`openSettingsModal`）が開く（タイトルバー右の歯車 `⚙` と同じ挙動）

### 3. `config.json` からの静的メニュー項目
1. `config.json`（未作成なら作成）に以下を追加する
   ```json
   "menuItems": [
     { "source": "config", "title": "Links",
       "items": [ { "id": "gh", "label": "GitHub", "icon": "🐙",
         "action": { "type": "open-url", "url": "https://github.com/vektor-inc" } } ] }
   ]
   ```
2. `npm start` で起動し、サイドバーを開く
   → 「Links」見出しの下に「🐙 GitHub」項目が表示される
3. 「GitHub」項目をクリックする
   → OS 既定ブラウザで https://github.com/vektor-inc が開く

### 4. HTTP API からの動的注入（VK Orchestrator 相当）
1. アプリを起動した状態で、別ターミナルから以下を実行する（API ポートは既定 13847）
   ```bash
   curl -X POST http://127.0.0.1:13847/api/menu \
     -H 'Content-Type: application/json' \
     -d '{"source":"vk-orchestrator","title":"VK Orchestrator","items":[{"id":"task-queue","label":"task-queue","icon":"📋","action":{"type":"open-url","url":"https://github.com/vektor-inc/task-queue/issues"}}]}'
   ```
   → `{"ok":true,"source":"vk-orchestrator"}` が返り、サイドバーに「VK Orchestrator」見出しと「📋 task-queue」項目が**リアルタイムで追加**される
2. 「task-queue」をクリックする
   → OS 既定ブラウザで task-queue の issue 一覧が開く
3. クリアを確認: `items` を空配列にして同じ `source` で POST する
   ```bash
   curl -X POST http://127.0.0.1:13847/api/menu -H 'Content-Type: application/json' \
     -d '{"source":"vk-orchestrator","items":[]}'
   ```
   → 「VK Orchestrator」セクションがサイドバーから消える

### 5. セキュリティ（拒否系の確認）
1. `javascript:` スキームは拒否されること
   ```bash
   curl -X POST http://127.0.0.1:13847/api/menu -H 'Content-Type: application/json' \
     -d '{"source":"x","items":[{"id":"a","label":"a","action":{"type":"open-url","url":"javascript:alert(1)"}}]}'
   ```
   → 400（`action.url must be http(s)` 等）が返り、メニューに追加されない
2. 未対応の action.type は拒否されること（`{"action":{"type":"send-command",...}}` → 400）

### デグレ確認
- 既存のターミナルペインの表示・分割・リサイズ、タイトルバー右の歯車 `⚙`（設定モーダル・使用状況ビュー）が従来どおり動作すること
- `npm test`（`node --test tests/`）が通ること（本ブランチで72件パスを確認済み）

## 補足

- 表示・UI 変更を含むため Before/After のスクリーンショット/GIF が望ましいですが、自動実行環境のため未添付です。動作確認（麗美による e2e/UI テスト）の結果を別途コメントで共有します。必要に応じて実機キャプチャを追補してください。
- `send-command` 等の高権限アクション・モバイル最適化は今回スコープ外（フェーズ3以降）。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/288