### PR TITLE
[ 機能追加 ] モバイル版に各ターミナル（ペイン）を終了するボタンを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] モバイル版で各ターミナル（ペイン）を終了するボタンを追加（[#100](https://github.com/vektor-inc/vk-terminals/issues/100)）
 - [ 開発環境 ] Playwright + Electron による e2e スモークテスト基盤を追加し、`POST /api/set-status` から renderer のステータス反映までを実行時に検証
 
 ## 1.13.0

--- a/main.js
+++ b/main.js
@@ -37,6 +37,8 @@ const globalPlainMode = process.argv.includes('--no-claude') || process.argv.inc
 // 並行リクエストでも取り違えが起きないように requestId で相関付ける
 const pendingNewPaneCallbacks = new Map();
 let nextNewPaneRequestId = 1;
+const pendingClosePaneCallbacks = new Map();
+let nextClosePaneRequestId = 1;
 
 // ─── Terminal state & HTTP API ───────────────────────────────────────────────
 // テストや並列起動時にポートを隔離できるよう、環境変数で上書き可能にする（既定 13847）。
@@ -903,6 +905,15 @@ ipcMain.on('terminal:new-pane-created', (event, payload = {}) => {
   resolve(result);
 });
 
+ipcMain.on('terminal:close-pane-done', (event, payload = {}) => {
+  const { requestId, ...result } = payload;
+  if (!requestId) return;
+  const resolve = pendingClosePaneCallbacks.get(requestId);
+  if (!resolve) return;
+  pendingClosePaneCallbacks.delete(requestId);
+  resolve(result);
+});
+
 /**
  * 指定された cwd で追加ペインを 1 枚作成する。
  * 内部的には renderer の splitPane を呼び出すのと同じ経路（pendingNewPaneCallbacks）を使う。
@@ -1443,6 +1454,61 @@ function startHttpApi() {
         if (typeof requestedNoClaude === 'boolean') payload.noClaude = requestedNoClaude;
         if (typeof requestedStashed === 'boolean') payload.stashed = requestedStashed;
         win.webContents.send('terminal:request-new-pane', payload);
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/close-pane') {
+      if (isForbiddenOrigin(req)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'forbidden origin' }));
+        return;
+      }
+      if (!win || win.isDestroyed()) {
+        res.writeHead(503, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'window not available' }));
+        return;
+      }
+      readJsonBody(req, res, 10 * 1024, (body) => {
+        let termId;
+        try {
+          const parsed = JSON.parse(body);
+          termId = parsed?.termId;
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'invalid JSON' }));
+          return;
+        }
+        if (!termId) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'termId required' }));
+          return;
+        }
+        if (!ptys.has(String(termId))) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'terminal ' + termId + ' not found' }));
+          return;
+        }
+        const requestId = String(nextClosePaneRequestId++);
+        const timeoutId = setTimeout(() => {
+          if (pendingClosePaneCallbacks.has(requestId)) {
+            pendingClosePaneCallbacks.delete(requestId);
+            res.writeHead(504, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'timeout waiting for close pane' }));
+          }
+        }, 15000);
+        const resolve = (result) => {
+          clearTimeout(timeoutId);
+          if (result.error) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: result.error }));
+          } else {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true, termId: result.termId }));
+          }
+        };
+        pendingClosePaneCallbacks.set(requestId, resolve);
+        win.webContents.send('terminal:request-close-pane', { requestId, termId: String(termId) });
       });
       return;
     }

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -2756,6 +2756,23 @@ ipcRenderer.on('terminal:request-new-pane', async (event, payload = {}) => {
   }
 });
 
+ipcRenderer.on('terminal:request-close-pane', (event, payload = {}) => {
+  const { requestId, termId } = payload;
+  const reply = (result) => ipcRenderer.send('terminal:close-pane-done', { requestId, ...result });
+  // termId → paneId 逆引き（既存の terminal:title / set-status ハンドラと同じパターン）
+  const paneId = Object.keys(terminals).find(k => String(terminals[k]?.termId) === String(termId));
+  if (!paneId) {
+    reply({ error: 'terminal not found' });
+    return;
+  }
+  try {
+    closePane(paneId);
+    reply({ ok: true, termId: termId });
+  } catch (e) {
+    reply({ error: e?.message || 'failed to close pane' });
+  }
+});
+
 // ─── Title update from main (HTTP API POST /api/set-title) ──────────────────
 // API 由来のタイトルは apiTitle に保存し、OSC 由来の taskTitle とは別フィールドで管理する。
 // これにより claude TUI が継続的に発行する OSC 0/2 で API 設定タイトルが上書きされない。

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -81,6 +81,14 @@
   button.k.yes { border-color: #2f6b3f; color: #8fe0a6; }
   button.k.no  { border-color: #6b2f2f; color: #f0a3a3; }
   button.k.stop { border-color: #6b5a2f; color: #e8d08a; }
+  /* ペイン終了（issue #100）。実行中プロセスを kill する不可逆操作なので、
+     クイックボタン（アウトライン様式）と格を変えた「塗りの赤」にし、
+     .actions 最下段に独立した全幅ボタンとして高頻度操作から分離する。 */
+  .actions .danger-row { margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--card-border); }
+  button.k.kill { flex: 1 1 100%; width: 100%; min-height: 44px;
+    background: #b03636; border-color: #b03636; color: #fff; font-weight: 700; }
+  button.k.kill:active { background: #8f2a2a; border-color: #8f2a2a; }
+  button.k.kill:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
   .sendrow { display: flex; gap: 6px; }
   .sendrow input { flex: 1; padding: 9px 10px; border-radius: 8px; border: 1px solid var(--card-border);
     background: #0d0f13; color: var(--fg); font-size: 14px; font-family: ui-monospace, Menlo, monospace; }
@@ -261,6 +269,26 @@ async function send(termId, input) {
   }
 }
 
+async function closeTerm(termId, label) {
+  var nm = (label && label.trim()) ? label : ("Terminal " + termId);
+  if (!window.confirm("「" + nm + "」を終了しますか？\n実行中のプロセス（claude 等）が停止し、元に戻せません。")) return;
+  try {
+    var res = await fetch("/api/close-pane", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ termId: termId })
+    });
+    if (!res.ok) {
+      var j = await res.json().catch(function(){ return {}; });
+      showErr("終了失敗: " + (j.error || res.status));
+    } else {
+      showErr("");
+    }
+  } catch (e) {
+    showErr("終了失敗: " + e.message);
+  }
+}
+
 // quick ボタン定義: ラベルと送る文字列
 var QUICK = [
   [
@@ -397,11 +425,19 @@ function ensureCard(termId) {
   actions.appendChild(sendrow);
   actions.appendChild(nlLabel);
 
+  // ペイン終了ボタン（issue #100）。破壊的操作なので最下段・独立行・全幅・塗り赤。
+  var killRow = document.createElement("div"); killRow.className = "row danger-row";
+  var killBtn = document.createElement("button");
+  killBtn.className = "k kill"; killBtn.textContent = "✕ ターミナルを終了";
+  killBtn.addEventListener("click", function() { closeTerm(termId, name.textContent); });
+  killRow.appendChild(killBtn);
+  actions.appendChild(killRow);
+
   root.appendChild(head); root.appendChild(pre); root.appendChild(actions);
   list.appendChild(root);
 
   cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge,
-    prLink: prLink, head: head, chevron: chevron };
+    prLink: prLink, head: head, chevron: chevron, killBtn: killBtn };
   // 復活時を含め、現在の collapsed 状態を初期反映
   syncCollapseUI(cards[termId], termId);
   return cards[termId];
@@ -531,6 +567,7 @@ function render(data) {
     // フォールバックしていた不具合を修正（issue: モバイル側でタスク名が出ない）。
     var title = t.displayTitle || t.apiTitle || t.taskTitle || "";
     c.name.textContent = title.trim() ? title : ("Terminal " + termId);
+    c.killBtn.setAttribute("aria-label", (c.name.textContent || ("Terminal " + termId)) + " を終了する（実行中プロセスを停止）");
     c.cwd.textContent = t.cwdShort || t.cwd || "";
     // PR リンク（issue #53）。安全な http(s) URL のときだけ href にセットして表示、
     // そうでなければ href を空にして非表示にする。

--- a/tests/e2e/close-pane.smoke.spec.js
+++ b/tests/e2e/close-pane.smoke.spec.js
@@ -1,0 +1,212 @@
+const { test, expect, _electron, chromium } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// issue #100 / PR #101: モバイル Web UI から HTTP API 経由でデスクトップ側の
+// ペイン（ターミナル）を終了（kill）できるようにした変更の end-to-end 確認。
+//   POST /api/new-pane で作成 → GET /api/states で termId 確認 →
+//   POST /api/close-pane { termId } → /api/states から当該 termId が消える、を実機 Electron で検証する。
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  // 既定ポート 13847 を避け、開発中の通常起動インスタンスと衝突させない。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+// GET /api/states を叩き、terminals（paneId -> state）を返す。
+async function getStates(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/api/states`);
+  if (res.status !== 200) throw new Error(`/api/states returned ${res.status}`);
+  const json = await res.json();
+  return json.terminals || {};
+}
+
+// states 内に存在する termId の一覧（文字列）を返す。
+function termIdsOf(states) {
+  return Object.values(states)
+    .map((t) => (t && t.termId != null ? String(t.termId) : null))
+    .filter(Boolean);
+}
+
+// 指定 termId が states に現れる / 消えるまで短くリトライして待つ。
+// report-states は renderer 側で 2 秒ごとに送られるため、猶予を持って待機する。
+async function waitForTermId(port, termId, shouldExist, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen = null;
+  while (Date.now() < deadline) {
+    try {
+      const states = await getStates(port);
+      const ids = termIdsOf(states);
+      lastSeen = ids;
+      const exists = ids.includes(String(termId));
+      if (exists === shouldExist) return ids;
+    } catch (_e) {
+      // HTTP サーバー起動前は fetch が失敗する。同じループで吸収する。
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(
+    `termId ${termId} did not reach exists=${shouldExist} in time. last states: ${JSON.stringify(lastSeen)}`
+  );
+}
+
+async function postJson(port, pathname, payload) {
+  const res = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  let body = null;
+  try { body = await res.json(); } catch (_e) { /* 非 JSON 応答も診断のため許容 */ }
+  return { status: res.status, body };
+}
+
+// 一時 HOME を用意して Electron を素のシェル（--no-claude）で起動する。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-close-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  // 実ユーザーの ~/.vk-terminals/config.json に依存しないよう HOME を一時化する。
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  await app.firstWindow();
+  return { app, tmpRoot };
+}
+
+test('POST /api/close-pane で作成したペインが終了し /api/states から消える', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  try {
+    // 起動直後の最初のペイン（termId "1"）が登録されるまで待つ。
+    await waitForTermId(port, '1', true);
+
+    // 追加ペインを作成する（claude を起動しない素のシェル）。
+    const created = await postJson(port, '/api/new-pane', { noClaude: true });
+    expect(created.status).toBe(200);
+    expect(created.body).toBeTruthy();
+    expect(created.body.ok).toBe(true);
+    const newTermId = String(created.body.termId);
+    expect(newTermId).toBeTruthy();
+
+    // states に新規 termId が現れることを確認する。
+    await waitForTermId(port, newTermId, true);
+
+    // 本命: close-pane で新規ペインを終了する。200 と ok:true が返る。
+    const closed = await postJson(port, '/api/close-pane', { termId: newTermId });
+    expect(closed.status).toBe(200);
+    expect(closed.body).toBeTruthy();
+    expect(closed.body.ok).toBe(true);
+    expect(String(closed.body.termId)).toBe(newTermId);
+
+    // states から当該 termId が消えることを確認する（レンダラ closePane → report-states 反映）。
+    const remaining = await waitForTermId(port, newTermId, false);
+    // 最初のペイン（"1"）は残っていること = 対象だけをピンポイントで閉じられている。
+    expect(remaining).toContain('1');
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test('POST /api/close-pane の異常系（存在しない termId は 404 / termId 欠落は 400）', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  try {
+    await waitForTermId(port, '1', true);
+
+    // 存在しない termId → 404。誤って別ペインを閉じないための境界確認。
+    const notFound = await postJson(port, '/api/close-pane', { termId: '999999' });
+    expect(notFound.status).toBe(404);
+    expect(notFound.body && notFound.body.error).toBeTruthy();
+
+    // termId 欠落 → 400。
+    const missing = await postJson(port, '/api/close-pane', {});
+    expect(missing.status).toBe(400);
+    expect(missing.body && missing.body.error).toBeTruthy();
+
+    // 異常系リクエスト後も最初のペインは無事に残っていること。
+    const states = await getStates(port);
+    expect(termIdsOf(states)).toContain('1');
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test('モバイルページ: 終了ボタンと確認ダイアログ（却下でペイン残存 / 承認で終了）', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1', true);
+    // 終了対象の追加ペインを作成する（termId は 2 以降の連番）。
+    const created = await postJson(port, '/api/new-pane', { noClaude: true });
+    expect(created.status).toBe(200);
+    const targetId = String(created.body.termId);
+    await waitForTermId(port, targetId, true);
+
+    // モバイル Web UI（mobile.html）を実ブラウザで開く。ページは同一オリジンで /api/* を叩く。
+    const page = await browser.newPage();
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    // 対象ペインのカード（タイトル未設定なので "Terminal <id>" 表示）内の終了ボタンを特定する。
+    const targetCard = page.locator('.card', { hasText: `Terminal ${targetId}` });
+    const killBtn = targetCard.locator('button.kill');
+    await expect(killBtn).toBeVisible({ timeout: 10_000 });
+    await expect(killBtn).toHaveText('✕ ターミナルを終了');
+
+    // (1) 確認ダイアログを「却下」する → close-pane は呼ばれず、ペインは残る。
+    page.once('dialog', (dialog) => dialog.dismiss());
+    await killBtn.click();
+    // 却下直後は API を叩いていないはず。念のため少し待ってから states を確認する。
+    await page.waitForTimeout(1500);
+    expect(termIdsOf(await getStates(port))).toContain(targetId);
+
+    // (2) 確認ダイアログを「承認」する → close-pane が呼ばれ、ペインが終了する。
+    page.once('dialog', (dialog) => dialog.accept());
+    await killBtn.click();
+    // states から消えることを確認する（API → renderer closePane → report-states 反映）。
+    await waitForTermId(port, targetId, false);
+    // UI 側でも該当カードが消える（ポーリング再描画で除去）。
+    await expect(targetCard).toHaveCount(0, { timeout: 10_000 });
+    // 最初のペインのカードは残っていること。
+    await expect(page.locator('.card', { hasText: 'Terminal 1' })).toBeVisible();
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

モバイル用リモート Web UI（`renderer/mobile.html`）から、各ターミナル（ペイン）を終了（PC 側で実行中の claude 等を kill）できるようにする。従来モバイルからはペインを閉じられなかったため、PC が手元に無い状況で不要なペインを片付けられるようにする。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/100

## 変更内容

- **`main.js`**: 新規 `POST /api/close-pane { termId }` を追加。既存 `/api/send`・`/api/new-pane` に倣い `isForbiddenOrigin` チェック → `readJsonBody`（上限 10KB）→ `termId` 検証 → `ptys.has(String(termId))` で存在確認（無ければ 404）→ レンダラへ `terminal:request-close-pane` を送り往復（pending callback・15s タイムアウト）→ 結果を応答。`ipcMain.on('terminal:close-pane-done')` で受信。
- **`renderer/app.js`**: `terminal:request-close-pane` ハンドラを追加。`termId` → `paneId` 逆引き（既存 `terminal:title` 等と同じパターン）→ 既存 `closePane()` を実行して ack。
- **`renderer/mobile.html`**: 各カードの操作エリア `.actions` 最下段に、確認ダイアログ付きの終了ボタン（塗り赤・全幅・独立行 `.danger-row`）を追加。折り畳み時は非表示で誤タップを防ぐ。
- **`CHANGELOG.md`**: 機能追加として1行追記。

## レビュー状況（PR 作成前）

- 🔒 安藤（セキュリティ）: PASS — 既存 `/api/send`（kill 相当が既に可能）より弱い権限で攻撃面は広がらず、往復処理のリーク・二重 resolve なし。
- 🎨 植草（UX）: PASS — 破壊操作を折り畳み内・最下段に分離、塗り赤＋白文字コントラスト 6.13:1（AA クリア）、対象名入り確認・aria-label あり。

## テスト（確認手順）

前提: `npm start` でアプリを起動し、複数ペインを開いておく。`config.json` の `apiHost` を設定するか `http://127.0.0.1:13847/` にアクセスしてモバイルページを開く（スマホからは Tailscale IP 等）。

1. モバイルページで任意のターミナルカードのヘッダをタップして展開する
   → 操作エリア最下段に赤い「✕ ターミナルを終了」ボタンが、送信欄・クイックボタンと余白で分離されて表示される
2. カードを折り畳む（ヘッダ再タップ）
   → 終了ボタンが非表示になる（誤タップ防止）
3. 展開状態で「✕ ターミナルを終了」をタップ
   → 「『{ターミナル名}』を終了しますか？ 実行中のプロセス（claude 等）が停止し、元に戻せません。」の確認ダイアログが出る
4. キャンセルする
   → 何も起きず、ペインは残る
5. もう一度タップして OK する
   → PC 側の該当ペインが閉じ、約2秒後にモバイル側のカードも一覧から消える
6. 異常系: 既に閉じた termId 宛に `POST /api/close-pane` を送る
   → 404 `terminal <id> not found` が返り、モバイル側は「終了失敗: ...」を表示

デグレ確認: クイックボタン（1/2/3/Enter/Yes/No/Esc/Ctrl-C）・自由入力送信・折り畳み・スクロール位置復元が従来どおり動作すること。

> スクリーンショット / 動作 GIF は e2e 確認（麗美）時に取得予定。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/327