### PR TITLE
[ 不具合修正 ] モバイル版ペインプレビューにスピナー記号など読めない文字列が表示される不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [ 機能追加 ] モバイル版で各ターミナル（ペイン）を終了するボタンを追加（[#100](https://github.com/vektor-inc/vk-terminals/issues/100)）
+- [ 不具合修正 ] モバイル版のペインプレビューにスピナー記号や数字断片だけの意味がない行が表示される不具合を修正（[#102](https://github.com/vektor-inc/vk-terminals/issues/102)）
 - [ 開発環境 ] Playwright + Electron による e2e スモークテスト基盤を追加し、`POST /api/set-status` から renderer のステータス反映までを実行時に検証
 
 ## 1.13.0

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -174,6 +174,25 @@ function stripAnsi(s) {
     .replace(/\x1b[@-Z\\-_]/g, "")
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, ""); // その他制御文字（改行・タブは残す）
 }
+
+// Claude Code などの CLI スピナー / プログレス描画で残りやすい装飾グリフ。
+// 入力待ち検知と共有する lastLines には影響させず、モバイルプレビュー表示だけで除去する。
+var MOBILE_PREVIEW_DECORATIVE_GLYPH_RE = /[✻✽✶✷✴✳✢✥✦✧✩✪✫✬✭✮✯✰✱✲✵✸✹✺✼✾✿·]/g;
+var MOBILE_PREVIEW_READABLE_LINE_RE = /[A-Za-z\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]/;
+
+function sanitizeMobilePreviewText(s) {
+  if (!s) return "";
+  return s.split("\n").reduce(function(lines, line) {
+    var cleaned = line.replace(MOBILE_PREVIEW_DECORATIVE_GLYPH_RE, "");
+    if (cleaned.trim() === "") {
+      if (line.trim() === "") lines.push(cleaned);
+      return lines;
+    }
+    if (MOBILE_PREVIEW_READABLE_LINE_RE.test(cleaned)) lines.push(cleaned);
+    return lines;
+  }, []).join("\n");
+}
+
 function tail(s, n) { return s.length > n ? s.slice(s.length - n) : s; }
 
 // href に入れる URL を http(s) のみに制限する防御（issue #53）。
@@ -580,7 +599,7 @@ function render(data) {
       c.prLink.removeAttribute("title");
       c.prLink.classList.remove("show");
     }
-    c.pre.textContent = tail(stripAnsi(t.lastLines || ""), 1400).replace(/\n{3,}/g, "\n\n").trim();
+    c.pre.textContent = sanitizeMobilePreviewText(tail(stripAnsi(t.lastLines || ""), 1400)).replace(/\n{3,}/g, "\n\n").trim();
     // 折り畳み状態を毎回当て直す（再描画・端末の消失→復活をまたいで一致させる）
     syncCollapseUI(c, termId);
     // CSS order で並び替え（DOM移動をやめてモバイルでの入力フォーカス消失を防ぐ）

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -178,7 +178,7 @@ function stripAnsi(s) {
 // Claude Code などの CLI スピナー / プログレス描画で残りやすい装飾グリフ。
 // 入力待ち検知と共有する lastLines には影響させず、モバイルプレビュー表示だけで除去する。
 var MOBILE_PREVIEW_DECORATIVE_GLYPH_RE = /[✻✽✶✷✴✳✢✥✦✧✩✪✫✬✭✮✯✰✱✲✵✸✹✺✼✾✿·]/g;
-var MOBILE_PREVIEW_READABLE_LINE_RE = /[A-Za-z\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]/;
+var MOBILE_PREVIEW_READABLE_LINE_RE = /[A-Za-z぀-ヿ㐀-䶿一-鿿豈-﫿가-힯０-９Ａ-Ｚａ-ｚｦ-ﾟ]/;
 
 function sanitizeMobilePreviewText(s) {
   if (!s) return "";

--- a/tests/mobilePreviewSanitize.test.js
+++ b/tests/mobilePreviewSanitize.test.js
@@ -51,3 +51,15 @@ test('sanitizeMobilePreviewText: 英字と日本語を含む本文行は残す',
 
   assert.equal(sanitizeMobilePreviewText(input), input);
 });
+
+test('sanitizeMobilePreviewText: 半角カナと全角英数だけの本文行は残す', () => {
+  const sanitizeMobilePreviewText = loadSanitizeMobilePreviewText();
+  const input = [
+    'ﾆﾎﾝｺﾞ',
+    '２０２０',
+    'ＡＢＣ',
+    'ａｂｃ',
+  ].join('\n');
+
+  assert.equal(sanitizeMobilePreviewText(input), input);
+});

--- a/tests/mobilePreviewSanitize.test.js
+++ b/tests/mobilePreviewSanitize.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+const assert = require('node:assert/strict');
+
+function loadSanitizeMobilePreviewText() {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'renderer', 'mobile.html'), 'utf8');
+  const match = html.match(/\/\/ Claude Code[\s\S]*?\nfunction tail/);
+  assert.ok(match, 'sanitizeMobilePreviewText の定義を renderer/mobile.html から抽出できる');
+
+  const context = {};
+  vm.runInNewContext(match[0].replace(/\nfunction tail$/, ''), context);
+  return context.sanitizeMobilePreviewText;
+}
+
+test('sanitizeMobilePreviewText: スピナー記号だけの行と数字断片行を除去する', () => {
+  const sanitizeMobilePreviewText = loadSanitizeMobilePreviewText();
+  const input = [
+    '✻',
+    '✳40',
+    ' 123 ',
+    '---',
+    'Claude is working',
+    '作業完了です',
+    '✻ Thinking...',
+  ].join('\n');
+
+  assert.equal(
+    sanitizeMobilePreviewText(input),
+    [
+      'Claude is working',
+      '作業完了です',
+      ' Thinking...',
+    ].join('\n')
+  );
+});
+
+test('sanitizeMobilePreviewText: 英字と日本語を含む本文行は残す', () => {
+  const sanitizeMobilePreviewText = loadSanitizeMobilePreviewText();
+  const input = [
+    'npm test passed 12/12',
+    '変更内容をご確認ください',
+    'カタカナの本文も残す',
+    'APIレスポンスは200',
+    '',
+    '次の作業に進みます',
+  ].join('\n');
+
+  assert.equal(sanitizeMobilePreviewText(input), input);
+});


### PR DESCRIPTION
関連 issue: https://github.com/vektor-inc/vk-terminals/issues/102

## 概要

モバイル版（`renderer/mobile.html`、スマホのブラウザから `http://<host>:13847` にアクセスするビュー）の各ペインのプレビュー表示に、CLI（Claude Code 等）のスピナー/プログレスアニメの記号（`✻ ✽ ✳` 等）や、カーソル制御が剥がれて残った「記号・数字だけの意味のない行」が混ざって表示され、内容が読みづらくなっていました。

これを、プレビュー表示の直前で除去するようにしました。

## 実装

- `renderer/mobile.html` に `sanitizeMobilePreviewText()` を追加し、プレビュー整形チェーン（`c.pre.textContent = ...`）に挟みました。
  1. スピナー/装飾グリフ（星型・点系）を除去
  2. 除去後、可読文字（ラテン・ひらがな/カタカナ・CJK・ハングル・全角英数・半角カナ）を1つも含まない非空行を「意味のない行」として行ごと削除
- **共有バッファ `t.lastLines` の蓄積処理（`renderer/app.js`）や `utils/stripAnsi.js`・`renderer/waitingState.js` には手を入れていません**。これらは issue #32 で作った「入力待ち」検知と共有されているため、モバイル表示側だけに閉じることで待機検知への副作用をゼロにしています。
- 既存挙動（末尾1400文字の切り出し・空行圧縮 `\n{3,}`→`\n\n`・`.trim()`）は維持しています。

## テスト（確認手順）

### 自動テスト
```
cd <repo>
npm test
```
→ `sanitizeMobilePreviewText` の単体テストを含め全 90 件が pass すること（`tests/mobilePreviewSanitize.test.js`）。

### 手動確認

**修正前（再現）**
1. アプリを起動し、Claude Code などスピナーアニメを出す CLI を実行中のペインを用意する。
2. スマホ等のブラウザでモバイル版（`http://<PCのホスト名>:13847`）を開く。
3. 該当ペインのプレビュー欄を見る。
→ `✻` 単独行や `✳40` のような記号・数字だけの行が並び、内容が読みづらい。

**修正後（確認）**
1. 同じ手順でモバイル版のプレビュー欄を見る。
→ スピナー記号・記号/数字だけの行が消え、実際のログ本文だけが表示される。
→ 日本語・英語・全角英数（`２０２０` 等）・半角カナ（`ﾆﾎﾝｺﾞ` 等）を含む本文行は消えずに残る。

### デグレ確認
- PC 版（`index.html`）のターミナル表示は変更対象外（プレビューはモバイル専用のため）。表示が従来どおりであること。
- 「入力待ち」ステータス検知（issue #32）が従来どおり機能すること（共有バッファは未変更）。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/328