### PR TITLE
[ 開発環境 ] Electron e2e スモークテスト基盤を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 build/
 *.log
+test-results/
+playwright-report/
 .DS_Store
 .claude/
 config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 開発環境 ] Playwright + Electron による e2e スモークテスト基盤を追加し、`POST /api/set-status` から renderer のステータス反映までを実行時に検証
+
 ## 1.13.0
 
 - [ 機能追加 ] HTTP API `POST /api/set-status` を追加し、オーケストレーター等が入力待ち状態を外部から権威的に設定/解除できるように。外部権威フラグは自動入力・リサイズ・再描画では解除されず、明示 push でのみ解除（[#95](https://github.com/vektor-inc/vk-terminals/issues/95)）

--- a/main.js
+++ b/main.js
@@ -39,7 +39,11 @@ const pendingNewPaneCallbacks = new Map();
 let nextNewPaneRequestId = 1;
 
 // ─── Terminal state & HTTP API ───────────────────────────────────────────────
-const API_PORT = 13847;
+// テストや並列起動時にポートを隔離できるよう、環境変数で上書き可能にする（既定 13847）。
+const API_PORT = (() => {
+  const raw = Number(process.env.VK_TERMINALS_API_PORT);
+  return Number.isInteger(raw) && raw >= 1 && raw <= 65535 ? raw : 13847;
+})();
 const DATA_DIR = path.join(os.homedir(), '.vk-terminals');
 const STATE_FILE = path.join(DATA_DIR, 'states.json');
 const LOG_PREFIX = '[vk-terminals]';

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
-        "@electron/rebuild": "^3.6.0"
+        "@electron/rebuild": "^3.6.0",
+        "@playwright/test": "^1.61.1"
       },
       "engines": {
         "node": ">=20"
@@ -196,6 +197,22 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -966,6 +983,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1757,6 +1789,38 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/proc-log": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "electron .",
     "test": "node --test tests/",
+    "test:e2e": "playwright test",
     "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
     "xterm-addon-fit": "^0.8.0"
   },
   "devDependencies": {
-    "@electron/rebuild": "^3.6.0"
+    "@electron/rebuild": "^3.6.0",
+    "@playwright/test": "^1.61.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,7 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 60_000,
+  workers: 1,
+});

--- a/tests/e2e/set-status.smoke.spec.js
+++ b/tests/e2e/set-status.smoke.spec.js
@@ -1,0 +1,149 @@
+const { test, expect, _electron } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  // 既定ポート 13847 を避けることで、開発中の通常起動インスタンスと衝突させない。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (!port) {
+          reject(new Error('failed to allocate a free port'));
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function postSetStatus(port, waiting) {
+  const response = await fetch(`http://127.0.0.1:${port}/api/set-status`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ termId: '1', waiting }),
+  });
+
+  let body = null;
+  try {
+    body = await response.json();
+  } catch (_e) {
+    // 失敗時の診断用に本文が JSON でないケースも許容する。
+  }
+
+  return { response, body };
+}
+
+async function waitForPtyRegistration(port) {
+  const deadline = Date.now() + 20_000;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      // termId "1" は起動時に renderer が作る最初のペインの PTY。
+      // PTY 登録前は main 側が 404 を返すため、200 になるまで短くリトライする。
+      const result = await postSetStatus(port, true);
+      if (result.response.status === 200) return;
+      if (result.response.status !== 404) {
+        throw new Error(`unexpected status ${result.response.status}: ${JSON.stringify(result.body)}`);
+      }
+      lastError = new Error(`terminal 1 not ready: ${JSON.stringify(result.body)}`);
+    } catch (e) {
+      // HTTP サーバー起動前は fetch 自体が失敗するため、同じ待機ループで吸収する。
+      lastError = e;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw lastError || new Error('terminal 1 was not registered in time');
+}
+
+test('POST /api/set-status が renderer の waiting 表示へ反映される', async () => {
+  const port = await getFreePort();
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  const descriptorPath = path.join(tmpRoot, 'settings-descriptor.json');
+  let app;
+
+  fs.mkdirSync(configDir, { recursive: true });
+
+  // loadUserConfig() は HOME 配下の config.json を読むため、HOME 自体を一時化して
+  // 実ユーザーの ~/.vk-terminals/config.json（Tailscale IP 等）に依存しないようにする。
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  // VK_TERMINALS_SETTINGS は設定パネル用ディスクリプタとして読まれる。
+  // テスト中に設定 UI が開かれても一時 config だけを指すようにしておく。
+  fs.writeFileSync(descriptorPath, JSON.stringify({
+    title: 'E2E Settings',
+    targetPath: configPath,
+    groups: [
+      {
+        label: 'E2E',
+        fields: [
+          { key: 'apiHost', type: 'text' },
+          { key: 'initialCommand', type: 'text' },
+          { key: 'agentroom', type: 'boolean' },
+          { key: 'additionalPanes', type: 'json' },
+        ],
+      },
+    ],
+  }), 'utf8');
+
+  try {
+    app = await _electron.launch({
+      // このテストは HTTP API と renderer 反映の統合パスだけを見る。
+      // Claude CLI の有無に依存させないため、起動時は素のシェルにしておく。
+      args: ['.', '--no-claude'],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        USERPROFILE: tmpHome,
+        VK_TERMINALS_API_PORT: String(port),
+        VK_TERMINALS_SETTINGS: descriptorPath,
+      },
+    });
+
+    const win = await app.firstWindow();
+
+    await waitForPtyRegistration(port);
+
+    const pane = win.locator('.pane').first();
+    const status = win.locator('.pane .pane-status').first();
+
+    // main の HTTP API → webContents.send → renderer の ipcRenderer.on →
+    // recomputeStatus → DOM 反映、という統合パスを実際の Electron 上で確認する。
+    await expect(status).toHaveAttribute('data-status', 'waiting');
+    await expect(pane).toHaveClass(/\bwaiting\b/);
+
+    const clearResult = await postSetStatus(port, false);
+    expect(clearResult.response.status).toBe(200);
+
+    // 解除側も確認する。waiting が残り続ける回帰は利用者に見えるため、ここを芯にする。
+    await expect(status).not.toHaveAttribute('data-status', 'waiting');
+    await expect(pane).not.toHaveClass(/\bwaiting\b/);
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

Electron レンダラ／HTTP API→renderer の統合パスを自動検証する手段が無かったため、Playwright + Electron（`_electron` launch API）による最小 e2e スモークテスト基盤を追加します。

`main.js` の HTTP API（`POST /api/set-status`）→ `win.webContents.send('terminal:set-status', ...)` → renderer の `ipcRenderer.on(...)` → status 派生 → DOM 反映、という統合パスを実際の Electron 上で 1 本のスモークテストとして検証します（#95 の外部権威 waiting 回帰を実行時にも押さえる）。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/97

## 変更内容

- **`main.js`**: `API_PORT`（従来 `13847` ハードコード）を環境変数 `VK_TERMINALS_API_PORT` で上書き可能に変更。1〜65535 の整数のみ受理し、未設定・不正値は既定 `13847` にフォールバック（後方互換維持）。テスト・並列起動時に開発中インスタンスとのポート衝突を避けるため。
- **`@playwright/test`** を devDependency に追加、**`playwright.config.js`** 新設（`testDir: tests/e2e`、`workers: 1`）。
- **`tests/e2e/set-status.smoke.spec.js`**: スモークテスト 1 本を追加。空きポート確保・一時 HOME/config による隔離のうえアプリを起動し、`set-status` の waiting 付与／解除が `.pane-status[data-status]` バッジと `.pane.waiting` クラスへ反映されることを assert。
- **`package.json`**: `test:e2e` script（`playwright test`）を追加。既存の `npm test`（node:test）は据え置き。
- **`.gitignore`**: `test-results/` `playwright-report/` を追加。**`CHANGELOG.md`**: エントリを 1 件追記。

## テスト（確認手順）

前提: リポジトリルートで `npm install`（`@playwright/test` が入る）。`_electron` はアプリ同梱の electron を直接起動するため `playwright install`（ブラウザDL）は不要。GUI 描画が必要なため、ヘッドレス CI では xvfb 等が必要（今回のスコープ外）。

1. リポジトリルートで `npm run test:e2e` を実行する。
   - → e2e スモークテスト（`POST /api/set-status が renderer の waiting 表示へ反映される`）が **1 件 PASS** する。
   - → 内部で Electron アプリが一時ポート・一時 HOME で起動し、`set-status` の waiting 付与→バッジ `data-status="waiting"`・`.pane.waiting` 付与、解除→両方が外れることを検証する。
2. 既存ユニットテストの回帰確認: `npm test` を実行する。
   - → node:test のユニットテスト（87 件）がすべて PASS する（`tests/e2e/*.spec.js` は `node --test` の対象外のため巻き込まれない）。
3. 後方互換の確認: 環境変数を付けずに `npm start` でアプリを起動する。
   - → 従来どおり API サーバーが `13847` で待ち受ける（`VK_TERMINALS_API_PORT` 未設定時は既定値）。

※ 表示・UI に関わる変更（CSS/マークアップ）は含まないため、スクリーンショットは省略します。

## 補足（セキュリティレビュー）

安藤（セキュリティ）レビュー: PASS。LOW・任意の堅牢性助言（`getFreePort` の TOCTOU フレーク・一時ディレクトリ生成が try 外・特権ポートの graceful 無効化）は本 PR のスコープを最小に保つため今回は反映見送り（詳細は issue #97 のコメント参照）。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/323