### PR TITLE
[ 機能追加 ] HTTP API /api/set-status を追加し外部権威の入力待ちフラグを導入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 機能追加 ] HTTP API `POST /api/set-status` を追加し、オーケストレーター等が入力待ち状態を外部から権威的に設定/解除できるように。外部権威フラグは自動入力・リサイズ・再描画では解除されず、明示 push でのみ解除（[#95](https://github.com/vektor-inc/vk-terminals/issues/95)）
+
 ## 1.12.0
 
 - [ 機能追加 ] HTTP API `POST /api/new-pane` に `stashed` オプションを追加し、`stashed: true` で生成ペインをサイドバー格納＋折りたたみ状態で開けるように（[#93](https://github.com/vektor-inc/vk-terminals/issues/93)）

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ curl -s http://127.0.0.1:13847/api/states | python3 -m json.tool
       "cwd": "/Users/you/project",
       "cwdShort": "~/project",
       "waiting": false,
+      "externalWaiting": false,
+      "status": "idle",
       "lastOutputTime": 1713340800000,
       "lastInputTime": 1713340790000,
       "lastLines": "最近の出力15行分..."
@@ -331,6 +333,8 @@ curl -s http://127.0.0.1:13847/api/states | python3 -m json.tool
 | `termId` | ターミナル ID（`/api/send` で使用） |
 | `cwd` / `cwdShort` | カレントディレクトリ（フルパス / 短縮表示） |
 | `waiting` | 入力待ち状態（権限確認プロンプト等）かどうか |
+| `externalWaiting` | `POST /api/set-status` で設定された外部権威の入力待ち状態 |
+| `status` | 表示用ステータス（`idle` / `running` / `waiting`） |
 | `lastOutputTime` | 最後に出力があった時刻（Unix ms） |
 | `lastInputTime` | 最後にユーザーが入力した時刻（Unix ms） |
 | `lastLines` | 最近の出力テキスト（ANSI除去済み、最大15行） |
@@ -429,6 +433,47 @@ curl -i -s -X POST http://127.0.0.1:13847/api/set-title \
 ```
 
 設定された値は `GET /api/states` のレスポンス（および `~/.vk-terminals/states.json`）の各ペインオブジェクトに `apiTitle` / `apiUrl` / `apiPrUrl` フィールドとして含まれます。
+
+#### `POST /api/set-status`
+
+指定ペインの入力待ち状態を外部権威として設定します。オーケストレーター等が GitHub status などの外部状態をもとに、ローカル PTY のパターン検知とは別レイヤーで `waiting` 表示を制御するための API です。
+
+```bash
+# 外部権威の入力待ちフラグを立てる
+curl -s -X POST http://127.0.0.1:13847/api/set-status \
+  -H 'Content-Type: application/json' \
+  -d '{"termId": "1", "waiting": true}'
+
+# 外部権威の入力待ちフラグを解除する
+curl -s -X POST http://127.0.0.1:13847/api/set-status \
+  -H 'Content-Type: application/json' \
+  -d '{"termId": "1", "waiting": false}'
+```
+
+リクエストボディ:
+
+- `termId`: 対象のターミナル ID（必須）
+- `waiting`: 外部権威の入力待ち状態（真偽値必須）。文字列 `"true"` / `"false"` は受け付けません。
+
+挙動:
+
+- `waiting: true` を送ると、ローカル PTY 検知の `waiting` が false でも表示用 `status` は `waiting` になります。
+- `waiting: false` を送ると、外部権威フラグだけを解除します。ローカル PTY 検知の `waiting` が true の場合、表示用 `status` は引き続き `waiting` です。
+- 外部権威フラグは自動入力（`POST /api/send`）・リサイズ・再描画では解除されず、`POST /api/set-status` で `waiting: false` が明示 push されたときだけ解除されます。
+
+レスポンス例:
+
+```json
+{ "ok": true, "termId": "1", "waiting": true }
+```
+
+エラー例:
+
+- `400 {"error": "termId required"}` — `termId` 未指定
+- `400 {"error": "waiting must be a boolean"}` — `waiting` が真偽値以外
+- `404 {"error": "terminal <id> not found"}` — 指定 `termId` のペインが存在しない
+
+設定された値は `GET /api/states` のレスポンス（および `~/.vk-terminals/states.json`）の各ペインオブジェクトに `externalWaiting` フィールドとして含まれます。表示用 `status` はローカル `waiting` と `externalWaiting` の OR で `waiting` になります。
 
 #### `POST /api/new-pane`
 

--- a/main.js
+++ b/main.js
@@ -1201,6 +1201,51 @@ function startHttpApi() {
       return;
     }
 
+    // POST /api/set-status  { termId: "1", waiting: true }
+    //   — オーケストレーター等の外部権威が、そのペインの入力待ち状態を明示設定する。
+    //   waiting: true で外部権威フラグを立て、waiting: false で解除する。
+    //   ローカル PTY 検知とは別レイヤーとして renderer 側で OR 合流し、自動入力・再描画では解除しない。
+    //   termId は必須、waiting は真偽値のみ許可する（文字列 "true" 等は 400）。
+    if (req.method === 'POST' && url.pathname === '/api/set-status') {
+      if (isForbiddenOrigin(req)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'forbidden origin' }));
+        return;
+      }
+      const MAX_BODY = 10 * 1024;
+      readJsonBody(req, res, MAX_BODY, (body) => {
+        try {
+          const parsed = JSON.parse(body);
+          const termId = parsed?.termId != null ? String(parsed.termId) : '';
+          if (!termId) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'termId required' }));
+            return;
+          }
+          if (!ptys.has(termId)) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: `terminal ${termId} not found` }));
+            return;
+          }
+          if (typeof parsed?.waiting !== 'boolean') {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'waiting must be a boolean' }));
+            return;
+          }
+          const waiting = parsed.waiting;
+          if (win && !win.isDestroyed()) {
+            win.webContents.send('terminal:set-status', termId, waiting);
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, termId, waiting }));
+        } catch (e) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid JSON' }));
+        }
+      });
+      return;
+    }
+
     // POST /api/agentroom  { termId: "1", agents?: {"和田":"working", ...}, agent?: "麗美", state?: "consulting" }
     //   — エージェントルーム（issue #58）の稼働状況を更新する。config.json の `agentroom: true` 時のみ表示に反映。
     //   `agents` オブジェクトを渡すとそのペインのルーム状態を丸ごと置換する（置換セマンティクス）。

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -57,7 +57,7 @@ const PANE_DROP_DEADZONE = 0.2;
 //     どちらも false で直近 1500ms 以内に PTY 出力があり、かつ直近 200ms 以内に入力がなければ 'running'。
 //     どちらでもなければ 'idle'（DOM 側で要素ごと非表示）。
 //   - runningTimer (number|null): 'running' を 1500ms 後に 'idle' へ戻すための setTimeout id。
-//     bumpRunning() が出力イベントごとに張り直し、closePane() で必ず clearTimeout する。
+//     recomputeStatus() / bumpRunning() が張り直し、closePane() で必ず clearTimeout する。
 let terminals = {};    // paneId -> { termId, term, fitAddon, element, cwd, cwdFull, waiting, status, runningTimer, lastLines, ... }
 let focusedPaneId = null;
 let dragState = null;
@@ -135,6 +135,29 @@ function markPaneInput(paneId) {
   recomputeStatus(paneId);
 }
 
+function clearRunningIdleTimer(t) {
+  if (!t?.runningTimer) return;
+  clearTimeout(t.runningTimer);
+  t.runningTimer = null;
+}
+
+// running 表示の自動 idle 復帰タイマーを張り直す。
+function armRunningIdleTimer(paneId) {
+  const t = terminals[paneId];
+  if (!t) return;
+  clearRunningIdleTimer(t);
+  t.runningTimer = setTimeout(() => {
+    const cur = terminals[paneId];
+    if (!cur) return;
+    cur.runningTimer = null;
+    // タイマー満了時に waiting に変わっていたらそのまま、そうでなければ idle に戻す。
+    if (!cur.waiting && !cur.externalWaiting && cur.status === 'running') {
+      cur.status = 'idle';
+      updatePaneStatus(paneId);
+    }
+  }, RUNNING_IDLE_TIMEOUT_MS);
+}
+
 // status を waiting フラグ・外部権威フラグ・最終出力時刻・最終入力時刻から再計算してセットする。
 // 派生フィールドのため、ここ以外から t.status を直接書き換えないこと。
 function recomputeStatus(paneId) {
@@ -149,6 +172,11 @@ function recomputeStatus(paneId) {
     runningIdleTimeoutMs: RUNNING_IDLE_TIMEOUT_MS,
     runningInputGuardMs: RUNNING_INPUT_GUARD_MS,
   });
+  if (next === 'running') {
+    armRunningIdleTimer(paneId);
+  } else {
+    clearRunningIdleTimer(t);
+  }
   if (next !== t.status) {
     t.status = next;
     updatePaneStatus(paneId);
@@ -163,10 +191,7 @@ function bumpRunning(paneId) {
   // waiting は最優先のため running に上書きしない
   if (t.waiting || t.externalWaiting) return;
   // タイマーは出力ごとに張り直す
-  if (t.runningTimer) {
-    clearTimeout(t.runningTimer);
-    t.runningTimer = null;
-  }
+  clearRunningIdleTimer(t);
   const now = Date.now();
   const recentInput = now - (t.lastInputTime || 0) <= RUNNING_INPUT_GUARD_MS;
   // 入力直後（タイプ中のエコー）は running と見なさない。idle のまま据え置く。
@@ -175,16 +200,7 @@ function bumpRunning(paneId) {
     t.status = 'running';
     updatePaneStatus(paneId);
   }
-  t.runningTimer = setTimeout(() => {
-    const cur = terminals[paneId];
-    if (!cur) return;
-    cur.runningTimer = null;
-    // タイマー満了時に waiting に変わっていたらそのまま、そうでなければ idle に戻す
-    if (!cur.waiting && !cur.externalWaiting && cur.status === 'running') {
-      cur.status = 'idle';
-      updatePaneStatus(paneId);
-    }
-  }, RUNNING_IDLE_TIMEOUT_MS);
+  armRunningIdleTimer(paneId);
 }
 
 // ─── Create terminal ──────────────────────────────────────────────────────────
@@ -278,7 +294,7 @@ async function createTerminal(paneId, cwd, options = {}) {
     // 初期値 'idle' は何も表示しない（.pane-status[data-status="idle"] は display:none）。
     status: 'idle',
     // runningTimer: 'running' を 1500ms 後に 'idle' に戻すタイマー id。
-    // 出力イベントごとに bumpRunning() が張り直す。closePane() で必ず clearTimeout する。
+    // recomputeStatus() / bumpRunning() が張り直す。closePane() で必ず clearTimeout する。
     runningTimer: null,
     lastLines: '',
     lastOutputTime: Date.now(),
@@ -1194,10 +1210,7 @@ function closePane(paneId) {
   if (t) {
     // status の自動 idle 復帰タイマーが残っているとクロージャ経由で terminals[paneId] を
     // 参照し続けてしまうため、必ず破棄する（リーク防止）。
-    if (t.runningTimer) {
-      clearTimeout(t.runningTimer);
-      t.runningTimer = null;
-    }
+    clearRunningIdleTimer(t);
     // auto-input バッジの自動非表示タイマーも残っていればクリアする
     // （runningTimer と一貫させた防御的なクリーンアップ／issue #38）
     const paneEl = document.querySelector(`.pane[data-id="${paneId}"]`);

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -6,6 +6,7 @@ const { stripAnsiForDisplay } = require('../utils/stripAnsi');
 // エージェントルーム（issue #58）。サブエージェントの稼働状況をドット絵キャラで可視化する。
 const { AGENT_ORDER, buildScene, resolveAgentStatesFromOutput } = require('./agentRoom');
 const { matchesWaiting, nextWaitingState } = require('./waitingState');
+const { deriveStatus } = require('./statusState');
 
 // ─── xterm.css の注入 ─────────────────────────────────────────────────────────
 // xterm.css は index.html の相対パス <link> ではなく、Node のモジュール解決
@@ -49,9 +50,11 @@ const PANE_DROP_DEADZONE = 0.2;
 // terminals[paneId] のフィールド概要（status / runningTimer は issue #23 で追加）:
 //   - waiting (bool): 内部判定用フラグ。WAITING_PATTERNS ヒットで true になり、入力まで保持。
 //     states.json 後方互換のために残してある（task-queue 等の外部連携が参照している）。
+//   - externalWaiting (bool): 外部権威の入力待ちフラグ。POST /api/set-status の明示 push だけで更新。
+//     自動入力・リサイズ・再描画では解除せず、waiting と OR で status に合流する。
 //   - status ('idle'|'running'|'waiting'): 表示用の派生値。
-//     waiting が true なら 'waiting' を最優先。
-//     waiting でなく直近 1500ms 以内に PTY 出力があり、かつ直近 200ms 以内に入力がなければ 'running'。
+//     waiting または externalWaiting が true なら 'waiting' を最優先。
+//     どちらも false で直近 1500ms 以内に PTY 出力があり、かつ直近 200ms 以内に入力がなければ 'running'。
 //     どちらでもなければ 'idle'（DOM 側で要素ごと非表示）。
 //   - runningTimer (number|null): 'running' を 1500ms 後に 'idle' へ戻すための setTimeout id。
 //     bumpRunning() が出力イベントごとに張り直し、closePane() で必ず clearTimeout する。
@@ -119,8 +122,8 @@ function checkWaiting(paneId) {
   }
 }
 
-// 入力（ユーザー入力・ドロップ送信・API 送信）があったペインの入力待ち状態を解除する。
-// スティッキー化した waiting の唯一の解除経路。全入力エントリポイントから呼ぶこと。
+// 入力（ユーザー入力・ドロップ送信・API 送信）があったペインのローカル入力待ち状態を解除する。
+// スティッキー化した waiting の唯一の解除経路。externalWaiting は外部の明示 false push だけで解除する。
 function markPaneInput(paneId) {
   const t = terminals[paneId];
   if (!t) return;
@@ -132,20 +135,20 @@ function markPaneInput(paneId) {
   recomputeStatus(paneId);
 }
 
-// status を waiting フラグ・最終出力時刻・最終入力時刻から再計算してセットする。
+// status を waiting フラグ・外部権威フラグ・最終出力時刻・最終入力時刻から再計算してセットする。
 // 派生フィールドのため、ここ以外から t.status を直接書き換えないこと。
 function recomputeStatus(paneId) {
   const t = terminals[paneId];
   if (!t) return;
-  let next;
-  if (t.waiting) {
-    next = 'waiting';
-  } else {
-    const now = Date.now();
-    const recentOutput = now - (t.lastOutputTime || 0) <= RUNNING_IDLE_TIMEOUT_MS;
-    const recentInput = now - (t.lastInputTime || 0) <= RUNNING_INPUT_GUARD_MS;
-    next = (recentOutput && !recentInput) ? 'running' : 'idle';
-  }
+  const next = deriveStatus({
+    localWaiting: t.waiting,
+    externalWaiting: t.externalWaiting,
+    now: Date.now(),
+    lastOutputTime: t.lastOutputTime,
+    lastInputTime: t.lastInputTime,
+    runningIdleTimeoutMs: RUNNING_IDLE_TIMEOUT_MS,
+    runningInputGuardMs: RUNNING_INPUT_GUARD_MS,
+  });
   if (next !== t.status) {
     t.status = next;
     updatePaneStatus(paneId);
@@ -158,7 +161,7 @@ function bumpRunning(paneId) {
   const t = terminals[paneId];
   if (!t) return;
   // waiting は最優先のため running に上書きしない
-  if (t.waiting) return;
+  if (t.waiting || t.externalWaiting) return;
   // タイマーは出力ごとに張り直す
   if (t.runningTimer) {
     clearTimeout(t.runningTimer);
@@ -177,7 +180,7 @@ function bumpRunning(paneId) {
     if (!cur) return;
     cur.runningTimer = null;
     // タイマー満了時に waiting に変わっていたらそのまま、そうでなければ idle に戻す
-    if (!cur.waiting && cur.status === 'running') {
+    if (!cur.waiting && !cur.externalWaiting && cur.status === 'running') {
       cur.status = 'idle';
       updatePaneStatus(paneId);
     }
@@ -267,6 +270,10 @@ async function createTerminal(paneId, cwd, options = {}) {
     cwd: shortCwd,
     cwdFull: initialCwd,
     waiting: false,
+    // externalWaiting: オーケストレーター等が POST /api/set-status で明示 push する外部権威の入力待ちフラグ。
+    // ローカル PTY 検知(waiting)と OR で status に合流する。markPaneInput / リサイズ / 再描画 /
+    // 自動入力では解除されず、明示的な false push でのみ解除される。
+    externalWaiting: false,
     // status: 表示用ステータス。issue #23 で追加。
     // 初期値 'idle' は何も表示しない（.pane-status[data-status="idle"] は display:none）。
     status: 'idle',
@@ -752,10 +759,11 @@ function stashToggleLabel(open) { return open ? 'ターミナルを隠す' : '�
 //   - term-container（xterm。既定は非表示、― で開閉）
 function renderStashItem(id, idx, count) {
   const t = terminals[id];
+  const waiting = !!(t && (t.waiting || t.externalWaiting));
   const li = document.createElement('li');
   li.className = 'stash-item'
     + (id === focusedPaneId ? ' focused' : '')
-    + (t?.waiting ? ' waiting' : '');
+    + (waiting ? ' waiting' : '');
   li.dataset.id = id;
   const xtermOpen = !!(t && t.stashXtermOpen);
   if (xtermOpen) li.classList.add('stash-xterm-open');
@@ -814,7 +822,7 @@ function updateStashItem(paneId) {
   if (!li) return;
   const t = terminals[paneId];
   if (!t) return;
-  li.classList.toggle('waiting', !!t.waiting);
+  li.classList.toggle('waiting', !!(t.waiting || t.externalWaiting));
   const badge = li.querySelector('.pane-status');
   if (badge) {
     const status = t.status || 'idle';
@@ -1036,7 +1044,7 @@ function updatePaneTitle(paneId) {
 }
 
 // .pane-status バッジ（ヘッダ最左）と .pane.waiting 枠点滅の両方を更新する。
-// status は派生フィールドのため、t.waiting / t.status は呼び出し側で先にセット済みである前提。
+// status は派生フィールドのため、waiting 系フラグ / t.status は呼び出し側で先にセット済みである前提。
 function updatePaneStatus(paneId) {
   const t = terminals[paneId];
   if (!t) return;
@@ -1044,8 +1052,8 @@ function updatePaneStatus(paneId) {
   updateStashItem(paneId);
   const paneEl = document.querySelector(`.pane[data-id="${paneId}"]`);
   if (!paneEl) return;
-  // 枠の点滅アニメ（周辺視野での気付き用、issue #23 でも残置）は waiting フラグ準拠
-  paneEl.classList.toggle('waiting', t.waiting);
+  // 枠の点滅アニメ（周辺視野での気付き用、issue #23 でも残置）は派生 waiting 準拠
+  paneEl.classList.toggle('waiting', !!(t.waiting || t.externalWaiting));
 
   const badge = paneEl.querySelector('.pane-status');
   if (!badge) return;
@@ -1696,7 +1704,7 @@ function refreshAgentRoomIfChanged(paneId) {
 function renderLeaf(node) {
   const t = terminals[node.id];
   const cwd = t?.cwd || '~';
-  const waiting = t?.waiting || false;
+  const waiting = !!(t && (t.waiting || t.externalWaiting));
   // 表示用ステータス（issue #23, #27）。idle 時は CSS の visibility:hidden で不可視のまま幅は保持。
   // ドットは CSS の .pane-status::before（currentColor）で描画するため、ラベルはテキストのみ。
   // ラベル / aria-label の対応は getStatusPresentation に集約（updatePaneStatus と共用）。
@@ -2659,6 +2667,8 @@ setInterval(() => {
       cwdShort: t.cwd || '~',
       // waiting は内部判定フラグ。後方互換のため引き続き出力（task-queue 連携などが参照）。
       waiting: t.waiting,
+      // externalWaiting は POST /api/set-status 由来の外部権威フラグ。
+      externalWaiting: t.externalWaiting || false,
       // status は issue #23 で追加した表示用ステータス（'idle' | 'running' | 'waiting'）。
       // 既存フィールドは破壊せず、新規追加のみ。
       status: t.status || 'idle',
@@ -2759,6 +2769,17 @@ ipcRenderer.on('terminal:title', (event, termId, title, url, prUrl) => {
     terminals[paneId].apiPrUrl = prUrl;
   }
   updatePaneTitle(paneId);
+});
+
+// ─── Status update from main (HTTP API POST /api/set-status) ────────────────
+// 外部権威の入力待ちフラグを明示的に設定する。markPaneInput / 自動入力では解除しない。
+ipcRenderer.on('terminal:set-status', (event, termId, waiting) => {
+  const paneId = Object.keys(terminals).find(k => terminals[k]?.termId === termId);
+  if (!paneId) return;
+  const t = terminals[paneId];
+  if (!t) return;
+  t.externalWaiting = !!waiting;
+  recomputeStatus(paneId);
 });
 
 // ─── Auto-input notification from main (HTTP API経由の入力時) ─────────────────

--- a/renderer/statusState.js
+++ b/renderer/statusState.js
@@ -1,0 +1,23 @@
+/* global module */
+
+// ─── Status derivation ───────────────────────────────────────────────────────
+
+// deriveStatus: waiting / running / idle を純粋に判定する。
+function deriveStatus({
+  localWaiting,
+  externalWaiting,
+  now,
+  lastOutputTime,
+  lastInputTime,
+  runningIdleTimeoutMs,
+  runningInputGuardMs,
+}) {
+  if (localWaiting || externalWaiting) return 'waiting';
+  const recentOutput = now - (lastOutputTime || 0) <= runningIdleTimeoutMs;
+  const recentInput = now - (lastInputTime || 0) <= runningInputGuardMs;
+  return (recentOutput && !recentInput) ? 'running' : 'idle';
+}
+
+module.exports = {
+  deriveStatus,
+};

--- a/tests/statusState.test.js
+++ b/tests/statusState.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  deriveStatus,
+} = require('../renderer/statusState');
+
+const RUNNING_IDLE_TIMEOUT_MS = 1500;
+const RUNNING_INPUT_GUARD_MS = 200;
+
+function status(overrides) {
+  return deriveStatus({
+    localWaiting: false,
+    externalWaiting: false,
+    now: 10000,
+    lastOutputTime: 0,
+    lastInputTime: 0,
+    runningIdleTimeoutMs: RUNNING_IDLE_TIMEOUT_MS,
+    runningInputGuardMs: RUNNING_INPUT_GUARD_MS,
+    ...overrides,
+  });
+}
+
+test('deriveStatus: 外部権威 waiting は自動入力直後でも waiting を維持する', () => {
+  const lastOutputTime = 9700;
+  const lastInputTime = 9950;
+
+  assert.equal(status({ externalWaiting: true, lastOutputTime, lastInputTime }), 'waiting');
+  assert.equal(status({ externalWaiting: false, lastOutputTime, lastInputTime }), 'idle');
+});
+
+test('deriveStatus: ローカル waiting が true なら waiting', () => {
+  assert.equal(status({ localWaiting: true, externalWaiting: false }), 'waiting');
+});
+
+test('deriveStatus: 直近出力あり・直近入力なしなら running', () => {
+  assert.equal(status({ lastOutputTime: 9500, lastInputTime: 0 }), 'running');
+});
+
+test('deriveStatus: 直近入力ありなら idle', () => {
+  assert.equal(status({ lastOutputTime: 9500, lastInputTime: 9950 }), 'idle');
+});
+
+test('deriveStatus: 出力も入力も古ければ idle', () => {
+  assert.equal(status({ lastOutputTime: 1000, lastInputTime: 1000 }), 'idle');
+});


### PR DESCRIPTION
## 概要

入力待ちのペインで「🟡 入力待ち」マーカーが **HTTP API 経由の自動入力で誤解除され、以降復活しない** 不具合（#95）への対応です。

ローカルの PTY テキストパターンマッチ（`renderer/waitingState.js`）は本質的に脆く、スティッキー化した `waiting` の唯一の解除経路 `markPaneInput()` が「ユーザー入力」だけでなく HTTP API 経由の自動入力（オーケストレーターの再送など）でも発火してしまうことが原因でした。自動入力で解除された後は新規出力が出ないため `checkWaiting()` が再評価されず、マーカーが復活しません。

そこで **外部権威の入力待ちフラグ `externalWaiting` を新設し、ローカル PTY 検知の上に重ねる二層構成**にしました。外部権威フラグは自動入力・リサイズ・再描画では一切消えず、オーケストレーターが明示的に `false` を push したときだけ解除されます。GitHub status を検知して push する側は別 issue（下記）で実装します。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/95
ペア issue（push 側・別対応）: https://github.com/vektor-inc/vk-orchestrator/issues/59

## 変更内容

- **`POST /api/set-status`（新設）** — `{ "termId": "1", "waiting": true|false }` で外部権威の入力待ちフラグを設定/解除。バリデーション（origin/termId 存在/boolean 厳格/MAX_BODY/JSON 例外）は既存 `/api/set-title` と同水準。
- **`externalWaiting` フラグ導入**（`renderer/app.js`）— `markPaneInput` / リサイズ / 再描画 / 自動入力では解除せず、明示 `false` push でのみ解除。
- **status を OR 派生に**（`t.waiting || t.externalWaiting`）— ローカル検知と外部権威のどちらかが true なら `waiting`。ペイン枠の点滅・サイドバー格納アイテム・ステータスバッジすべてに反映。
- **派生ロジックを純粋モジュール化**（`renderer/statusState.js`）— `deriveStatus()` に抽出し `recomputeStatus` から利用。ユニットテスト（`tests/statusState.test.js`）で担保。
- `GET /api/states`・`states.json` に `externalWaiting` フィールドを追加。
- README.md に `POST /api/set-status` の API ドキュメントを追記。CHANGELOG.md に `[ 機能追加 ]` エントリを追記。

## スコープ外

- GitHub の `Status: waiting-input` を検知して `/api/set-status` を push する定期監視は `vektor-inc/vk-orchestrator#59` で実装します。本 PR は vk-terminals 側の「受け口」と「合流ロジック」のみ。
- 権限プロンプト（`[y/N]` / `Allow?`）と非 issue ペインは引き続きローカル PTY 検知が担当（一本化ではなく補完・上書き）。

## テスト（確認手順）

### 自動テスト

```bash
node --test tests/statusState.test.js tests/waitingState.test.js
```
→ 全 11 件 pass（うち `statusState.test.js` に本 issue の回帰テスト「外部権威 waiting は自動入力＝`lastInputTime > lastOutputTime` でも解除されない」を含む）。

### 手動確認（アプリ起動 `npm start`、HTTP API は `http://127.0.0.1:13847`）

前提: ペインが1つ以上開いている状態。`termId` は `GET /api/states` で確認できる（以下は `"1"` の例）。

**After（外部権威フラグの挙動）**

1. 外部権威 waiting を立てる:
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/set-status -H 'Content-Type: application/json' -d '{"termId":"1","waiting":true}'
   ```
   → 対象ペインのステータスが「🟡 入力待ち」になり、ペイン枠が点滅する。
2. 自動入力を送る（本 issue の誤解除トリガー）:
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/send -H 'Content-Type: application/json' -d '{"termId":"1","input":"echo test\n"}'
   ```
   → **🟡 入力待ちマーカーが維持される**（従来はここで解除され復活しなかった。これが修正の要点）。
3. 外部権威 waiting を解除する:
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/set-status -H 'Content-Type: application/json' -d '{"termId":"1","waiting":false}'
   ```
   → 外部権威フラグが解除され、ローカル `waiting` が false なら status が idle / running に戻る。
4. 状態の確認:
   ```bash
   curl -s http://127.0.0.1:13847/api/states | python3 -m json.tool
   ```
   → 該当ペインに `externalWaiting` フィールドが出力される。

**バリデーション（デグレ確認）**

```bash
# waiting が真偽値以外 → 400
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:13847/api/set-status -H 'Content-Type: application/json' -d '{"termId":"1","waiting":"true"}'   # → 400
# termId 欠落 → 400
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:13847/api/set-status -H 'Content-Type: application/json' -d '{"waiting":true}'                    # → 400
# 存在しない termId → 404
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:13847/api/set-status -H 'Content-Type: application/json' -d '{"termId":"9999","waiting":true}'    # → 404
```

※ 表示スタイル（CSS）の変更は無く、既存の `.waiting` 表現をそのまま使うため Before/After スクリーンショットは省略。

🤖 Generated with [Claude Code](https://claude.com/claude-code)