### PR TITLE
[ 仕様変更 ] ペインヘッダの上下移動ボタン（▲▼）を削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 仕様変更 ] ペインヘッダの上下移動ボタン（▲▼）を削除。Flex Grid レイアウトで上下移動が機能しないため（[#87](https://github.com/vektor-inc/vk-terminals/issues/87)）
+
 ## 1.10.1
 
 - [ デザイン不具合修正 ] 設定ダイアログの select がダークテーマで白地に浮く問題・boolean 行のフォーム様式の不揃い・ラベルの語中改行・余白のグルーピングを修正（[vektor-inc/vk-orchestrator#48](https://github.com/vektor-inc/vk-orchestrator/issues/48)）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1010,9 +1010,7 @@ function closePane(paneId) {
   requestAnimationFrame(fitAll);
 }
 
-// ペインをグリッド上で dir 方向の隣と入れ替える。端で隣が無ければ何もしない。
-//   left/right … 同一行内の隣（行をまたがない）
-//   up/down    … 上下の行の同じ列
+// ペインをグリッド上で左右の隣と入れ替える。端で隣が無ければ何もしない。
 function movePane(paneId, dir) {
   const order = tree.order;
   const i = order.indexOf(paneId);
@@ -1021,8 +1019,6 @@ function movePane(paneId, dir) {
   let j = -1;
   if (dir === 'left'  && i % cols !== 0) j = i - 1;
   else if (dir === 'right' && i % cols !== cols - 1 && i + 1 < order.length) j = i + 1;
-  else if (dir === 'up'    && i - cols >= 0) j = i - cols;
-  else if (dir === 'down'  && i + cols < order.length) j = i + cols;
   if (j < 0) return;
   [order[i], order[j]] = [order[j], order[i]];
   render();
@@ -1407,8 +1403,6 @@ function renderLeaf(node) {
     <div class="pane-actions">
       <span class="pane-badge auto-input-badge" hidden></span>
       <button class="btn btn-move btn-move-left" title="左へ移動">◀</button>
-      <button class="btn btn-move btn-move-down" title="下へ移動">▼</button>
-      <button class="btn btn-move btn-move-up" title="上へ移動">▲</button>
       <button class="btn btn-move btn-move-right" title="右へ移動">▶</button>
       <button class="btn btn-split" title="ペインを追加">＋</button>
       <button class="btn btn-close" title="閉じる">✕</button>
@@ -1458,14 +1452,6 @@ function renderLeaf(node) {
   header.querySelector('.btn-move-right').addEventListener('click', e => {
     e.stopPropagation();
     movePane(node.id, 'right');
-  });
-  header.querySelector('.btn-move-up').addEventListener('click', e => {
-    e.stopPropagation();
-    movePane(node.id, 'up');
-  });
-  header.querySelector('.btn-move-down').addEventListener('click', e => {
-    e.stopPropagation();
-    movePane(node.id, 'down');
   });
   header.querySelector('.btn-split').addEventListener('click', e => {
     e.stopPropagation();


### PR DESCRIPTION
## 概要

ペインヘッダにあった上下移動ボタン（▲▼）を削除しました。レイアウトが Flex Grid になった結果、上下移動が機能しなくなっていたため、押しても何も起きないボタンを取り除きます。左右移動ボタン（◀▶）はそのまま残します。

上下方向の並べ替えは既存のドラッグ&ドロップ（`handlePaneDrop`）で引き続き可能なため、機能自体は失われません。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/87

## 変更内容

- `renderer/app.js`
  - ペインヘッダ（`.pane-actions`）から `▼`（`btn-move-down`）・`▲`（`btn-move-up`）ボタンを削除
  - 上記2ボタンの click イベントハンドラを削除
  - `movePane()` の `up` / `down` 分岐を削除（ボタン削除により到達不能なデッドコードになるため）。関数コメントも左右のみを扱う旨に更新
- `CHANGELOG.md` に `[ 仕様変更 ]` エントリを追記

ドラッグ&ドロップ経由の上下並べ替え（`computePaneDropDir` / `handlePaneDrop`）には手を入れていません。CSS も `.btn-move` 固有ルールが元々存在しない（汎用 `.btn` で描画）ため変更なしです。

## テスト（確認手順）

### Before（修正前）
1. アプリを起動し、ペインを2つ以上に分割する（各ペインの `＋` ボタン）
2. ペイン右上の移動ボタンを確認する → ◀ ▼ ▲ ▶ の4つが並んでいる
3. ▼ または ▲ をクリックする → **何も起きない**（Flex Grid のため上下移動が機能しない）

### After（修正後）
1. アプリを起動し、ペインを2つ以上に分割する
2. ペイン右上の移動ボタンを確認する → **◀ ▶ の2つだけ**になっている（▼▲ が消えている）
3. ◀ / ▶ をクリックする → 従来どおり左右にペインが入れ替わる（デグレなし）
4. ペインをドラッグして別ペインの上半分／下半分にドロップする → 上下方向の並べ替えが従来どおり機能する（D&D は温存）

### デグレ確認
- `＋`（ペイン追加）・`✕`（閉じる）ボタンが従来どおり動作すること
- ボタンが2つ減ってもヘッダの余白・並び（◀ ▶ ＋ ✕）が崩れないこと

> UI の Before / After スクリーンショットは、麗美（e2e/UI テスト）の確認ステップで取得・添付予定です。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ペインヘッダの移動操作を左右の入れ替えのみに統一しました。
  * 上下移動ボタンを削除し、利用できない操作が表示されないようにしました。
  * グリッド上で機能しない上下移動の挙動を無効化しました。

* **Documentation**
  * 変更内容を更新し、上下移動ボタンを削除した旨を反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->