### PR TITLE
[ 不具合修正 ] 依存として組み込むと postinstall の electron-rebuild がホイスティングで ENOENT になる不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 不具合修正 ] vk-terminals を依存として組み込んだ際、npm ホイスティングでネストした node_modules に electron-rebuild が無く postinstall が ENOENT で失敗する不具合を修正（bin 解決を上方探索で堅牢化）（[#82](https://github.com/vektor-inc/vk-terminals/issues/82)）
+
 ## 1.9.0
 
 - [ 機能追加 ] Claude Desktop 風のサイドバーメニューを追加。設定項目・config.json の `menuItems`・HTTP API `POST /api/menu` から外部リンクや設定モーダル起動項目を表示可能に（[#80](https://github.com/vektor-inc/vk-terminals/issues/80)）

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -161,18 +161,26 @@ function logMissingElectronRebuildBin(searchedPaths) {
   }
 }
 
+const loggedMissingElectronRebuildBins = new WeakSet();
+
+function logMissingElectronRebuildBinOnce(resolvedBin) {
+  if (resolvedBin.found || loggedMissingElectronRebuildBins.has(resolvedBin)) {
+    return;
+  }
+
+  loggedMissingElectronRebuildBins.add(resolvedBin);
+  logMissingElectronRebuildBin(resolvedBin.searchedPaths);
+}
+
 /**
  * electron-rebuild を実行する。CXXFLAGS を追加指定したい場合は cxxflags を渡す。
  * 戻り値は spawnSync の結果（status に終了コードが入る）。
  */
-function runElectronRebuild(cxxflags) {
-  const resolvedBin = resolveElectronRebuildBinDetails();
+function runElectronRebuild(cxxflags, resolvedBin = resolveElectronRebuildBinDetails()) {
   const bin = resolvedBin.bin;
   const env = Object.assign({}, process.env);
 
-  if (!resolvedBin.found) {
-    logMissingElectronRebuildBin(resolvedBin.searchedPaths);
-  }
+  logMissingElectronRebuildBinOnce(resolvedBin);
 
   if (cxxflags) {
     // 既存の CXXFLAGS があれば前置きして温存する（元のシェル実装と同じ挙動）。
@@ -219,14 +227,15 @@ function main() {
   // macOS のみ、Command Line Tools の libc++ ヘッダを CXXFLAGS に付与して試す。
   // Windows / Linux では最初から追加フラグなしでビルドする。
   const cxxflags = process.platform === 'darwin' ? getMacCxxFlagsInclude() : null;
+  const resolvedBin = resolveElectronRebuildBinDetails();
 
-  let result = runElectronRebuild(cxxflags);
+  let result = runElectronRebuild(cxxflags, resolvedBin);
   logSpawnError(result);
 
   // CXXFLAGS 付きでの実行が失敗した場合（未検出時含む）、CXXFLAGS なしで再試行する。
   // 元のシェル実装（`... || electron-rebuild -f -w node-pty`）のフォールバックを踏襲。
   if (result.status !== 0 && cxxflags) {
-    result = runElectronRebuild(null);
+    result = runElectronRebuild(null, resolvedBin);
     logSpawnError(result);
   }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -84,9 +84,81 @@ function compareSdkVersions(a, b) {
  * node_modules/.bin 配下の electron-rebuild 実行ファイルの絶対パスを返す。
  * Windows では拡張子 .cmd 付きの wrapper が生成されるため、プラットフォームで拡張子を切り替える。
  */
-function resolveElectronRebuildBin() {
-  const binName = process.platform === 'win32' ? 'electron-rebuild.cmd' : 'electron-rebuild';
-  return path.join(__dirname, '..', 'node_modules', '.bin', binName);
+function getElectronRebuildBinName(platform = process.platform) {
+  return platform === 'win32' ? 'electron-rebuild.cmd' : 'electron-rebuild';
+}
+
+/**
+ * startDir から親方向へ、electron-rebuild の npm bin が置かれうるパスを列挙する。
+ */
+function getElectronRebuildBinCandidates(startDir = __dirname, platform = process.platform) {
+  const binName = getElectronRebuildBinName(platform);
+  const candidates = [];
+  const seen = new Set();
+  let currentDir = path.resolve(startDir);
+
+  const addCandidate = (candidate) => {
+    const normalized = path.normalize(candidate);
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      candidates.push(normalized);
+    }
+  };
+
+  while (true) {
+    addCandidate(path.join(currentDir, 'node_modules', '.bin', binName));
+
+    const parentDir = path.dirname(currentDir);
+    if (path.basename(currentDir) === 'node_modules') {
+      addCandidate(path.join(currentDir, '.bin', binName));
+    }
+    if (path.basename(parentDir) === 'node_modules') {
+      addCandidate(path.join(parentDir, '.bin', binName));
+    }
+
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  return candidates;
+}
+
+/**
+ * electron-rebuild の解決結果と探索したパスを返す。
+ * 見つからない場合は PATH 解決に委ねるため、binName のみを返す。
+ */
+function resolveElectronRebuildBinDetails(startDir = __dirname, platform = process.platform) {
+  const binName = getElectronRebuildBinName(platform);
+  const searchedPaths = getElectronRebuildBinCandidates(startDir, platform);
+  const foundPath = searchedPaths.find((candidate) => fs.existsSync(candidate));
+
+  if (foundPath) {
+    return {
+      bin: foundPath,
+      found: true,
+      searchedPaths,
+    };
+  }
+
+  return {
+    bin: binName,
+    found: false,
+    searchedPaths,
+  };
+}
+
+function resolveElectronRebuildBin(startDir = __dirname) {
+  return resolveElectronRebuildBinDetails(startDir).bin;
+}
+
+function logMissingElectronRebuildBin(searchedPaths) {
+  console.error('[postinstall] electron-rebuild の npm bin が見つかりませんでした。PATH 上の electron-rebuild にフォールバックします。');
+  console.error('[postinstall] 探索したパス:');
+  for (const searchedPath of searchedPaths) {
+    console.error(`[postinstall] - ${searchedPath}`);
+  }
 }
 
 /**
@@ -94,8 +166,13 @@ function resolveElectronRebuildBin() {
  * 戻り値は spawnSync の結果（status に終了コードが入る）。
  */
 function runElectronRebuild(cxxflags) {
-  const bin = resolveElectronRebuildBin();
+  const resolvedBin = resolveElectronRebuildBinDetails();
+  const bin = resolvedBin.bin;
   const env = Object.assign({}, process.env);
+
+  if (!resolvedBin.found) {
+    logMissingElectronRebuildBin(resolvedBin.searchedPaths);
+  }
 
   if (cxxflags) {
     // 既存の CXXFLAGS があれば前置きして温存する（元のシェル実装と同じ挙動）。
@@ -158,4 +235,19 @@ function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  compareSdkVersions,
+  getElectronRebuildBinCandidates,
+  getElectronRebuildBinName,
+  getMacCxxFlagsInclude,
+  logMissingElectronRebuildBin,
+  logSpawnError,
+  main,
+  resolveElectronRebuildBin,
+  resolveElectronRebuildBinDetails,
+  runElectronRebuild,
+};

--- a/tests/postinstall.test.js
+++ b/tests/postinstall.test.js
@@ -6,7 +6,12 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { resolveElectronRebuildBin } = require('../scripts/postinstall');
+const {
+  getElectronRebuildBinCandidates,
+  getElectronRebuildBinName,
+  resolveElectronRebuildBin,
+  resolveElectronRebuildBinDetails,
+} = require('../scripts/postinstall');
 
 test('resolveElectronRebuildBin: hoisted electron-rebuild bin を親 node_modules/.bin から解決する', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-postinstall-'));
@@ -31,6 +36,72 @@ test('resolveElectronRebuildBin: hoisted electron-rebuild bin を親 node_module
 
     assert.equal(resolved, hoistedBin);
     assert.equal(fs.existsSync(resolved), true);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('resolveElectronRebuildBinDetails: bin が見つからない場合は PATH 解決用の裸の bin 名を返す', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-postinstall-'));
+
+  try {
+    const startDir = path.join(tempDir, 'app', 'node_modules', 'vk-terminals', 'scripts');
+    fs.mkdirSync(startDir, { recursive: true });
+
+    const resolved = resolveElectronRebuildBinDetails(startDir);
+
+    assert.equal(resolved.found, false);
+    assert.equal(resolved.bin, getElectronRebuildBinName());
+    assert.equal(resolved.searchedPaths.length > 0, true);
+    assert.equal(
+      resolved.searchedPaths.some((candidate) => fs.existsSync(candidate)),
+      false
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('getElectronRebuildBinName: Windows では .cmd wrapper を返す', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-postinstall-'));
+
+  try {
+    const startDir = path.join(tempDir, 'app', 'node_modules', 'vk-terminals', 'scripts');
+    fs.mkdirSync(startDir, { recursive: true });
+
+    assert.equal(getElectronRebuildBinName('win32'), 'electron-rebuild.cmd');
+    assert.equal(getElectronRebuildBinName('darwin'), 'electron-rebuild');
+
+    const candidates = getElectronRebuildBinCandidates(startDir, 'win32');
+
+    assert.equal(candidates.length > 0, true);
+    assert.equal(
+      candidates.some((candidate) => candidate.endsWith('electron-rebuild.cmd')),
+      true
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('getElectronRebuildBinCandidates: 深い startDir でも有限個の候補を返して終了する', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-postinstall-'));
+
+  try {
+    const segments = Array.from({ length: 40 }, (_, index) => `deep-${index}`);
+    const startDir = path.join(tempDir, ...segments);
+    fs.mkdirSync(startDir, { recursive: true });
+
+    const candidates = getElectronRebuildBinCandidates(startDir);
+
+    assert.equal(Array.isArray(candidates), true);
+    assert.equal(Number.isFinite(candidates.length), true);
+    assert.equal(candidates.length > 0, true);
+    assert.equal(candidates.length < 100, true);
+    assert.equal(
+      candidates[candidates.length - 1],
+      path.join(path.parse(startDir).root, 'node_modules', '.bin', getElectronRebuildBinName())
+    );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tests/postinstall.test.js
+++ b/tests/postinstall.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { resolveElectronRebuildBin } = require('../scripts/postinstall');
+
+test('resolveElectronRebuildBin: hoisted electron-rebuild bin を親 node_modules/.bin から解決する', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-postinstall-'));
+
+  try {
+    const appDir = path.join(tempDir, 'app');
+    const packageDir = path.join(appDir, 'node_modules', 'vk-terminals');
+    const scriptsDir = path.join(packageDir, 'scripts');
+    const hoistedBinDir = path.join(appDir, 'node_modules', '.bin');
+    const binName = process.platform === 'win32' ? 'electron-rebuild.cmd' : 'electron-rebuild';
+    const hoistedBin = path.join(hoistedBinDir, binName);
+    const nestedBin = path.join(packageDir, 'node_modules', '.bin', binName);
+
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    fs.mkdirSync(hoistedBinDir, { recursive: true });
+    fs.writeFileSync(hoistedBin, '#!/bin/sh\n');
+
+    assert.equal(fs.existsSync(hoistedBin), true);
+    assert.equal(fs.existsSync(nestedBin), false);
+
+    const resolved = resolveElectronRebuildBin(scriptsDir);
+
+    assert.equal(resolved, hoistedBin);
+    assert.equal(fs.existsSync(resolved), true);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/postinstall.test.js
+++ b/tests/postinstall.test.js
@@ -21,7 +21,7 @@ test('resolveElectronRebuildBin: hoisted electron-rebuild bin を親 node_module
     const packageDir = path.join(appDir, 'node_modules', 'vk-terminals');
     const scriptsDir = path.join(packageDir, 'scripts');
     const hoistedBinDir = path.join(appDir, 'node_modules', '.bin');
-    const binName = process.platform === 'win32' ? 'electron-rebuild.cmd' : 'electron-rebuild';
+    const binName = getElectronRebuildBinName();
     const hoistedBin = path.join(hoistedBinDir, binName);
     const nestedBin = path.join(packageDir, 'node_modules', '.bin', binName);
 


### PR DESCRIPTION
## 概要

vk-terminals を **他プロジェクトの依存として組み込んだ場合**、`scripts/postinstall.js` の electron-rebuild 実行が `ENOENT` で失敗する不具合を修正します（[#82](https://github.com/vektor-inc/vk-terminals/issues/82)）。

`@electron/rebuild` は npm のホイスティングで**親（トップレベル）の `node_modules/.bin`** に上がるのに対し、修正前の `resolveElectronRebuildBin()` は `__dirname`（= `.../node_modules/vk-terminals/scripts`）起点でネストした `node_modules/.bin` の固定パスしか見ていませんでした。optional 依存としてインストールされた場合、postinstall の失敗を npm が黙って除外するため「入ったつもりで入っていない（node-pty が未ビルド）」状態になり、vk-orchestrator の `npm start` で発現していました。

## 原因

`scripts/postinstall.js` の `resolveElectronRebuildBin()` がネスト固定パス（`__dirname/../node_modules/.bin/electron-rebuild`）を返すため、ホイスティングで bin が親に上がる構成では常に不在パスを掴んでいた。

```
node_modules/.bin/electron-rebuild                          ← 実在（親に上がる）
node_modules/vk-terminals/node_modules/.bin/electron-rebuild ← 不在 → ENOENT
```

## 変更点

- `scripts/postinstall.js`
  - bin 解決を、起点ディレクトリから **親方向へ `node_modules/.bin/electron-rebuild(.cmd)` を上方探索**し、最初に実在したものを返す方式に変更（`getElectronRebuildBinCandidates` / `resolveElectronRebuildBinDetails`）。ホイスト先の親 `.bin` を正しく拾えるようになる。
  - どの候補にも無ければ **PATH 上の `electron-rebuild` にフォールバック**し、その際に **探索したパス一覧をログ出力**して切り分けを容易化。
  - Windows の `.cmd` 拡張子分岐・`spawnSync` の shell 分岐・CXXFLAGS 処理は従来どおり維持。
  - テスト可能にするため末尾の `main()` 呼び出しを `if (require.main === module)` でガードし、関数を `module.exports`。require 時にネイティブビルドが走る副作用も併せて解消。
- `tests/postinstall.test.js`（新規）
  - ホイスト配置での親 `.bin` 解決 / 未検出時の PATH フォールバック / Windows `.cmd` 名 / 深い起点でも有限終了、の回帰テストを追加。
- `CHANGELOG.md`
  - `[ 不具合修正 ]` を1件追記。

## テスト（確認手順）

前提: リポジトリのルートで `node` が使えること（本テストは Node 標準テストランナーのみで node_modules 不要）。

### 自動テスト

1. 本ブランチをチェックアウトする。
2. リポジトリルートで `npm test`（= `node --test tests/`）を実行する。
   - → 全テストが pass する（`# pass 76` / `# fail 0`）。うち `tests/postinstall.test.js` の 4 ケースが本修正の対象。

### Before（修正前の再現）

1. `git stash` 等で `scripts/postinstall.js` を修正前の状態に戻す（または修正前コミットで確認）。
2. `node --test tests/postinstall.test.js` を実行する。
   - → 「hoisted electron-rebuild bin を親 node_modules/.bin から解決する」テストが **FAIL**（ネスト固定パスを返し、実在する親 `.bin` に解決できない）。
   - 実環境での再現: `@electron/rebuild` を親に持つ別プロジェクトの依存として vk-terminals を入れると、postinstall が `spawnSync .../vk-terminals/node_modules/.bin/electron-rebuild ENOENT` で失敗する。

### After（修正後の確認）

1. 本ブランチの状態で `node --test tests/postinstall.test.js` を実行する。
   - → 4 ケースすべて **pass**。上方探索で親 `.bin` の実在 bin を解決する。
2. 依存として組み込む構成での確認（任意・実環境）: vk-orchestrator など `@electron/rebuild` を親に持つプロジェクトで vk-terminals を導入し、`npm install` の postinstall が ENOENT で落ちず node-pty がビルドされること。bin が全く無い環境では ENOENT の代わりに「探索したパス一覧」がログ出力される。

### デグレ確認

- 単体開発時（nested に bin がある構成）でも従来どおり bin を解決できること（`npm test` 全 pass で担保）。
- Windows（`.cmd` 分岐）・CXXFLAGS フォールバック・shell 分岐の挙動は変更なし。

## 補足

issue に外部ユーザーから ZIP 添付のパッチ提案がありましたが、信頼できない入力として取り込まず、自前で設計・実装しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - ホイストされた依存関係環境でも `postinstall` が失敗しにくくなり、必要な実行ファイルの解決がより堅牢になりました。
  - 解決結果に応じたフォールバック挙動を改善し、再試行が安定しました。  
- **Documentation**
  - 更新履歴に、該当不具合の修正内容を追記しました。  
- **Tests**
  - `postinstall` の主要な挙動について、解決・未検出・候補生成のケースを追加で検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->