### PR TITLE
[ 機能追加 ] HTTP API /api/new-pane に stashed オプションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 機能追加 ] HTTP API `POST /api/new-pane` に `stashed` オプションを追加し、`stashed: true` で生成ペインをサイドバー格納＋折りたたみ状態で開けるように（[#93](https://github.com/vektor-inc/vk-terminals/issues/93)）
+
 ## 1.11.1
 
 - [ 不具合修正 ] ペインをリサイズすると「🟡 入力待ち」インジケータが消える不具合を修正。入力待ち状態を入力まで保持し、リサイズ起因の再描画（確認文の折り返し変化）による誤解除を防止（[#91](https://github.com/vektor-inc/vk-terminals/issues/91)）

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ curl -i -s -X POST http://127.0.0.1:13847/api/set-title \
 
 #### `POST /api/new-pane`
 
-新規ペインを作成し、作成されたターミナルの `termId` を返します。ペインはグリッドの末尾に追加され、全体は自動折返しグリッドで再配置されます。
+新規ペインを作成し、作成されたターミナルの `termId` を返します。ペインは通常グリッドの末尾に追加され、全体は自動折返しグリッドで再配置されます。`stashed: true` を指定した場合はサイドバー格納＋折りたたみ状態で作成されます。
 
 ```bash
 curl -s -X POST http://127.0.0.1:13847/api/new-pane
@@ -447,12 +447,18 @@ curl -s -X POST http://127.0.0.1:13847/api/new-pane \
 curl -s -X POST http://127.0.0.1:13847/api/new-pane \
   -H 'Content-Type: application/json' \
   -d '{"noClaude": true}'
+
+# サイドバーに格納して折りたたみ状態で開く
+curl -s -X POST http://127.0.0.1:13847/api/new-pane \
+  -H 'Content-Type: application/json' \
+  -d '{"stashed": true}'
 ```
 
 リクエストボディ（任意）:
 
 - `cwd`：新規ペインのカレントディレクトリ（絶対パス）。未指定ならホームディレクトリ。
 - `noClaude`：`true` の場合、新規ペインで claude を自動起動せず素のシェルとして開く。未指定なら起動時の `--no-claude` フラグの値に従う。
+- `stashed`：`true` の場合、新規ペインをサイドバー格納＋折りたたみ状態で開く。未指定または `false` ならグリッドに追加。
 
 レスポンス:
 

--- a/main.js
+++ b/main.js
@@ -1333,9 +1333,10 @@ function startHttpApi() {
       return;
     }
 
-    // POST /api/new-pane  { cwd?: "/path/to/dir", noClaude?: boolean } — 新規ペインを作成して termId を返す
+    // POST /api/new-pane  { cwd?: "/path/to/dir", noClaude?: boolean, stashed?: boolean } — 新規ペインを作成して termId を返す
     //   cwd を指定すればそのディレクトリで開く。未指定なら HOME で開く。
     //   noClaude: true を指定すると、新規ペインで claude を自動起動せず素のシェルとして開く。
+    //   stashed: true を指定すると、サイドバー格納＋折りたたみ状態で開く。
     if (req.method === 'POST' && url.pathname === '/api/new-pane') {
       if (isForbiddenOrigin(req)) {
         res.writeHead(403, { 'Content-Type': 'application/json' });
@@ -1351,6 +1352,7 @@ function startHttpApi() {
       readJsonBody(req, res, MAX_BODY, (body) => {
         let requestedCwd = null;
         let requestedNoClaude;
+        let requestedStashed;
         if (body.length > 0) {
           try {
             const parsed = JSON.parse(body);
@@ -1359,6 +1361,9 @@ function startHttpApi() {
             }
             if (typeof parsed?.noClaude === 'boolean') {
               requestedNoClaude = parsed.noClaude;
+            }
+            if (typeof parsed?.stashed === 'boolean') {
+              requestedStashed = parsed.stashed;
             }
           } catch {
             res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -1387,6 +1392,7 @@ function startHttpApi() {
         pendingNewPaneCallbacks.set(requestId, resolve);
         const payload = { requestId, cwd: requestedCwd };
         if (typeof requestedNoClaude === 'boolean') payload.noClaude = requestedNoClaude;
+        if (typeof requestedStashed === 'boolean') payload.stashed = requestedStashed;
         win.webContents.send('terminal:request-new-pane', payload);
       });
       return;

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -2707,7 +2707,7 @@ ipcRenderer.on('terminal:agentroom', (event, termId, agents, replace) => {
 
 // ─── New pane request from HTTP API ──────────────────────────────────────────
 ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
-  const { requestId, cwd, noClaude } = payload;
+  const { requestId, cwd, noClaude, stashed } = payload;
   const reply = (result) => ipcRenderer.send('terminal:new-pane-created', { requestId, ...result });
   const targetPaneId = findLargestVisiblePaneId() || focusedPaneId || (tree ? getAllLeafIds(tree)[0] : null);
   if (!targetPaneId) {
@@ -2723,6 +2723,9 @@ ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
     if (!result || !result.termId) {
       reply({ error: 'split failed or termId unavailable' });
       return;
+    }
+    if (stashed === true) {
+      stashPane(result.paneId);
     }
     reply({ termId: result.termId });
   } catch (e) {


### PR DESCRIPTION
## 概要

HTTP API `POST /api/new-pane` に `stashed: boolean` オプションを追加しました。`stashed: true` を指定すると、生成したペインをグリッドではなく **サイドバー格納＋折りたたみ（コンパクト表示 / `stashXtermOpen: false`）** の状態で開きます。

vk-orchestrator が `up` 時に orchestrator ペインを「サイドバー格納＋折りたたみ」で起動したい（vektor-inc/vk-orchestrator#54）という要望に対応するものです。従来サイドバー格納は renderer 内の UI 操作（`stashPane`）でしか起こせず、API 生成時に格納する経路がありませんでした。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/93

## 変更内容

- **main.js** — `POST /api/new-pane` の payload パースで `stashed`（boolean）を受理し、`terminal:request-new-pane` の payload へ透過（既存の `noClaude` 透過と同じパターン）。API 仕様コメントも更新。
- **renderer/app.js** — `terminal:request-new-pane` ハンドラで `stashed === true` のとき、`splitPane` 成功後に生成 paneId を既存の `stashPane()` に通してサイドバー格納＋折りたたみにする。未指定・`false` は従来どおりグリッドに追加（後方互換維持）。
- **README.md** — `/api/new-pane` の API 仕様に `stashed` オプションと curl 例を追記。
- **CHANGELOG.md** — 機能追加エントリを追記。

## テスト（確認手順）

前提: `npm start` で VK Terminals を起動しておく（HTTP API はデフォルト `http://127.0.0.1:13847`）。

### 1. stashed: true でサイドバー格納＋折りたたみ生成

```bash
curl -s -X POST http://127.0.0.1:13847/api/new-pane \
  -H 'Content-Type: application/json' \
  -d '{"stashed": true}'
```

→ レスポンスが `{"ok":true,"termId":...}` を返す。
→ 新規ペインが **グリッドに現れず**、サイドバーが開いて格納リストに折りたたみ（xterm 非表示のコンパクト）状態で追加される。

### 2. 後方互換（stashed 未指定）

```bash
curl -s -X POST http://127.0.0.1:13847/api/new-pane
```

→ 従来どおり新規ペインが **グリッドの末尾** に追加される（サイドバー格納されない）。

### 3. 型ガードの確認（不正値は無視）

```bash
curl -s -X POST http://127.0.0.1:13847/api/new-pane \
  -H 'Content-Type: application/json' \
  -d '{"stashed": "true"}'
```

→ 文字列 `"true"` は boolean ではないため無視され、**グリッドに追加**される（誤発火しない）。

### デグレ確認

- `noClaude` オプションが従来どおり機能すること（`{"noClaude": true}` で素のシェルペインが生成される）。
- `npm test`（82 件）が通ること。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 新しいペイン作成時に、サイドバーへ格納した折りたたみ状態で開けるオプションが追加されました。
  * この設定を使うと、通常のグリッド追加ではなく、整理された表示で新規ペインを開けます。

* **ドキュメント**
  * API 利用例と説明を更新し、新オプションの指定方法と動作が分かるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->