### PR TITLE
[ 仕様変更 ] Claude使用量表示を設定モーダルから分離しサイドバーの独立項目・専用モーダルに変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 仕様変更 ] Claude の使用量表示を設定モーダルのタブから切り離し、サイドバーに独立項目「Claude使用量」と専用モーダルを追加。使用率の警告ドットは歯車ボタンから ☰ メニューボタンとサイドバー項目へ移動
+
 ## 1.9.1
 
 - [ 不具合修正 ] vk-terminals を依存として組み込んだ際、npm ホイスティングでネストした node_modules に electron-rebuild が無く postinstall が ENOENT で失敗する不具合を修正（bin 解決を上方探索で堅牢化）（[#82](https://github.com/vektor-inc/vk-terminals/issues/82)）

--- a/main.js
+++ b/main.js
@@ -52,7 +52,7 @@ const SEND_ENTER_SPLIT_DELAY_MS = 150;
 let cachedStates = {};  // renderer から受け取った状態キャッシュ
 let httpServer = null;
 
-const MENU_ACTION_TYPES = new Set(['open-settings', 'open-url']);
+const MENU_ACTION_TYPES = new Set(['open-settings', 'open-usage', 'open-url']);
 const MENU_MAX_SECTIONS = 20;
 const MENU_MAX_ITEMS = 50;
 const MENU_MAX_CHILDREN = 20;
@@ -133,6 +133,8 @@ function validateMenuItem(raw, source, depth, seenIds) {
     }
     if (raw.action.type === 'open-settings') {
       item.action = { type: 'open-settings' };
+    } else if (raw.action.type === 'open-usage') {
+      item.action = { type: 'open-usage' };
     } else if (raw.action.type === 'open-url') {
       const r = validateUrlField(raw.action.url, 'action.url');
       if (!r.ok || !r.value) {
@@ -226,6 +228,12 @@ function builtinMenuSection() {
   return {
     source: 'builtin',
     items: [
+      {
+        id: 'usage',
+        label: 'Claude使用量',
+        icon: '📊',
+        action: { type: 'open-usage' },
+      },
       {
         id: 'settings',
         label: '設定',
@@ -549,7 +557,7 @@ function builtinSettingsDescriptor() {
           { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: '1 ペイン目で claude 起動直後に自動実行させたいコマンドがあれば記入してください。' },
           // showUsage（issue #69）は opt-out（既定 ON）。default:true で「未設定 boolean が
           // 保存時に false になる」問題を避ける（settings:describe / settings:save が default 尊重）。
-          { key: 'showUsage',      label: 'トークン使用量を表示',   type: 'boolean', default: true, help: 'Claude の利用状況（セッション% / 週間制限%）を設定モーダルの「Claude使用状況」タブ・モバイルページに表示します。' },
+          { key: 'showUsage',      label: 'トークン使用量を表示',   type: 'boolean', default: true, help: 'Claude の利用状況（セッション% / 週間制限%）をサイドバーの「Claude使用量」・モバイルページに表示します。' },
           // GPU 起動モード（utils/gpu.js）。環境変数 VK_TERMINALS_GPU を優先し、未指定時にこの値を使う。
           // 空（自動）はプラットフォーム既定（macOS=default / それ以外=off）。反映には再起動が必要（note に記載）。
           { key: 'gpu', label: 'GPU 起動モード', type: 'select', emptyToNull: true, default: '', help: 'GUI(Electron) の GPU 初期化方法。WSLg 等ではエラー抑制のため既定で無効化されます。環境変数 VK_TERMINALS_GPU 指定時はそちらが優先されます。', options: [

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -2049,13 +2049,20 @@ function renderSettingsField(f, value, id) {
 //   - 「設定」タブは settings:describe が使えるときだけ描画し、従来どおり保存できる
 //   - 使用状況のポーリングは「Claude使用状況タブ表示中のみ」初回即時＋60秒間隔。
 //     残り時間表示（◯時間◯分後にリセット）は毎秒ライブ再計算する
+// 設定モーダル・使用量モーダルの同時オープンを防ぐ共有ロック。settings:describe の
+// await 中は overlay がまだ DOM に無いため、.settings-overlay の有無チェックだけでは
+// もう一方のモーダルがすり抜けて二重生成されうる。await より前に同期で立てるこのフラグ
+// で「チェック〜生成」を原子的に守り、モーダルを閉じた／生成に失敗した時に必ず戻す。
+let modalOpen = false;
+
 // ─── Claude使用量モーダル ─────────────────────────────────────────────────────
 // 設定から切り離した読み取り専用の使用状況ビュー。サイドバーの「Claude使用量」項目
 // （builtin メニューの open-usage アクション）から起動する。設定モーダルとは別物で、
 // 保存フッターは持たず、表示中のみ 60 秒ポーリング＋リセット残時間の毎秒再計算を行う。
 async function openUsageModal() {
-  // 二重オープン防止（設定モーダルとも共通の .settings-overlay で 1 枚に限定）
-  if (document.querySelector('.settings-overlay')) return;
+  // 二重オープン防止（設定モーダルと共通の同期ロックで 1 枚に限定）
+  if (modalOpen) return;
+  modalOpen = true;
 
   const overlay = document.createElement('div');
   overlay.className = 'settings-overlay usage-overlay';
@@ -2102,6 +2109,7 @@ async function openUsageModal() {
     if (usageTickTimer) { clearInterval(usageTickTimer); usageTickTimer = null; }
     document.removeEventListener('keydown', onKey);
     overlay.remove();
+    modalOpen = false;
   };
   const onKey = (e) => { if (e.key === 'Escape') close(); };
   document.addEventListener('keydown', onKey);
@@ -2110,8 +2118,9 @@ async function openUsageModal() {
 }
 
 async function openSettingsModal() {
-  // 二重オープン防止
-  if (document.querySelector('.settings-overlay')) return;
+  // 二重オープン防止（使用量モーダルと共通の同期ロック。describe の await より前に立てる）
+  if (modalOpen) return;
+  modalOpen = true;
 
   // 設定ディスクリプタが無い環境でも空の設定モーダルとして開く（使用量は別モーダル）。
   let desc = null;
@@ -2163,6 +2172,7 @@ async function openSettingsModal() {
   const close = () => {
     document.removeEventListener('keydown', onKey);
     overlay.remove();
+    modalOpen = false;
   };
   const onKey = (e) => { if (e.key === 'Escape') close(); };
   document.addEventListener('keydown', onKey);

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -528,6 +528,10 @@ function runMenuAction(action) {
     openSettingsModal();
     return;
   }
+  if (action.type === 'open-usage') {
+    openUsageModal();
+    return;
+  }
   if (action.type === 'open-url') {
     openExternalUrlSafe(action.url);
   }
@@ -544,10 +548,11 @@ function createMenuActionElement(item) {
       event.preventDefault();
       runMenuAction(action);
     });
-  } else if (action?.type === 'open-settings') {
+  } else if (action?.type === 'open-settings' || action?.type === 'open-usage') {
     el = document.createElement('button');
     el.className = 'sidebar-menu-button';
     el.type = 'button';
+    el.dataset.menuAction = action.type;
     el.addEventListener('click', () => runMenuAction(action));
   } else {
     el = document.createElement('span');
@@ -622,6 +627,7 @@ function renderSidebarMenu() {
   }
 
   nav.appendChild(inner);
+  applyUsageBadge(); // 再描画で消えた使用率警告ドットを貼り直す
 }
 
 function createSidebarMenu() {
@@ -1738,9 +1744,9 @@ window.addEventListener('resize', debouncedFitAll);
 // ─── 設定パネル（汎用）────────────────────────────────────────────────────────
 // main プロセス（settings:describe / settings:save）経由で、呼び出し側が env
 // VK_TERMINALS_SETTINGS で指定した config ファイルをこの GUI から編集する。
-// issue #73 で歯車ボタンは常時表示になった。使用状況ビューは descriptor の有無に
-// かかわらず開けるため、describe の結果を待たずに click を配線する（describe が
-// 使えない環境ではモーダル側で設定タブを描画しない）。
+// 歯車ボタンは設定モーダル（設定項目のみ）を開く。Claude の使用状況はサイドバーの
+// 「Claude使用量」項目（openUsageModal）へ分離した。describe が使えない環境では
+// モーダル側で「設定項目なし」を表示する。
 function setupSettingsPanel() {
   const btn = document.getElementById('settings-btn');
   if (!btn) return;
@@ -1923,15 +1929,37 @@ function renderUsageView(container, usage) {
 // （80〜90%: アンバー / 90%〜: 赤）。フォールバック（自己ピーク比）は上限比ではないため
 // バッジ対象にしない。ポーリングは 60 秒間隔で main 側 60s TTL キャッシュに相乗りする。
 // 色のみの表現にしないよう、警告レベルに応じて title / aria-label も切り替える（a11y）。
-const USAGE_BADGE_LABELS = {
-  '':     '設定',
-  'warn': '設定（Claude使用状況: 警告）',
-  'crit': '設定（Claude使用状況: 危険）',
+const USAGE_ALERT_LABELS = {
+  '':     '',
+  'warn': 'Claude使用量: 警告（80%超）',
+  'crit': 'Claude使用量: 危険（90%超）',
 };
 
+// 直近の使用率警告レベル（'' / 'warn' / 'crit'）。サイドバーは menu:update で
+// 作り直されるため、レベルはモジュール変数で保持し renderSidebarMenu から貼り直す。
+let usageAlertLevel = '';
+
+// 使用率の警告ドットを ☰ メニューボタン（常時表示）とサイドバーの「Claude使用量」
+// 項目の両方に反映する。サイドバー閉時でも ☰ 側で警告に気付けるようにする。
+function applyUsageBadge() {
+  const level = usageAlertLevel;
+  const menuBtn = document.getElementById('menu-btn');
+  const targets = [];
+  if (menuBtn) targets.push(menuBtn);
+  document.querySelectorAll('[data-menu-action="open-usage"]').forEach((el) => targets.push(el));
+  for (const el of targets) {
+    el.classList.toggle('usage-alert-warn', level === 'warn');
+    el.classList.toggle('usage-alert-crit', level === 'crit');
+  }
+  if (menuBtn) {
+    const extra = USAGE_ALERT_LABELS[level];
+    const label = extra ? `メニュー（${extra}）` : 'メニュー';
+    menuBtn.title = label;
+    menuBtn.setAttribute('aria-label', label);
+  }
+}
+
 function setupUsageBadge() {
-  const btn = document.getElementById('settings-btn');
-  if (!btn) return;
   const refresh = async () => {
     let level = '';
     try {
@@ -1945,11 +1973,8 @@ function setupUsageBadge() {
     } catch (_e) {
       level = ''; // 取得失敗時はバッジを消す（古い警告を残さない）
     }
-    btn.classList.toggle('usage-alert-warn', level === 'warn');
-    btn.classList.toggle('usage-alert-crit', level === 'crit');
-    const label = USAGE_BADGE_LABELS[level] || USAGE_BADGE_LABELS[''];
-    btn.title = label;
-    btn.setAttribute('aria-label', label);
+    usageAlertLevel = level;
+    applyUsageBadge();
   };
   refresh();
   setInterval(refresh, USAGE_POLL_INTERVAL_MS);
@@ -2024,11 +2049,71 @@ function renderSettingsField(f, value, id) {
 //   - 「設定」タブは settings:describe が使えるときだけ描画し、従来どおり保存できる
 //   - 使用状況のポーリングは「Claude使用状況タブ表示中のみ」初回即時＋60秒間隔。
 //     残り時間表示（◯時間◯分後にリセット）は毎秒ライブ再計算する
+// ─── Claude使用量モーダル ─────────────────────────────────────────────────────
+// 設定から切り離した読み取り専用の使用状況ビュー。サイドバーの「Claude使用量」項目
+// （builtin メニューの open-usage アクション）から起動する。設定モーダルとは別物で、
+// 保存フッターは持たず、表示中のみ 60 秒ポーリング＋リセット残時間の毎秒再計算を行う。
+async function openUsageModal() {
+  // 二重オープン防止（設定モーダルとも共通の .settings-overlay で 1 枚に限定）
+  if (document.querySelector('.settings-overlay')) return;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'settings-overlay usage-overlay';
+  overlay.innerHTML = `
+    <div class="settings-modal usage-modal" role="dialog" aria-modal="true" aria-label="Claude使用量">
+      <div class="settings-header">
+        <h2>Claude使用量</h2>
+        <button class="settings-close" title="閉じる">✕</button>
+      </div>
+      <div class="settings-view settings-view-usage" role="region">
+        <p class="usage-empty">Claude の使用状況を取得中…</p>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+
+  const modal = overlay.querySelector('.usage-modal');
+  const usageView = modal.querySelector('.settings-view-usage');
+
+  // 使用状況のポーリング（main 側 60s TTL キャッシュに相乗り）と、リセット残時間の
+  // 毎秒ライブ再計算。モーダルを閉じたら両方止める。
+  let usagePollTimer = null;
+  let usageTickTimer = null;
+  const refreshUsage = async () => {
+    let u = null;
+    try {
+      u = await ipcRenderer.invoke('usage:get');
+    } catch (_e) {
+      u = null;
+    }
+    if (!overlay.isConnected) return; // 取得中に閉じられたら何もしない
+    renderUsageView(usageView, u);
+  };
+  refreshUsage(); // 初回即時（ポーリング待ちにしない）
+  usagePollTimer = setInterval(refreshUsage, USAGE_POLL_INTERVAL_MS);
+  usageTickTimer = setInterval(() => {
+    usageView.querySelectorAll('[data-reset-at]').forEach((el) => {
+      const at = Number(el.dataset.resetAt);
+      if (Number.isFinite(at)) el.textContent = formatRemainingJa(at - Date.now());
+    });
+  }, 1000);
+
+  const close = () => {
+    if (usagePollTimer) { clearInterval(usagePollTimer); usagePollTimer = null; }
+    if (usageTickTimer) { clearInterval(usageTickTimer); usageTickTimer = null; }
+    document.removeEventListener('keydown', onKey);
+    overlay.remove();
+  };
+  const onKey = (e) => { if (e.key === 'Escape') close(); };
+  document.addEventListener('keydown', onKey);
+  overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) close(); });
+  modal.querySelector('.settings-close').addEventListener('click', close);
+}
+
 async function openSettingsModal() {
   // 二重オープン防止
   if (document.querySelector('.settings-overlay')) return;
 
-  // describe が失敗しても使用状況ビューだけのモーダルとして開く。
+  // 設定ディスクリプタが無い環境でも空の設定モーダルとして開く（使用量は別モーダル）。
   let desc = null;
   try {
     desc = await ipcRenderer.invoke('settings:describe');
@@ -2058,81 +2143,24 @@ async function openSettingsModal() {
         <h2>${escText((settingsAvailable && desc.title) || 'VK Terminals')}${appVersion ? `<span class="settings-version">VK Terminals v${escText(appVersion)}</span>` : ''}</h2>
         <button class="settings-close" title="閉じる">✕</button>
       </div>
-      <div class="settings-tabs" role="tablist">
-        <button type="button" class="settings-tab" data-tab="usage" role="tab" aria-selected="false">Claude使用状況</button>
-        ${settingsAvailable ? '<button type="button" class="settings-tab" data-tab="config" role="tab" aria-selected="false">設定</button>' : ''}
-      </div>
-      <div class="settings-view settings-view-usage" role="tabpanel" hidden>
-        <p class="usage-empty">Claude の使用状況を取得中…</p>
-      </div>
-      <div class="settings-view settings-view-config" role="tabpanel" hidden>
+      <div class="settings-view settings-view-config" role="region">
         ${settingsAvailable && desc.note ? `<p class="settings-note">${escText(desc.note)}</p>` : ''}
         ${settingsAvailable ? `<p class="settings-target">保存先: <code>${escText(desc.targetPath || '')}</code></p>` : ''}
-        <form class="settings-form" onsubmit="return false">${groupsHtml}</form>
+        ${settingsAvailable
+          ? `<form class="settings-form" onsubmit="return false">${groupsHtml}</form>`
+          : '<p class="settings-empty">この環境では編集できる設定項目がありません。</p>'}
       </div>
-      <div class="settings-footer" hidden>
+      ${settingsAvailable ? `<div class="settings-footer">
         <span class="settings-msg" role="status"></span>
         <button type="button" class="settings-cancel">キャンセル</button>
         <button type="button" class="settings-save">保存</button>
-      </div>
+      </div>` : ''}
     </div>`;
   document.body.appendChild(overlay);
 
   const modal = overlay.querySelector('.settings-modal');
-  const msg = modal.querySelector('.settings-msg');
-  const usageView = modal.querySelector('.settings-view-usage');
-  const configView = modal.querySelector('.settings-view-config');
-  const footer = modal.querySelector('.settings-footer');
-  const tabs = Array.from(modal.querySelectorAll('.settings-tab'));
-
-  // ── 使用状況のポーリング（Claude使用状況タブ表示中のみ）──────────────────
-  let usagePollTimer = null; // 60 秒間隔の再取得（main 側 60s TTL キャッシュに相乗り）
-  let usageTickTimer = null; // 「◯時間◯分後にリセット」の毎秒ライブ再計算
-  const refreshUsage = async () => {
-    let u = null;
-    try {
-      u = await ipcRenderer.invoke('usage:get');
-    } catch (_e) {
-      u = null;
-    }
-    if (!overlay.isConnected) return; // 取得中に閉じられたら何もしない
-    renderUsageView(usageView, u);
-  };
-  const startUsagePolling = () => {
-    if (usagePollTimer) return;
-    refreshUsage(); // 初回即時（ポーリング待ちにしない）
-    usagePollTimer = setInterval(refreshUsage, USAGE_POLL_INTERVAL_MS);
-    usageTickTimer = setInterval(() => {
-      usageView.querySelectorAll('[data-reset-at]').forEach((el) => {
-        const at = Number(el.dataset.resetAt);
-        if (Number.isFinite(at)) el.textContent = formatRemainingJa(at - Date.now());
-      });
-    }, 1000);
-  };
-  const stopUsagePolling = () => {
-    if (usagePollTimer) { clearInterval(usagePollTimer); usagePollTimer = null; }
-    if (usageTickTimer) { clearInterval(usageTickTimer); usageTickTimer = null; }
-  };
-
-  // ── タブ切替 ──────────────────────────────────────────────────────────────
-  const selectTab = (name) => {
-    tabs.forEach((t) => {
-      const on = t.dataset.tab === name;
-      t.classList.toggle('active', on);
-      t.setAttribute('aria-selected', on ? 'true' : 'false');
-    });
-    usageView.hidden = name !== 'usage';
-    configView.hidden = name !== 'config';
-    // 使用状況ビューは読み取り専用のため、保存/キャンセルのフッターごと隠す（閉じるのみ）。
-    footer.hidden = name !== 'config';
-    if (name === 'usage') startUsagePolling();
-    else stopUsagePolling();
-  };
-  tabs.forEach((t) => t.addEventListener('click', () => selectTab(t.dataset.tab)));
-  selectTab('usage'); // 既定タブは「Claude使用状況」
 
   const close = () => {
-    stopUsagePolling();
     document.removeEventListener('keydown', onKey);
     overlay.remove();
   };
@@ -2141,6 +2169,11 @@ async function openSettingsModal() {
 
   overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) close(); });
   modal.querySelector('.settings-close').addEventListener('click', close);
+
+  // 設定項目が無い環境ではフォーム関連の配線は不要（閉じるだけ）。
+  if (!settingsAvailable) return;
+
+  const msg = modal.querySelector('.settings-msg');
   modal.querySelector('.settings-cancel').addEventListener('click', close);
 
   // password の表示/非表示トグル
@@ -2216,10 +2249,10 @@ initApp().then(() => {
   ipcRenderer.send('terminal:renderer-ready');
 });
 
-// 設定パネル（Claude使用状況｜設定モーダル）の歯車ボタンを配線する（issue #73 で常時表示）。
+// 設定モーダルの歯車ボタンを配線する（設定のみ。使用量はサイドバーの別モーダルへ）。
 setupSettingsPanel();
 
-// 歯車ボタンの使用率警告ドットバッジ（issue #73）を配線する。
+// 使用率警告ドットバッジ（☰ メニューボタン＋サイドバーの「Claude使用量」項目）を配線する。
 setupUsageBadge();
 
 // ─── State reporting to main process ─────────────────────────────────────────

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -12,9 +12,10 @@
   <div class="titlebar">
     <button id="menu-btn" class="titlebar-menu-btn" type="button" aria-label="メニュー" aria-expanded="false" aria-controls="sidebar-menu" title="メニュー">☰</button>
     <span class="app-title">VK Terminals</span>
-    <!-- 歯車は常時表示（issue #73）。使用状況ビューは設定ディスクリプタの有無に
-         かかわらず開けるため、hidden にしない。使用率 80% 超過時は app.js が
-         .usage-alert-warn / .usage-alert-crit を付与して警告ドットを重ねる。 -->
+    <!-- 歯車は常時表示。設定モーダル（設定項目のみ）を開く。Claude の使用量は
+         サイドバーの「Claude使用量」項目へ分離した。使用率 80% 超過時の警告ドットは
+         app.js が ☰ メニューボタンとサイドバー項目に .usage-alert-warn /
+         .usage-alert-crit を付与して表示する。 -->
     <button id="settings-btn" class="titlebar-btn" title="設定">⚙</button>
   </div>
   <div id="root"></div>

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -91,12 +91,22 @@ html, body {
   outline-offset: 2px;
 }
 
-/* 歯車ボタンの警告ドットバッジ（issue #73）。
-   公式の使用率（セッション・週間のいずれか）が 80% を超えたときだけ app.js が
-   .usage-alert-warn（80〜90%: アンバー）/ .usage-alert-crit（90%〜: 赤）を付与する。
-   タイトルバー背景（#0d1117）と同色の縁取りで、⚙ グリフと視覚的に分離する。 */
+/* 使用率の警告ドットバッジ。公式の使用率（セッション・週間のいずれか）が 80% を
+   超えたときだけ app.js が .usage-alert-warn（80〜90%: アンバー）/ .usage-alert-crit
+   （90%〜: 赤）を付与する。使用量表示を設定から分離したため、常時見える ☰ メニュー
+   ボタンと、サイドバーの「Claude使用量」項目の両方に表示する。 */
+.titlebar-menu-btn.usage-alert-warn,
+.titlebar-menu-btn.usage-alert-crit,
+.sidebar-menu-button.usage-alert-warn,
+.sidebar-menu-button.usage-alert-crit {
+  position: relative;
+}
 .titlebar-btn.usage-alert-warn::after,
-.titlebar-btn.usage-alert-crit::after {
+.titlebar-btn.usage-alert-crit::after,
+.titlebar-menu-btn.usage-alert-warn::after,
+.titlebar-menu-btn.usage-alert-crit::after,
+.sidebar-menu-button.usage-alert-warn::after,
+.sidebar-menu-button.usage-alert-crit::after {
   content: "";
   position: absolute;
   top: 3px;
@@ -106,8 +116,12 @@ html, body {
   border-radius: 50%;
   border: 1px solid #0d1117;
 }
-.titlebar-btn.usage-alert-warn::after { background: #d29922; }
-.titlebar-btn.usage-alert-crit::after { background: #f85149; }
+.titlebar-btn.usage-alert-warn::after,
+.titlebar-menu-btn.usage-alert-warn::after,
+.sidebar-menu-button.usage-alert-warn::after { background: #d29922; }
+.titlebar-btn.usage-alert-crit::after,
+.titlebar-menu-btn.usage-alert-crit::after,
+.sidebar-menu-button.usage-alert-crit::after { background: #f85149; }
 
 /* ─── 設定パネル（モーダル）──────────────────────────────────────────────────── */
 .settings-overlay {
@@ -166,30 +180,8 @@ html, body {
 /* ─── 設定モーダルのタブ（Claude使用状況｜設定, issue #73）─────────────────────
  * ヘッダー直下のセグメント切替。既定タブは「Claude使用状況」（読み取り専用ビュー）。
  * 設定ディスクリプタが使えない環境では「設定」タブ自体を描画しない。 */
-.settings-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 18px 0;
-  border-bottom: 1px solid #21262d;
-}
-.settings-tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: #8b949e;
-  padding: 6px 10px 8px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-}
-.settings-tab:hover { color: #e6edf3; }
-.settings-tab.active {
-  color: #e6edf3;
-  border-bottom-color: #58a6ff;
-}
-
-/* タブで切り替わるビュー。モーダル（flex column・max-height 制限）内で
- * ビュー単位にスクロールさせる。hidden 属性で非表示切替。 */
+/* モーダル（flex column・max-height 制限）内でビュー単位にスクロールさせる。
+ * hidden 属性で非表示切替。 */
 .settings-view {
   overflow-y: auto;
   min-height: 0;
@@ -277,6 +269,13 @@ html, body {
   word-break: break-all;
 }
 .settings-target code { color: #8b949e; }
+.settings-empty {
+  margin: 0;
+  padding: 18px;
+  color: #8b949e;
+  font-size: 13px;
+  line-height: 1.6;
+}
 .settings-form {
   padding: 12px 18px;
   overflow-y: auto;


### PR DESCRIPTION
## 概要

これまで設定モーダル内のタブ（「Claude使用状況」）にあった Claude の使用量表示を設定から切り離し、サイドバーに「設定」と同列の独立項目「Claude使用量」として追加しました。使用量データの取得経路（vk-terminals main プロセスの公式 usage API → トランスクリプト集計フォールバック）は従来どおりで変更ありません。

## 変更内容

### サイドバーに独立項目を追加
- `main.js` `builtinMenuSection()` に `📊 Claude使用量`（`open-usage` アクション）を「設定」と同列で追加。メニューバリデーション（`MENU_ACTION_TYPES` / `validateMenuItem`）にも `open-usage` を許可
- `app.js` に専用モーダル `openUsageModal()` を新設。設定モーダルと同じ見た目のオーバーレイで使用状況のみを表示（読み取り専用・保存フッターなし）。表示中のみ 60 秒ポーリング＋リセット残時間の毎秒ライブ再計算を行い、閉じたら停止

### 設定モーダルから使用状況を分離
- `openSettingsModal()` からタブ・使用状況ビュー・ポーリング処理を削除し、設定項目のみに単純化
- 設定ディスクリプタが未提供の環境では「設定項目なし」を表示

### 警告ドットの移動
- 使用率 80% 超の警告ドットを歯車ボタン ⚙ から **☰ メニューボタン**（常時表示）と**サイドバーの「Claude使用量」項目**の両方へ移動
- サイドバーは `menu:update` で作り直されるため、`renderSidebarMenu` から `applyUsageBadge()` を呼び直してドットを貼り直す
- `style.css`: バッジ CSS を両ボタンに拡張し、不要になったタブ用 CSS を削除

## 補足（実装判断）
- 警告ドットは新項目へ移すのが指示でしたが、サイドバーが閉じていると見えないため ☰ ボタンにも重ねて常時見えるようにしています。
- 歯車 ⚙ とサイドバー「設定」は従来どおり両方とも設定モーダルを開きます（元からある二重導線）。

## テスト
- `npm test`: 76 件すべて pass
- `node --check` で `main.js` / `renderer/app.js` の構文確認済み
- 実機（Electron GUI）での表示確認は未実施

関連 issue: なし（ユーザー要望に基づく直接対応）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * サイドバーに「Claude使用量」項目を追加し、専用モーダルで使用量を確認できるようになりました。
* **改善**
  * 使用率の警告ドットの表示元を見直し、メニューボタンとサイドバー項目にも表示されるようになりました。
  * 設定画面と使用量表示を分離し、設定モーダルは設定専用の構成に整理されました。
  * 使用量モーダルの更新・閉じる動作が安定しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->