### PR TITLE
[ 機能追加 ] グリッドのペインをサイドバーに格納・復帰できる機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] グリッドのペインをサイドバーに格納して表示エリアを空け、必要なときにグリッドへ戻せる機能を追加。格納中もターミナルは稼働を継続し、サイドバー幅のドラッグ変更にも対応（[#89](https://github.com/vektor-inc/vk-terminals/issues/89)）
 - [ 仕様変更 ] ペインヘッダの上下移動ボタン（▲▼）を削除。Flex Grid レイアウトで上下移動が機能しないため（[#87](https://github.com/vektor-inc/vk-terminals/issues/87)）
 
 ## 1.10.1

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -438,6 +438,12 @@ ipcRenderer.on('terminal:exit', (event, id) => {
 function updatePaneCwd(paneId, cwd) {
   const el = document.querySelector(`.pane[data-id="${paneId}"] .pane-cwd`);
   if (el) el.textContent = cwd;
+  // 格納中のコンパクト表示の cwd も同期する（issue #89）。
+  const stashCwd = document.querySelector(`.stash-item[data-id="${paneId}"] .stash-item-cwd`);
+  if (stashCwd) {
+    stashCwd.textContent = cwd;
+    stashCwd.title = cwd;
+  }
 }
 
 // API（POST /api/set-title）由来のタイトルを最優先で表示し、未設定なら OSC 0/2 由来の
@@ -493,6 +499,12 @@ function openExternalUrlSafe(url) {
 let sidebarMenuSections = [];
 let sidebarOpen = false;
 let sidebarTransitionCleanup = null;
+// サイドバー幅リサイズ（issue #89）。ドラッグ中の一時状態。
+let sidebarResizeState = null;
+// サイドバー幅の既定値・下限（px）。上限はウィンドウ幅比で動的に決める（sidebarMaxWidth）。
+// 従来の 252px から約 1.3 倍に拡張した既定幅。永続化はしない（再起動で既定に戻る）。
+const DEFAULT_SIDEBAR_WIDTH = 330;
+const SIDEBAR_MIN_WIDTH = 200;
 
 function isReducedMotion() {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
@@ -593,9 +605,16 @@ function createMenuItem(item) {
 function renderSidebarMenu() {
   const nav = document.getElementById('sidebar-menu');
   if (!nav) return;
-  nav.replaceChildren();
-  const inner = document.createElement('div');
-  inner.className = 'sidebar-menu-inner';
+  // メニューは専用の内側コンテナ（.sidebar-menu-inner）だけを作り直す。
+  // 格納ペイン（#pane-stash）は nav の別の子として同居させ、ここでは touch しない。
+  // これにより格納ペインの xterm 要素がメニュー再描画のたびに detach されるのを防ぐ（issue #89）。
+  let inner = nav.querySelector('.sidebar-menu-inner');
+  if (!inner) {
+    inner = document.createElement('div');
+    inner.className = 'sidebar-menu-inner';
+    nav.insertBefore(inner, nav.firstChild);
+  }
+  inner.replaceChildren();
 
   for (let sectionIndex = 0; sectionIndex < sidebarMenuSections.length; sectionIndex++) {
     const section = sidebarMenuSections[sectionIndex];
@@ -626,23 +645,232 @@ function renderSidebarMenu() {
     }
   }
 
-  nav.appendChild(inner);
   applyUsageBadge(); // 再描画で消えた使用率警告ドットを貼り直す
 }
 
-function createSidebarMenu() {
+// サイドバーのラッパー（.sidebar）を組み立てる（issue #89）。
+// 中身は「スクロールする nav（メニュー内側 + 格納ペインセクション）」と「幅リサイズハンドル」。
+// 開閉トランジション・可変幅の基準はこのラッパー側に持たせる。
+function createSidebar() {
+  const aside = document.createElement('aside');
+  aside.id = 'sidebar';
+  aside.className = 'sidebar';
+
   const nav = document.createElement('nav');
   nav.id = 'sidebar-menu';
   nav.className = 'sidebar-menu';
   nav.setAttribute('aria-label', 'メインメニュー');
-  return nav;
+
+  // メニュー内側（renderSidebarMenu が作り直す対象）
+  const inner = document.createElement('div');
+  inner.className = 'sidebar-menu-inner';
+  nav.appendChild(inner);
+
+  // 格納ペインセクション（renderSidebarMenu の再構築対象外・別管理）
+  nav.appendChild(createPaneStashContainer());
+
+  aside.appendChild(nav);
+  aside.appendChild(createSidebarResizer());
+  return aside;
 }
 
-function ensureSidebarMenu(root) {
-  const existing = root.querySelector('#sidebar-menu');
-  const nav = existing || createSidebarMenu();
-  if (!existing) renderSidebarMenu();
-  return nav;
+// 格納ペインを収めるセクション（見出し＋リスト）。中身は renderPaneStash が更新する。
+function createPaneStashContainer() {
+  const section = document.createElement('section');
+  section.id = 'pane-stash';
+  section.className = 'pane-stash';
+  section.hidden = true;
+  section.setAttribute('aria-label', '格納したペイン');
+
+  const title = document.createElement('div');
+  title.className = 'pane-stash-title';
+  title.textContent = '格納したペイン';
+
+  const list = document.createElement('ul');
+  list.className = 'pane-stash-list';
+
+  section.appendChild(title);
+  section.appendChild(list);
+  return section;
+}
+
+// サイドバー右端の幅リサイズハンドル（グリッドの .grid-handle 相当のアクセシブル版）。
+function createSidebarResizer() {
+  const h = document.createElement('div');
+  h.className = 'sidebar-resizer';
+  h.setAttribute('role', 'separator');
+  h.setAttribute('aria-orientation', 'vertical');
+  h.setAttribute('aria-label', 'サイドバーの幅を変更');
+  h.setAttribute('tabindex', '0');
+  h.setAttribute('aria-valuemin', String(SIDEBAR_MIN_WIDTH));
+  h.setAttribute('aria-valuemax', String(sidebarMaxWidth()));
+  h.setAttribute('aria-valuenow', String(getSidebarWidth()));
+  h.addEventListener('mousedown', startSidebarResize);
+  h.addEventListener('keydown', onSidebarResizerKey);
+  return h;
+}
+
+function ensureSidebar(root) {
+  let el = root.querySelector('#sidebar');
+  if (!el) {
+    el = createSidebar();
+    renderSidebarMenu();
+    renderPaneStash();
+  }
+  return el;
+}
+
+// ─── Sidebar width（issue #89）────────────────────────────────────────────────
+// 上限はウィンドウ幅の約 45%（40〜50% の範囲）。狭いウィンドウでもグリッドを潰さない。
+function sidebarMaxWidth() {
+  return Math.max(SIDEBAR_MIN_WIDTH, Math.round(window.innerWidth * 0.45));
+}
+
+function clampSidebarWidth(w) {
+  return Math.max(SIDEBAR_MIN_WIDTH, Math.min(sidebarMaxWidth(), Math.round(w)));
+}
+
+// 現在のサイドバー幅（セッション内保持値、無ければ既定）をクランプして返す。
+function getSidebarWidth() {
+  const w = tree && typeof tree.sidebarWidth === 'number' ? tree.sidebarWidth : DEFAULT_SIDEBAR_WIDTH;
+  return clampSidebarWidth(w);
+}
+
+// 幅を確定し、CSS カスタムプロパティ・aria 値・セッション保持値を更新する。
+function setSidebarWidth(w) {
+  const width = clampSidebarWidth(w);
+  if (tree) tree.sidebarWidth = width;
+  const aside = document.getElementById('sidebar');
+  if (aside) aside.style.setProperty('--vktm-sidebar-width', `${width}px`);
+  const handle = document.querySelector('.sidebar-resizer');
+  if (handle) {
+    handle.setAttribute('aria-valuemin', String(SIDEBAR_MIN_WIDTH));
+    handle.setAttribute('aria-valuemax', String(sidebarMaxWidth()));
+    handle.setAttribute('aria-valuenow', String(width));
+  }
+}
+
+function startSidebarResize(e) {
+  e.preventDefault();
+  e.stopPropagation();
+  sidebarResizeState = { startX: e.clientX, startWidth: getSidebarWidth() };
+  document.body.classList.add('resizing-sidebar');
+}
+
+// 左右矢印キーで幅を増減する（Shift で大きめステップ）。
+function onSidebarResizerKey(e) {
+  const step = e.shiftKey ? 40 : 16;
+  let w = getSidebarWidth();
+  if (e.key === 'ArrowLeft') w -= step;
+  else if (e.key === 'ArrowRight') w += step;
+  else return;
+  e.preventDefault();
+  setSidebarWidth(w);
+  debouncedFitAll();
+  requestAnimationFrame(fitAll);
+}
+
+// ─── Pane stash rendering（issue #89）─────────────────────────────────────────
+// 格納ペインのコンパクト表示を stashOrder に従って組み立てる。
+// xterm 要素の再取り付けは render() の共通ループが担う（ここでは器だけ作る）。
+function renderPaneStash() {
+  const section = document.getElementById('pane-stash');
+  if (!section) return;
+  const stash = (tree && Array.isArray(tree.stashOrder)) ? tree.stashOrder : [];
+  // 0 件のときはセクションごと隠す。
+  section.hidden = stash.length === 0;
+  const list = section.querySelector('.pane-stash-list');
+  if (!list) return;
+  list.replaceChildren();
+  stash.forEach((id, idx) => {
+    list.appendChild(renderStashItem(id, idx, stash.length));
+  });
+}
+
+// 格納ペイン 1 件分（コンパクトカード）を生成する。
+//   - ヘッダ: 状態バッジ + タスク名 + アクション（▲ ▼ ―(表示トグル) →(復帰) ✕）
+//   - cwd 行
+//   - term-container（xterm。既定は非表示、― で開閉）
+function renderStashItem(id, idx, count) {
+  const t = terminals[id];
+  const li = document.createElement('li');
+  li.className = 'stash-item'
+    + (id === focusedPaneId ? ' focused' : '')
+    + (t?.waiting ? ' waiting' : '');
+  li.dataset.id = id;
+  const xtermOpen = !!(t && t.stashXtermOpen);
+  if (xtermOpen) li.classList.add('stash-xterm-open');
+
+  const status = t?.status || 'idle';
+  const { label: statusLabel, ariaLabel: statusAriaLabel } = getStatusPresentation(status);
+  const title = getDisplayTitle(t) || '(無題)';
+  const cwd = t?.cwd || '~';
+
+  const head = document.createElement('div');
+  head.className = 'stash-item-head';
+  // セキュリティ: cwd（OS 由来）・status 等は escAttr / escText でエスケープする（renderLeaf と同流儀）。
+  head.innerHTML = `
+    <span class="pane-badge pane-status" data-status="${escAttr(status)}" role="status" aria-live="polite"${statusAriaLabel ? ` aria-label="${escAttr(statusAriaLabel)}"` : ''}>${escText(statusLabel)}</span>
+    <span class="stash-item-title" title="${escAttr(title)}">${escText(title)}</span>
+    <div class="stash-item-actions">
+      <button class="btn btn-stash-up" title="上へ移動" aria-label="上へ移動">▲</button>
+      <button class="btn btn-stash-down" title="下へ移動" aria-label="下へ移動">▼</button>
+      <button class="btn btn-stash-toggle" title="ターミナルの表示を切り替え" aria-label="ターミナルの表示を切り替え" aria-expanded="${xtermOpen ? 'true' : 'false'}">―</button>
+      <span class="stash-actions-sep" aria-hidden="true"></span>
+      <button class="btn btn-stash-restore" title="グリッドへ戻す" aria-label="グリッドへ戻す">→</button>
+      <button class="btn btn-close" title="閉じる" aria-label="閉じる">✕</button>
+    </div>
+  `;
+
+  const cwdEl = document.createElement('div');
+  cwdEl.className = 'stash-item-cwd';
+  cwdEl.title = cwd;
+  cwdEl.textContent = cwd;
+
+  const termContainer = document.createElement('div');
+  termContainer.className = 'term-container';
+
+  li.appendChild(head);
+  li.appendChild(cwdEl);
+  li.appendChild(termContainer);
+
+  const upBtn = head.querySelector('.btn-stash-up');
+  const downBtn = head.querySelector('.btn-stash-down');
+  if (idx === 0) upBtn.disabled = true;
+  if (idx === count - 1) downBtn.disabled = true;
+  upBtn.addEventListener('click', e => { e.stopPropagation(); moveStashPane(id, 'up'); });
+  downBtn.addEventListener('click', e => { e.stopPropagation(); moveStashPane(id, 'down'); });
+  head.querySelector('.btn-stash-toggle').addEventListener('click', e => { e.stopPropagation(); toggleStashXterm(id); });
+  head.querySelector('.btn-stash-restore').addEventListener('click', e => { e.stopPropagation(); unstashPane(id); });
+  head.querySelector('.btn-close').addEventListener('click', e => { e.stopPropagation(); closePane(id); });
+  li.addEventListener('mousedown', () => focusPane(id));
+
+  return li;
+}
+
+// 格納ペイン（サイドバー内）のコンパクト表示を最新状態へ更新する。
+// グリッド用の update* 関数は .pane[data-id] しか見ないため、格納中はこちらで反映する。
+function updateStashItem(paneId) {
+  const li = document.querySelector(`.stash-item[data-id="${paneId}"]`);
+  if (!li) return;
+  const t = terminals[paneId];
+  if (!t) return;
+  li.classList.toggle('waiting', !!t.waiting);
+  const badge = li.querySelector('.pane-status');
+  if (badge) {
+    const status = t.status || 'idle';
+    badge.dataset.status = status;
+    const { label, ariaLabel } = getStatusPresentation(status);
+    badge.textContent = label;
+    if (ariaLabel) badge.setAttribute('aria-label', ariaLabel);
+    else badge.removeAttribute('aria-label');
+  }
+  const titleEl = li.querySelector('.stash-item-title');
+  if (titleEl) {
+    const title = getDisplayTitle(t) || '(無題)';
+    titleEl.textContent = title;
+    titleEl.title = title;
+  }
 }
 
 function focusFirstSidebarItem() {
@@ -654,7 +882,8 @@ function focusFirstSidebarItem() {
 function setSidebarOpen(open, options = {}) {
   const root = document.getElementById('root');
   const btn = document.getElementById('menu-btn');
-  const nav = root ? ensureSidebarMenu(root) : null;
+  // 開閉トランジション（transform）はラッパー .sidebar 側に付いている（issue #89）。
+  const aside = root ? ensureSidebar(root) : null;
   if (sidebarTransitionCleanup) {
     sidebarTransitionCleanup();
     sidebarTransitionCleanup = null;
@@ -672,7 +901,7 @@ function setSidebarOpen(open, options = {}) {
     }
   };
 
-  if (!nav || isReducedMotion()) {
+  if (!aside || isReducedMotion()) {
     requestAnimationFrame(afterLayout);
     return;
   }
@@ -681,7 +910,7 @@ function setSidebarOpen(open, options = {}) {
   let timeoutId = null;
   const cleanup = () => {
     done = true;
-    nav.removeEventListener('transitionend', onEnd);
+    aside.removeEventListener('transitionend', onEnd);
     if (timeoutId !== null) clearTimeout(timeoutId);
     if (sidebarTransitionCleanup === cleanup) sidebarTransitionCleanup = null;
   };
@@ -691,17 +920,17 @@ function setSidebarOpen(open, options = {}) {
     afterLayout();
   };
   const onEnd = (event) => {
-    if (event.target !== nav || event.propertyName !== 'transform') return;
+    if (event.target !== aside || event.propertyName !== 'transform') return;
     finish();
   };
   sidebarTransitionCleanup = cleanup;
-  nav.addEventListener('transitionend', onEnd);
+  aside.addEventListener('transitionend', onEnd);
   timeoutId = setTimeout(finish, 220);
 }
 
 function setupSidebarMenu() {
   const root = document.getElementById('root');
-  if (root) ensureSidebarMenu(root);
+  if (root) ensureSidebar(root);
   const btn = document.getElementById('menu-btn');
   if (btn) {
     btn.addEventListener('click', () => setSidebarOpen(!sidebarOpen, { focusFirst: true }));
@@ -816,6 +1045,8 @@ function renderTaskTitleContent(el, title, url, prUrl) {
 function updatePaneTitle(paneId) {
   const t = terminals[paneId];
   if (!t) return;
+  // 格納中ならコンパクト表示のタスク名を更新する（.pane が無いため下の処理は素通りする）。
+  updateStashItem(paneId);
   const el = document.querySelector(`.pane[data-id="${paneId}"] .pane-task-title`);
   if (!el) return;
   const title = getDisplayTitle(t);
@@ -824,7 +1055,7 @@ function updatePaneTitle(paneId) {
   // renderLeaf() 側の `canDragPane` 判定と同一の式に合わせる。
   // ここで考慮しないと、タイトル / PR をクリアした後に `.pane-task-title` が
   // empty 扱いで消え、ドラッグ起点を失う（CodeRabbit PR #45 指摘）。
-  const canDragPane = !!(tree && getAllLeafIds(tree).length > 1);
+  const canDragPane = !!(tree && Array.isArray(tree.order) && tree.order.length > 1);
   // PR ボタンは apiPrUrl があれば常時表示（採用: 案A）。
   // renderer 側でも http(s) 二段チェックを通してから採用する。
   const prUrl = isSafeExternalUrl(t.apiPrUrl) ? t.apiPrUrl : '';
@@ -850,6 +1081,8 @@ function updatePaneTitle(paneId) {
 function updatePaneStatus(paneId) {
   const t = terminals[paneId];
   if (!t) return;
+  // 格納中ならコンパクト表示の状態バッジを更新する（.pane が無いため下の処理は素通りする）。
+  updateStashItem(paneId);
   const paneEl = document.querySelector(`.pane[data-id="${paneId}"]`);
   if (!paneEl) return;
   // 枠の点滅アニメ（周辺視野での気付き用、issue #23 でも残置）は waiting フラグ準拠
@@ -900,13 +1133,22 @@ function resetGridSizing() {
   if (tree) { tree.colFr = null; tree.rowFr = null; }
 }
 
-// 全ペイン ID を表示順で返す（後方互換のため名前を維持）。
+// 全ペイン ID を返す（グリッド order ＋ サイドバー格納 stashOrder の和集合）。
+// fitAll・状態レポート・closePane の残ペイン算出などが依存するため、
+// グリッドと格納の両方を必ず走査対象に含める（issue #89）。
 function getAllLeafIds(t = tree) {
-  return (t && Array.isArray(t.order)) ? t.order.slice() : [];
+  if (!t) return [];
+  const grid = Array.isArray(t.order) ? t.order : [];
+  const stash = Array.isArray(t.stashOrder) ? t.stashOrder : [];
+  return grid.concat(stash);
 }
 
+// ペインがグリッド・格納のいずれかに存在するか（issue #89 で格納分も含める）。
 function paneExists(id) {
-  return !!(tree && Array.isArray(tree.order) && tree.order.includes(id));
+  if (!tree) return false;
+  const inGrid = Array.isArray(tree.order) && tree.order.includes(id);
+  const inStash = Array.isArray(tree.stashOrder) && tree.stashOrder.includes(id);
+  return inGrid || inStash;
 }
 
 function getPaneRect(paneId) {
@@ -989,9 +1231,12 @@ function closePane(paneId) {
     delete terminals[paneId];
   }
 
+  // グリッド・格納のどちらに居ても取り除く（issue #89）。
   tree.order = tree.order.filter(id => id !== paneId);
-  if (tree.order.length === 0) {
+  tree.stashOrder = (Array.isArray(tree.stashOrder) ? tree.stashOrder : []).filter(id => id !== paneId);
+  if (tree.order.length === 0 && tree.stashOrder.length === 0) {
     // Last pane closed → start fresh
+    // 格納ペインが 1 枚でも生き残っている場合は巻き込んで作り直さない（issue #89）。
     initApp().then(() => {
       ipcRenderer.send('terminal:renderer-ready');
     });
@@ -1026,6 +1271,86 @@ function movePane(paneId, dir) {
     fitAll();
     focusPane(paneId);
   });
+}
+
+// ─── Pane stash: サイドバーへの格納 / 復帰（issue #89）──────────────────────────
+// グリッド order とは別配列 stashOrder で管理する。xterm 要素（t.element）は破棄せず、
+// render() の appendChild 付け替えで格納コンテナ／グリッドコンテナ間を移動させる。
+
+// グリッドのペインをサイドバーへ格納する。
+function stashPane(paneId) {
+  if (!tree || !Array.isArray(tree.order)) return;
+  const i = tree.order.indexOf(paneId);
+  if (i < 0) return;
+  tree.order.splice(i, 1);
+  tree.stashOrder = Array.isArray(tree.stashOrder) ? tree.stashOrder : [];
+  tree.stashOrder.push(paneId);
+  // 格納直後は xterm を折り畳んだコンパクト表示にする。
+  const t = terminals[paneId];
+  if (t) t.stashXtermOpen = false;
+  // グリッドの寸法が変わるため手動リサイズ比率を均等に戻す。
+  resetGridSizing();
+  // 格納したペインにフォーカスがあった場合はグリッドの残ペインへ移す。
+  if (focusedPaneId === paneId) {
+    focusedPaneId = tree.order.length > 0 ? tree.order[tree.order.length - 1] : paneId;
+  }
+  render();
+  // 格納先を知らせるためサイドバーを開く（フォーカスはグリッドに残す）。
+  setSidebarOpen(true, { focusFirst: false });
+  requestAnimationFrame(() => {
+    fitAll();
+    if (tree.order.length > 0) focusPane(focusedPaneId);
+  });
+}
+
+// 格納中のペインをグリッドへ戻す。
+function unstashPane(paneId) {
+  if (!tree) return;
+  tree.stashOrder = Array.isArray(tree.stashOrder) ? tree.stashOrder : [];
+  const i = tree.stashOrder.indexOf(paneId);
+  if (i < 0) return;
+  tree.stashOrder.splice(i, 1);
+  if (!Array.isArray(tree.order)) tree.order = [];
+  tree.order.push(paneId);
+  resetGridSizing();
+  render();
+  requestAnimationFrame(() => {
+    fitAll();
+    focusPane(paneId);
+  });
+}
+
+// 格納エリア内でペインを上下に入れ替える（stashOrder の index swap）。
+function moveStashPane(paneId, dir) {
+  const arr = tree && tree.stashOrder;
+  if (!Array.isArray(arr)) return;
+  const i = arr.indexOf(paneId);
+  if (i < 0) return;
+  const j = dir === 'up' ? i - 1 : i + 1;
+  if (j < 0 || j >= arr.length) return;
+  [arr[i], arr[j]] = [arr[j], arr[i]];
+  render();
+  requestAnimationFrame(fitAll);
+}
+
+// 格納ペインの xterm 表示/非表示をトグルする（― ボタン）。
+// 非表示（display:none）からの復帰時は 0 サイズ基準のままになるため再フィットする。
+function toggleStashXterm(paneId) {
+  const t = terminals[paneId];
+  if (!t) return;
+  t.stashXtermOpen = !t.stashXtermOpen;
+  const li = document.querySelector(`.stash-item[data-id="${paneId}"]`);
+  if (li) {
+    li.classList.toggle('stash-xterm-open', t.stashXtermOpen);
+    const btn = li.querySelector('.btn-stash-toggle');
+    if (btn) btn.setAttribute('aria-expanded', t.stashXtermOpen ? 'true' : 'false');
+  }
+  if (t.stashXtermOpen) {
+    requestAnimationFrame(() => {
+      fitTerminal(paneId);
+      focusPane(paneId);
+    });
+  }
 }
 
 // ─── Pane D&D helpers (issue #40) ────────────────────────────────────────────
@@ -1146,12 +1471,19 @@ function focusPane(paneId) {
   document.querySelectorAll('.pane').forEach(el => {
     el.classList.toggle('focused', el.dataset.id === paneId);
   });
+  // 格納ペイン（サイドバー内）のフォーカスリングも同期する（issue #89）。
+  document.querySelectorAll('.stash-item').forEach(el => {
+    el.classList.toggle('focused', el.dataset.id === paneId);
+  });
   terminals[paneId]?.term.focus();
 }
 
 function fitTerminal(paneId) {
   const t = terminals[paneId];
   if (!t) return;
+  // 非表示（格納中で xterm を折り畳み中など、祖先が display:none）のときは
+  // 0 サイズでのフィット→pty への誤リサイズを避けるためスキップする（issue #89）。
+  if (t.element && t.element.offsetParent === null) return;
   try {
     t.fitAddon.fit();
     ipcRenderer.send('terminal:resize', t.termId, t.term.cols, t.term.rows);
@@ -1165,16 +1497,23 @@ function fitAll() {
 // ─── Rendering ────────────────────────────────────────────────────────────────
 function render() {
   const root = document.getElementById('root');
-  const sidebar = ensureSidebarMenu(root);
+  const sidebar = ensureSidebar(root);
   const newContent = renderGrid(tree);
   root.replaceChildren(sidebar, newContent);
   root.classList.toggle('sidebar-open', sidebarOpen);
 
+  // 格納ペインのコンパクト表示を作り直す（nav が root に付いた後に実行する）。
+  renderPaneStash();
+  // 現在のサイドバー幅を CSS 変数・aria へ反映（issue #89）。
+  setSidebarWidth(getSidebarWidth());
+
   // Reattach terminal elements (moved, not recreated)
+  // グリッド側（.pane）と格納側（.stash-item）のどちらのコンテナへも付け替える。
   getAllLeafIds(tree).forEach(paneId => {
     const t = terminals[paneId];
     if (!t) return;
-    const container = root.querySelector(`.pane[data-id="${paneId}"] .term-container`);
+    const container = root.querySelector(`.pane[data-id="${paneId}"] .term-container`)
+      || root.querySelector(`.stash-item[data-id="${paneId}"] .term-container`);
     if (container) {
       container.appendChild(t.element);
       // Open xterm after element is in the DOM (required for correct sizing)
@@ -1351,10 +1690,10 @@ function renderLeaf(node) {
   // タスクタイトル行（OSC 0/2 または POST /api/set-title で設定された文字列を表示）。
   // 空のときは .empty クラスで非表示にし、xterm の表示領域を圧迫しない。
   // apiUrl があるときは .has-link を付与し、内部を <a> 化する（renderTaskTitleContent）。
-  // ペイン D&D の可否判定（issue #40）。leaf が 2 つ以上ある時のみ drag 起点になれる。
-  // ルート leaf（ペイン 1 枚状態）は移動先が無いため drag 不可。
+  // ペイン D&D の可否判定（issue #40）。グリッド上のペインが 2 つ以上ある時のみ drag 起点になれる。
+  // D&D はグリッド内限定のため、格納分を含む getAllLeafIds ではなくグリッドの order 件数で判定する（issue #89）。
   // 空タイトル時も D&D 可なら .empty を付けず、ハンドルとして掴める高さを確保する。
-  const canDragPane = !!(tree && getAllLeafIds().length > 1);
+  const canDragPane = !!(tree && Array.isArray(tree.order) && tree.order.length > 1);
   const taskTitleEl = document.createElement('div');
   // empty 判定はタイトル本文・ドラッグ可・PR ボタンのいずれもないとき。
   // PR ボタンだけでも表示するためにこの条件で扱う（issue #44）。
@@ -1402,10 +1741,12 @@ function renderLeaf(node) {
     <span class="pane-cwd" title="${escAttr(cwd)}">${escText(cwd)}</span>
     <div class="pane-actions">
       <span class="pane-badge auto-input-badge" hidden></span>
-      <button class="btn btn-move btn-move-left" title="左へ移動">◀</button>
-      <button class="btn btn-move btn-move-right" title="右へ移動">▶</button>
-      <button class="btn btn-split" title="ペインを追加">＋</button>
-      <button class="btn btn-close" title="閉じる">✕</button>
+      <button class="btn btn-stash" title="サイドバーに格納" aria-label="サイドバーに格納">←</button>
+      <span class="pane-actions-sep" aria-hidden="true"></span>
+      <button class="btn btn-move btn-move-left" title="左へ移動" aria-label="左へ移動">◀</button>
+      <button class="btn btn-move btn-move-right" title="右へ移動" aria-label="右へ移動">▶</button>
+      <button class="btn btn-split" title="ペインを追加" aria-label="ペインを追加">＋</button>
+      <button class="btn btn-close" title="閉じる" aria-label="閉じる">✕</button>
     </div>
   `;
   // ドラッグ中に複数ファイルのヒントを表示
@@ -1445,6 +1786,10 @@ function renderLeaf(node) {
     el.appendChild(room);
   }
 
+  header.querySelector('.btn-stash').addEventListener('click', e => {
+    e.stopPropagation();
+    stashPane(node.id);
+  });
   header.querySelector('.btn-move-left').addEventListener('click', e => {
     e.stopPropagation();
     movePane(node.id, 'left');
@@ -1704,6 +2049,21 @@ document.addEventListener('mouseup', () => {
   fitAll();
 });
 
+// ─── Global drag handler（サイドバー幅リサイズ, issue #89）─────────────────────
+document.addEventListener('mousemove', e => {
+  if (!sidebarResizeState) return;
+  const dx = e.clientX - sidebarResizeState.startX;
+  setSidebarWidth(sidebarResizeState.startWidth + dx);
+  debouncedFitAll();
+});
+
+document.addEventListener('mouseup', () => {
+  if (!sidebarResizeState) return;
+  sidebarResizeState = null;
+  document.body.classList.remove('resizing-sidebar');
+  fitAll();
+});
+
 // ─── Resize observer ──────────────────────────────────────────────────────────
 let _fitTimer = null;
 function debouncedFitAll() {
@@ -1726,6 +2086,8 @@ function observePanes() {
 }
 
 window.addEventListener('resize', debouncedFitAll);
+// ウィンドウ幅が縮んだときにサイドバー幅の上限（幅比）を超えないよう再クランプする（issue #89）。
+window.addEventListener('resize', () => setSidebarWidth(getSidebarWidth()));
 
 // ─── 設定パネル（汎用）────────────────────────────────────────────────────────
 // main プロセス（settings:describe / settings:save）経由で、呼び出し側が env
@@ -2228,7 +2590,8 @@ async function initApp() {
   focusedPaneId = null;
 
   const paneId = newId();
-  tree = { type: 'grid', order: [paneId], colFr: null, rowFr: null };
+  // stashOrder: サイドバー格納ペインの並び（issue #89）。sidebarWidth: セッション内の可変幅。
+  tree = { type: 'grid', order: [paneId], colFr: null, rowFr: null, stashOrder: [], sidebarWidth: DEFAULT_SIDEBAR_WIDTH };
   await createTerminal(paneId, null);
   focusedPaneId = paneId;
 
@@ -2285,6 +2648,8 @@ setInterval(() => {
       displayTitle: getDisplayTitle(t),
       // collapsed: グリッド化で折り畳み機能を撤去したため常に false（後方互換のためキーは維持）。
       collapsed: false,
+      // stashed: サイドバーへ格納中かどうか（issue #89）。外部監視ツール向けの新規フィールド。
+      stashed: !!(tree && Array.isArray(tree.stashOrder) && tree.stashOrder.includes(paneId)),
       // agentRoom（issue #58）: 解決済みのルーム状態 { name: state }。
       // agentroom 有効時のみ出力（モバイルページ等の将来連携用）。
       ...(agentRoomEnabled ? { agentRoom: resolveRoomAgents(t) } : {}),

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -1268,9 +1268,13 @@ function closePane(paneId) {
   resetGridSizing();
 
   // Focus another pane
-  const remaining = getAllLeafIds();
-  if (remaining.length > 0 && (!focusedPaneId || focusedPaneId === paneId)) {
-    focusedPaneId = remaining[remaining.length - 1];
+  // フォーカス先は可視グリッド（tree.order）の末尾を優先する。getAllLeafIds は格納分も
+  // 含むため、その末尾を選ぶと非表示の格納ペインにフォーカスが移り、キー入力が見えない
+  // ターミナルへ流れてしまう。可視ペインが 1 つも無い（全て格納中）ときはどこにも
+  // フォーカスしない（null）（issue #89 / CodeRabbit 指摘）。
+  if (!focusedPaneId || focusedPaneId === paneId) {
+    const visible = Array.isArray(tree.order) ? tree.order : [];
+    focusedPaneId = visible.length > 0 ? visible[visible.length - 1] : null;
   }
 
   render();

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -727,7 +727,10 @@ function sidebarMaxWidth() {
 }
 
 function clampSidebarWidth(w) {
-  return Math.max(SIDEBAR_MIN_WIDTH, Math.min(sidebarMaxWidth(), Math.round(w)));
+  // 数値化できない値（NaN / undefined / 文字列など）は既定幅にフォールバックする。
+  const n = Number(w);
+  if (!Number.isFinite(n)) return DEFAULT_SIDEBAR_WIDTH;
+  return Math.max(SIDEBAR_MIN_WIDTH, Math.min(sidebarMaxWidth(), Math.round(n)));
 }
 
 // 現在のサイドバー幅（セッション内保持値、無ければ既定）をクランプして返す。
@@ -787,8 +790,14 @@ function renderPaneStash() {
   });
 }
 
+// xterm 表示トグル（― ボタン）のグリフ / ラベルを開閉状態から返す。
+// aria-expanded に加えて視覚グリフも切り替える（表示中=下向き▾ / 非表示=右向き▸）。
+// 並べ替えの ▲▼ とは向き（縦↔横起点）で区別する。
+function stashToggleGlyph(open) { return open ? '▾' : '▸'; }
+function stashToggleLabel(open) { return open ? 'ターミナルを隠す' : 'ターミナルを表示'; }
+
 // 格納ペイン 1 件分（コンパクトカード）を生成する。
-//   - ヘッダ: 状態バッジ + タスク名 + アクション（▲ ▼ ―(表示トグル) →(復帰) ✕）
+//   - ヘッダ: 状態バッジ + タスク名 + アクション（▲ ▼ 表示トグル(▸/▾) →(復帰) ✕）
 //   - cwd 行
 //   - term-container（xterm。既定は非表示、― で開閉）
 function renderStashItem(id, idx, count) {
@@ -815,7 +824,7 @@ function renderStashItem(id, idx, count) {
     <div class="stash-item-actions">
       <button class="btn btn-stash-up" title="上へ移動" aria-label="上へ移動">▲</button>
       <button class="btn btn-stash-down" title="下へ移動" aria-label="下へ移動">▼</button>
-      <button class="btn btn-stash-toggle" title="ターミナルの表示を切り替え" aria-label="ターミナルの表示を切り替え" aria-expanded="${xtermOpen ? 'true' : 'false'}">―</button>
+      <button class="btn btn-stash-toggle" title="${escAttr(stashToggleLabel(xtermOpen))}" aria-label="${escAttr(stashToggleLabel(xtermOpen))}" aria-expanded="${xtermOpen ? 'true' : 'false'}">${escText(stashToggleGlyph(xtermOpen))}</button>
       <span class="stash-actions-sep" aria-hidden="true"></span>
       <button class="btn btn-stash-restore" title="グリッドへ戻す" aria-label="グリッドへ戻す">→</button>
       <button class="btn btn-close" title="閉じる" aria-label="閉じる">✕</button>
@@ -1055,7 +1064,7 @@ function updatePaneTitle(paneId) {
   // renderLeaf() 側の `canDragPane` 判定と同一の式に合わせる。
   // ここで考慮しないと、タイトル / PR をクリアした後に `.pane-task-title` が
   // empty 扱いで消え、ドラッグ起点を失う（CodeRabbit PR #45 指摘）。
-  const canDragPane = !!(tree && Array.isArray(tree.order) && tree.order.length > 1);
+  const canDragPane = canDragGridPane();
   // PR ボタンは apiPrUrl があれば常時表示（採用: 案A）。
   // renderer 側でも http(s) 二段チェックを通してから採用する。
   const prUrl = isSafeExternalUrl(t.apiPrUrl) ? t.apiPrUrl : '';
@@ -1143,6 +1152,13 @@ function getAllLeafIds(t = tree) {
   return grid.concat(stash);
 }
 
+// グリッド上でペイン D&D の起点になれるか（issue #40）。
+// D&D はグリッド内限定のため、格納分を含まないグリッドの order 件数で判定する（issue #89）。
+// グリッドに 2 枚以上あるときのみドラッグ可（1 枚だと移動先が無い）。
+function canDragGridPane() {
+  return !!(tree && Array.isArray(tree.order) && tree.order.length > 1);
+}
+
 // ペインがグリッド・格納のいずれかに存在するか（issue #89 で格納分も含める）。
 function paneExists(id) {
   if (!tree) return false;
@@ -1182,17 +1198,15 @@ function findLargestVisiblePaneId() {
 // ─── Pane actions ─────────────────────────────────────────────────────────────
 // グリッド化により「分割」は入れ子を作らず、新ペインをグリッド末尾に追加する操作になった。
 // direction は後方互換のため引数として残すが、配置には影響しない（自動折返しグリッド）。
-async function splitPane(paneId, direction, overrideCwd, options = {}) {
-  if (!paneExists(paneId)) return null;
-
+// 新規ペインをグリッド末尾に追加する（基準ペイン不要）。
+// splitPane（＋ボタン）と空グリッドのプレースホルダ「新規ペインを追加」で共有する生成経路（issue #89）。
+//   - overrideCwd が指定されていればそれを使い、未指定ならホームディレクトリ（main 側でフォールバック）で開く。
+//   - options.noClaude が指定されていればそのまま main に渡す。未指定なら main 側のグローバル設定に従う。
+async function addPane(overrideCwd = null, options = {}) {
   const newPaneId = newId();
-  // overrideCwd が指定されていればそれを使い、未指定ならホームディレクトリ（main 側でフォールバック）で開く。
-  // 分割元ペインの cwd は継承しない（task-queue 等の特定ディレクトリにいるペインから分割しても
-  // 新ペインはデフォルト位置で開かせる方針）。
-  const targetCwd = overrideCwd || null;
-  // options.noClaude が指定されていればそのまま main に渡す。未指定なら main 側のグローバル設定に従う。
-  await createTerminal(newPaneId, targetCwd, options);
+  await createTerminal(newPaneId, overrideCwd || null, options);
 
+  if (!Array.isArray(tree.order)) tree.order = [];
   tree.order.push(newPaneId);
   // ペイン数が変わりグリッド寸法が変化するため、手動リサイズ比率は均等にリセットする。
   resetGridSizing();
@@ -1205,6 +1219,14 @@ async function splitPane(paneId, direction, overrideCwd, options = {}) {
 
   // 新ペインの情報を返す（focusedPaneId の更新を待たずに確定値を返す）
   return { paneId: newPaneId, termId: terminals[newPaneId]?.termId };
+}
+
+// グリッド化により「分割」は入れ子を作らず、新ペインをグリッド末尾に追加する操作。
+// 分割元ペインの cwd は継承しない（task-queue 等の特定ディレクトリにいるペインから分割しても
+// 新ペインはデフォルト位置で開かせる方針）。
+async function splitPane(paneId, direction, overrideCwd, options = {}) {
+  if (!paneExists(paneId)) return null;
+  return addPane(overrideCwd, options);
 }
 
 function closePane(paneId) {
@@ -1343,7 +1365,13 @@ function toggleStashXterm(paneId) {
   if (li) {
     li.classList.toggle('stash-xterm-open', t.stashXtermOpen);
     const btn = li.querySelector('.btn-stash-toggle');
-    if (btn) btn.setAttribute('aria-expanded', t.stashXtermOpen ? 'true' : 'false');
+    if (btn) {
+      btn.setAttribute('aria-expanded', t.stashXtermOpen ? 'true' : 'false');
+      // 開閉状態に応じてグリフ・ラベルも切り替える（視覚状態の可視化）。
+      btn.textContent = stashToggleGlyph(t.stashXtermOpen);
+      btn.title = stashToggleLabel(t.stashXtermOpen);
+      btn.setAttribute('aria-label', stashToggleLabel(t.stashXtermOpen));
+    }
   }
   if (t.stashXtermOpen) {
     requestAnimationFrame(() => {
@@ -1533,8 +1561,55 @@ function render() {
 //   - colFr / rowFr があれば fr トラックに反映（手動リサイズ結果）。無ければ均等。
 //   - 最終行がフルでない場合、最後のペインを残りの列に広げてスキマを埋める。
 //   - 列間・行間にドラッグ用リサイズハンドルをオーバーレイする。
+// グリッドが空（全ペイン格納中など）のときのプレースホルダ（issue #89）。
+// 空セルだけで行き止まりにならないよう、復帰導線を明示する。
+//   - 「新規ペインを追加」: ＋ と同じ生成経路（addPane）で新規ペインを作る。
+//   - 「サイドバーを開いて戻す」: ドロワーを開き、格納ペインを戻せるようにする。
+function renderEmptyGrid() {
+  const wrap = document.createElement('div');
+  wrap.className = 'grid grid-empty';
+
+  const box = document.createElement('div');
+  box.className = 'grid-empty-box';
+
+  const title = document.createElement('div');
+  title.className = 'grid-empty-title';
+  title.textContent = 'すべてのペインを格納中です';
+
+  const desc = document.createElement('div');
+  desc.className = 'grid-empty-desc';
+  desc.textContent = 'グリッドに表示するペインがありません。新規ペインを追加するか、サイドバーから格納したペインを戻してください。';
+
+  const actions = document.createElement('div');
+  actions.className = 'grid-empty-actions';
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'grid-empty-btn';
+  addBtn.textContent = '新規ペインを追加';
+  addBtn.setAttribute('aria-label', '新規ペインを追加');
+  addBtn.addEventListener('click', () => { addPane(); });
+
+  const openBtn = document.createElement('button');
+  openBtn.type = 'button';
+  openBtn.className = 'grid-empty-btn grid-empty-btn-secondary';
+  openBtn.textContent = 'サイドバーを開いて戻す';
+  openBtn.setAttribute('aria-label', 'サイドバーを開いて格納したペインを戻す');
+  openBtn.addEventListener('click', () => setSidebarOpen(true, { focusFirst: true }));
+
+  actions.appendChild(addBtn);
+  actions.appendChild(openBtn);
+  box.appendChild(title);
+  box.appendChild(desc);
+  box.appendChild(actions);
+  wrap.appendChild(box);
+  return wrap;
+}
+
 function renderGrid(t) {
   const order = (t && Array.isArray(t.order)) ? t.order : [];
+  // グリッドが空のときは行き止まり回避のプレースホルダを返す（issue #89）。
+  if (order.length === 0) return renderEmptyGrid();
   const { cols, rows } = gridDims(t);
 
   const grid = document.createElement('div');
@@ -1690,10 +1765,9 @@ function renderLeaf(node) {
   // タスクタイトル行（OSC 0/2 または POST /api/set-title で設定された文字列を表示）。
   // 空のときは .empty クラスで非表示にし、xterm の表示領域を圧迫しない。
   // apiUrl があるときは .has-link を付与し、内部を <a> 化する（renderTaskTitleContent）。
-  // ペイン D&D の可否判定（issue #40）。グリッド上のペインが 2 つ以上ある時のみ drag 起点になれる。
-  // D&D はグリッド内限定のため、格納分を含む getAllLeafIds ではなくグリッドの order 件数で判定する（issue #89）。
+  // ペイン D&D の可否判定（issue #40 / #89）。判定式は canDragGridPane に集約。
   // 空タイトル時も D&D 可なら .empty を付けず、ハンドルとして掴める高さを確保する。
-  const canDragPane = !!(tree && Array.isArray(tree.order) && tree.order.length > 1);
+  const canDragPane = canDragGridPane();
   const taskTitleEl = document.createElement('div');
   // empty 判定はタイトル本文・ドラッグ可・PR ボタンのいずれもないとき。
   // PR ボタンだけでも表示するためにこの条件で扱う（issue #44）。

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -424,12 +424,14 @@ html, body {
   transition: flex-basis 0.18s ease, transform 0.18s ease;
   z-index: 900;
   background: #0d1117;
-  border-right: 1px solid #21262d;
   color: #e6edf3;
 }
+/* 閉時（実幅 0）は境界線・リサイズハンドルが画面左端に残って見えるため、
+ * どちらも開いているときだけ有効化する（CodeRabbit 指摘）。 */
 #root.sidebar-open .sidebar {
   flex-basis: var(--vktm-sidebar-width, 330px);
   transform: translateX(0);
+  border-right: 1px solid #21262d;
 }
 /* リサイズ中は追従を即時にするためトランジションを切る。 */
 body.resizing-sidebar .sidebar {
@@ -459,6 +461,11 @@ body.resizing-sidebar .sidebar {
   z-index: 910;
   background: transparent;
   transition: background-color 0.12s ease;
+  /* 閉時は非表示（フォーカス対象からも外す）。開いているときだけ表示する。 */
+  display: none;
+}
+#root.sidebar-open .sidebar-resizer {
+  display: block;
 }
 .sidebar-resizer:hover {
   background: rgba(88, 166, 255, 0.35);
@@ -563,6 +570,8 @@ body.resizing-sidebar .sidebar {
 }
 .pane-stash-list {
   list-style: none;
+  margin: 0;
+  padding: 0;
 }
 .stash-item {
   margin-bottom: 8px;

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -410,13 +410,16 @@ html, body {
   overflow: hidden;
 }
 
-/* ─── Sidebar menu ─────────────────────────────────────────────────────────── */
-.sidebar-menu {
+/* ─── Sidebar ──────────────────────────────────────────────────────────────── */
+/* ラッパー（.sidebar）が flex 子・開閉トランジション・可変幅（--vktm-sidebar-width）の基準。
+ * 内側の nav（.sidebar-menu）がメニューと格納ペインをスクロール表示し、
+ * 右端の .sidebar-resizer で幅をドラッグ変更する（issue #89）。 */
+.sidebar {
+  position: relative;
   flex: 0 0 0;
-  width: 252px;
+  width: var(--vktm-sidebar-width, 330px);
   min-width: 0;
   height: 100%;
-  overflow: hidden auto;
   transform: translateX(-100%);
   transition: flex-basis 0.18s ease, transform 0.18s ease;
   z-index: 900;
@@ -424,13 +427,43 @@ html, body {
   border-right: 1px solid #21262d;
   color: #e6edf3;
 }
-#root.sidebar-open .sidebar-menu {
-  flex-basis: 252px;
+#root.sidebar-open .sidebar {
+  flex-basis: var(--vktm-sidebar-width, 330px);
   transform: translateX(0);
 }
+/* リサイズ中は追従を即時にするためトランジションを切る。 */
+body.resizing-sidebar .sidebar {
+  transition: none;
+}
+.sidebar-menu {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden auto;
+}
 .sidebar-menu-inner {
-  width: 252px;
+  width: 100%;
   padding: 10px 8px;
+}
+
+/* サイドバー右端の幅リサイズハンドル。グリッドの .grid-handle と同じく、
+ * 通常は透明・hover/focus 時のみアクセントカラーで可視化する。 */
+.sidebar-resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 8px;
+  height: 100%;
+  transform: translateX(50%);
+  cursor: col-resize;
+  z-index: 910;
+  background: transparent;
+  transition: background-color 0.12s ease;
+}
+.sidebar-resizer:hover,
+.sidebar-resizer:focus-visible {
+  background: rgba(88, 166, 255, 0.35);
+  outline: none;
 }
 .sidebar-menu-list,
 .sidebar-submenu-list {
@@ -501,9 +534,112 @@ html, body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .sidebar-menu {
+  .sidebar {
     transition: none;
   }
+}
+
+/* ─── Pane stash（サイドバーへの格納, issue #89）───────────────────────────────
+ * メニューリストの下に、格納ペインをコンパクトカードで縦積みする。 */
+.pane-stash {
+  margin: 10px 8px 0;
+  padding-top: 10px;
+  border-top: 1px solid #21262d;
+}
+.pane-stash[hidden] {
+  display: none;
+}
+.pane-stash-title {
+  padding: 0 4px 6px;
+  color: #8b949e;
+  font-size: 11px;
+  font-weight: 600;
+}
+.pane-stash-list {
+  list-style: none;
+}
+.stash-item {
+  margin-bottom: 8px;
+  border: 1px solid #21262d;
+  border-radius: var(--vktm--border-radius--md);
+  background: #0d1117;
+  overflow: hidden;
+}
+.stash-item.focused {
+  border-color: #388bfd;
+}
+.stash-item.waiting {
+  border-color: #d29922;
+  animation: waiting-pulse 1.5s ease-in-out infinite;
+}
+.stash-item-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  background: #161b22;
+}
+/* コンパクトカードでは幅が限られるため、idle 時のステータスバッジは
+ * （グリッドのように幅を予約せず）畳んでタスク名の表示幅を優先する。 */
+.stash-item-head .pane-status[data-status="idle"] {
+  display: none;
+}
+.stash-item-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #c9d1d9;
+  font-size: 12px;
+  font-weight: 600;
+}
+.stash-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-shrink: 0;
+}
+/* 格納カードはコンパクトなのでボタンをやや小さめにする。 */
+.stash-item-actions .btn {
+  width: 22px;
+  height: 22px;
+  font-size: 13px;
+}
+.stash-item-actions .btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.stash-item-actions .btn:disabled:hover {
+  color: #768390;
+  background: none;
+}
+.stash-item-cwd {
+  padding: 3px 8px 5px;
+  color: #6e7681;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* 格納中の xterm は既定で非表示。― トグルで開いたときのみ固定高で表示する。 */
+.stash-item .term-container {
+  display: none;
+  flex: none;
+  height: 200px;
+}
+.stash-item.stash-xterm-open .term-container {
+  display: block;
+}
+
+/* 格納/復帰（←→）と並べ替え（◀▶ / ▲▼）を視覚的に分ける区切り線。 */
+.pane-actions-sep,
+.stash-actions-sep {
+  width: 1px;
+  height: 16px;
+  margin: 0 3px;
+  background: #30363d;
+  flex-shrink: 0;
 }
 
 /* ─── Grid container ───────────────────────────────────────────────────────── */

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -460,10 +460,16 @@ body.resizing-sidebar .sidebar {
   background: transparent;
   transition: background-color 0.12s ease;
 }
-.sidebar-resizer:hover,
+.sidebar-resizer:hover {
+  background: rgba(88, 166, 255, 0.35);
+}
+/* キーボードフォーカス時は明確なフォーカスリングを出す（WCAG 2.4.7）。
+ * 細帯なので outline は内側にオフセットし、視認できる 2px の枠にする。 */
 .sidebar-resizer:focus-visible {
   background: rgba(88, 166, 255, 0.35);
-  outline: none;
+  outline: 2px solid #58a6ff;
+  outline-offset: -2px;
+  box-shadow: inset 0 0 0 2px #58a6ff;
 }
 .sidebar-menu-list,
 .sidebar-submenu-list {
@@ -654,6 +660,66 @@ body.resizing-sidebar .sidebar {
   display: grid;
   gap: 6px;
   padding: 6px;
+}
+
+/* ─── Empty grid placeholder（全ペイン格納中の行き止まり回避, issue #89）──────── */
+.grid.grid-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.grid-empty-box {
+  max-width: 420px;
+  padding: 24px;
+  text-align: center;
+  color: #c9d1d9;
+}
+.grid-empty-title {
+  margin-bottom: 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.grid-empty-desc {
+  margin-bottom: 20px;
+  color: #8b949e;
+  font-size: 13px;
+  line-height: 1.6;
+}
+.grid-empty-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.grid-empty-btn {
+  padding: 8px 16px;
+  border: 1px solid #2ea043;
+  border-radius: 6px;
+  background: #238636;
+  color: #ffffff;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.grid-empty-btn:hover {
+  background: #2ea043;
+  border-color: #3fb950;
+}
+.grid-empty-btn:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+/* 副次アクション（サイドバーを開く）は控えめなニュートラル配色にする。 */
+.grid-empty-btn-secondary {
+  border-color: #30363d;
+  background: #21262d;
+  color: #c9d1d9;
+}
+.grid-empty-btn-secondary:hover {
+  background: #30363d;
+  border-color: #8b949e;
 }
 
 /* ─── Grid resize handles ──────────────────────────────────────────────────── */


### PR DESCRIPTION
関連 issue: https://github.com/vektor-inc/vk-terminals/issues/89

## 概要

ペイン（ターミナル）が増えて表示エリアが足りなくなる問題への対処として、グリッド上のペインを既存サイドバー（☰ ドロワー）内に **格納（退避）** し、必要なときにグリッドへ戻せる機能を追加します。格納中もターミナル（pty）は稼働を継続し、サイドバー幅はドラッグで可変です。

格納先は新設ドックではなく **既存サイドバーの中** としています（issue の「幅は現状より1.3倍」＝既存サイドバー 252px 基準、および「常時監視は不要」というご意向を反映。仕様確定の経緯は issue #89 のコメント参照）。

## 変更内容

- **格納 / 復帰**: グリッドのペインヘッダに `←`（格納）を新設。格納ペインは既存サイドバー内の専用セクション（`#pane-stash`）にコンパクトカード（状態バッジ＋タスク名＋cwd）として表示。カードの `→` でグリッドへ復帰。
  - xterm 要素は破棄せず DOM を付け替えるだけ（既存の `render()` と同方式）なので、格納/復帰・表示切替で端末内容・スクロールバック・pty プロセスを維持。
  - サイドバーメニューの再描画（`renderSidebarMenu`）は内側リストのみ作り直し、`#pane-stash` は触らないため、再描画で xterm が detach されない構造に分離。
- **サイドバー幅**: 既定約 330px（従来 252px の約1.3倍）に拡張。右端ハンドルでドラッグ可変（最小 200px / 最大 ≈ウィンドウ幅 45%、ウィンドウ縮小時に再クランプ）。ハンドルは `role="separator"` ＋ 矢印キー操作対応・`:focus-visible` フォーカスリング付き。
- **ターミナル表示トグル**: 格納カードはデフォルト xterm 非表示。`▸`/`▾` ボタンで表示/非表示を切替（`aria-expanded`・ラベル同期）。
- **並べ替え**: 格納カードの `▲▼` で上下入替（グリッドの ◀▶ / D&D はグリッド内限定のまま）。
- **空グリッドの導線**: すべてのペインを格納してグリッドが空になった場合、「すべてのペインを格納中です」＋「新規ペインを追加」「サイドバーを開いて戻す」ボタンのプレースホルダを表示（行き止まり防止）。

## レビュー

- 🔒 セキュリティ（安藤）: PASS。格納カードの外部由来値（cwd 等）は `escText`/`escAttr` ＋ `textContent` 代入でエスケープ済み。
- 🎨 UX（植草）: PASS（空グリッド導線・リサイズハンドルのフォーカス視認性を初回指摘 → 対応済み）。

## テスト（確認手順）

前提: `npm start` でアプリを起動し、ヘッダの `＋` でペインを2枚以上用意する。

1. あるペインのヘッダ左端 `←` をクリックする → そのペインがサイドバー内の格納カードに移り、グリッドは1枚減って再レイアウトされる。サイドバーが自動で開く。
2. 格納カードの `▸` をクリック → ターミナルが表示され、記号が `▾` に変わる。もう一度クリックで非表示（`▸`）に戻る。表示中、格納したターミナルのプロンプト/ログが動いている（＝pty 継続稼働）ことを確認する。
3. ペインをもう1枚格納し、カードの `▲` / `▼` をクリック → 格納カードの上下の並び順が入れ替わる。
4. 格納カードの `→` をクリック → ペインがグリッドへ戻り、格納前の端末内容が保持されている。
5. サイドバー右端のハンドルを左右にドラッグ → サイドバー幅が変わる（約200px〜ウィンドウ幅45%でクランプ）。ハンドルに `Tab` でフォーカスし、`←`/`→` 矢印キーで幅が増減し、フォーカスリングが見えることを確認する。
6. すべてのペインを格納する → グリッドに「すべてのペインを格納中です」とプレースホルダが表示される。「新規ペインを追加」でグリッドに新規ペインが出る／「サイドバーを開いて戻す」でサイドバーが開くことを確認する。

### デグレ確認
- 既存のグリッド操作（`◀`/`▶` 並べ替え・ドラッグ&ドロップ並べ替え・`＋` 追加・`✕` 閉じる）が従来どおり動く。
- `npm test`（`node --test`）76 件が pass（既存テストの破壊なし）。

> **スクリーンショット / GIF**: 表示・UI 変更を含むため、実機での見た目（格納カード・空グリッド・幅リサイズ）の Before/After は、次工程の e2e/UI 確認（麗美）で取得・添付予定です。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * サイドバーにペインを格納・復帰できる機能を追加しました。
  * サイドバー幅の調整や、ドラッグ／キーボードでの操作に対応しました。
  * グリッドが空のときに案内カードと操作ボタンを表示するようになりました。

* **改善**
  * 格納中のペインでも状態表示やフォーカスの同期が反映されるようになりました。
  * ウィンドウサイズ変更時の表示崩れや、非表示時の不正なリサイズを抑制しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->