### PR TITLE
[ デザイン不具合修正 ] 設定ダイアログの select ダーク未対応・フォーム様式の不揃い・ラベル改行を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ デザイン不具合修正 ] 設定ダイアログの select がダークテーマで白地に浮く問題・boolean 行のフォーム様式の不揃い・ラベルの語中改行・余白のグルーピングを修正（[vektor-inc/vk-orchestrator#48](https://github.com/vektor-inc/vk-orchestrator/issues/48)）
+
 ## 1.10.0
 
 - [ 仕様変更 ] Claude の使用量表示を設定モーダルのタブから切り離し、サイドバーに独立項目「Claude使用量」と専用モーダルを追加。使用率の警告ドットは歯車ボタンから ☰ メニューボタンとサイドバー項目へ移動（[#84](https://github.com/vektor-inc/vk-terminals/pull/84)）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1988,10 +1988,12 @@ function renderSettingsField(f, value, id) {
   const help = f.help ? `<span class="settings-help">${escText(f.help)}</span>` : '';
 
   if (f.type === 'boolean') {
-    return `<label class="settings-row settings-row-check">
-      <input type="checkbox" id="${id}" ${value ? 'checked' : ''}>
-      <span class="settings-label">${label}</span>${help}
-    </label>`;
+    return `<div class="settings-row settings-row-check">
+      <label class="settings-check">
+        <input type="checkbox" id="${id}" ${value ? 'checked' : ''}>
+        <span class="settings-label">${label}</span>
+      </label>${help}
+    </div>`;
   }
 
   const strVal = value === null || value === undefined

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -284,7 +284,7 @@ html, body {
   border: 1px solid #21262d;
   border-radius: 6px;
   padding: 8px 12px 12px;
-  margin: 0 0 14px;
+  margin: 0 0 18px;
 }
 .settings-group legend {
   padding: 0 6px;
@@ -296,21 +296,23 @@ html, body {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  margin-top: 10px;
+  margin-top: 14px;
 }
 .settings-row:first-of-type { margin-top: 2px; }
 .settings-label {
   color: #c9d1d9;
   font-size: 12px;
   font-weight: 500;
+  white-space: nowrap;
 }
 .settings-help {
-  color: #6e7681;
+  color: #8b949e;
   font-size: 11px;
 }
 .settings-row input[type="text"],
 .settings-row input[type="number"],
 .settings-row input[type="password"],
+.settings-row select,
 .settings-row textarea {
   width: 100%;
   box-sizing: border-box;
@@ -322,21 +324,33 @@ html, body {
   font-size: 12px;
   font-family: inherit;
 }
+.settings-row select {
+  appearance: none;
+  -webkit-appearance: none;
+  color-scheme: dark;
+  padding-right: 28px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2 4.5l4 4 4-4' fill='none' stroke='%238b949e' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+}
 .settings-row textarea {
   resize: vertical;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .settings-row input:focus,
+.settings-row select:focus,
 .settings-row textarea:focus {
   outline: none;
   border-color: #58a6ff;
 }
-.settings-row-check {
+.settings-check {
+  display: flex;
   flex-direction: row;
   align-items: center;
   gap: 8px;
+  cursor: pointer;
 }
-.settings-row-check input { -webkit-app-region: no-drag; }
+.settings-check input { -webkit-app-region: no-drag; }
 .settings-pwd {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## 概要

「VK Orchestrator 設定」ダイアログ（VK Terminals v1.10.0 で表示される汎用設定パネル）の UI が、デザイン実装ルール（`design-rules.md` / `css.md`）に不整合だった問題を修正します。

> 元 issue は vk-orchestrator に起票されていますが、当該ダイアログの**描画・CSS は vk-terminals 側**（`renderer/app.js` の `renderSettingsField()` と `renderer/style.css`）にあるため、本リポジトリで修正します。vk-orchestrator は設定項目のディスクリプタ（ラベル・型・help）を渡すだけで、視覚的不整合には介入できません。

関連 issue: https://github.com/vektor-inc/vk-orchestrator/issues/48

## 変更内容

| # | 問題 | 対応 |
|---|---|---|
| 1 | GPU モードの `<select>` がダークテーマで白地のまま浮く | 入力共通セレクタに `select` を追加して他 input と同一トークンで暗色化。専用ブロックで `appearance:none` ＋ data-URI SVG の矢印、`color-scheme:dark` で option ポップアップまで暗色化。`:focus` にも `select` を追加 |
| 2 | boolean 行（「automerge の e2e ゲートを必須化」等）のフォーム様式が他項目と不揃い | boolean を `.settings-row` の縦積みフローに戻し、チェック＋ラベルだけを内側 `label.settings-check` で横並びグループ化。help は他項目同様に行直下へ |
| 3 | ラベルが語の途中で不自然に改行 | `.settings-label` に `white-space: nowrap`（`<br>` は不使用）。2 のレイアウト統一で行に横幅が戻り 1 行表示に |
| 4 | 余白のグルーピングが曖昧 | 余白階層を単調増加に（項目内 4px < 項目間 10→14px < グループ間 14→18px） |
| 補 | 説明テキストのコントラスト不足 | `.settings-help` を `#6e7681 → #8b949e`。モーダル背景 `#0d1117` 上で本文 WCAG 2.1 AA（4.5:1）を満たす |

設計方針は UX（design-rules「同一パネル内のフォーム様式の統一＝異種コントロールは無理に同一化せず、グループ化とラベル/入力欄左端の x 揃えで一貫性」）に沿って確定。詳細度は select 関連も既存 input 群と同一 `(0,1,1)`、`!important` は不使用。

### 本 PR に含めない（別 issue 化）

- 全 input 共通の境界線 `#30363d`（on `#010409`）の UI コントラスト 3:1 懸念。全入力欄に波及し本 issue の 4 点とは別軸のため、別 issue で扱う。

## テスト（確認手順）

VK Terminals を vk-orchestrator 連携（`VK_TERMINALS_SETTINGS` 指定）で起動し、歯車アイコンから「設定」タブを開く。

**Before（修正前・`main`）**
1. GPU 起動モードの `<select>` が周囲の暗色 input の中で**白地で浮いて**見える。
2. 「automerge の e2e ゲートを必須化」の行が「左にチェック＋ラベル、右に説明」の別レイアウトで、他項目の縦積みと**揃っていない**。
3. 同ラベルが狭い左カラム内で**語の途中から複数行に折り返す**。
4. 「コマンドテンプレート」textarea と直下のチェック行の間隔が近く、**同一項目か別項目か曖昧**。

**After（修正後・本ブランチ）**
1. `<select>` の地色・文字色・境界が他の input と揃い、ドロップダウンの矢印も表示される。展開時の option 一覧もダークで表示される → **白地の浮きが解消**。
2. チェック行が他項目と同じ縦積みリズム・左端 x で並ぶ → **様式が統一**。
3. ラベルが 1 行で表示され語中改行しない。
4. 項目間 14px・グループ間 18px で、textarea とチェック行が**別項目として読める**。

**デグレ確認**: text / number / password / json（textarea）/ select の各入力欄が従来どおり暗色で表示・編集・保存できること。チェックボックスのトグル操作（ラベルクリックでの切替）が機能すること。

## スクリーンショット

Electron 実機は起動時に PTY で `claude` を自動実行するためフルアプリ e2e が不安定です。本修正は純粋な CSS＋静的 HTML の描画結果であるため、実ファイルの `renderer/style.css` を Chromium（Playwright）に読み込ませ、`renderSettingsField()` が出力する形の設定フォームを同一条件で描画して撮影しました（boolean は Before/After で構造を作り分け）。

### Before（`main`）
![before](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-85/before-settings.png?raw=true)

- GPU 起動モードの `<select>` が白地で浮く
- 「automerge の e2e ゲートを必須化」が左カラムで語中改行（「必須／化」で分断）し、説明が右に横並び
- textarea とチェック行の間隔が近い

### After（本ブランチ）
![after](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-85/after-settings.png?raw=true)

- `<select>` が他 input と同じ暗色地＋右端の矢印
- チェック行が縦積みフローに入り、ラベル 1 行表示・説明は行直下（左端 x が他項目と揃う）
- 項目間・グループ間の余白が広がり別項目として読める
