### PR TITLE
[ 機能追加 ] モバイル版でペインのタイトルをタップするとリンク指定時に別タブで開くように変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 機能追加 ] モバイル版でペインのタイトルをタップすると、リンク指定（PR URL）がある場合に別タブで開くように変更（[#103](https://github.com/vektor-inc/vk-terminals/issues/103)）
 - [ 機能追加 ] モバイル版で各ターミナル（ペイン）を終了するボタンを追加（[#100](https://github.com/vektor-inc/vk-terminals/issues/100)）
 - [ 仕様変更 ] モバイル版でペインヘッダーをタイトル行と操作行の2段表示に変更（[#105](https://github.com/vektor-inc/vk-terminals/issues/105)）
 - [ 不具合修正 ] モバイル版のペインプレビューにスピナー記号や数字断片だけの意味がない行が表示される不具合を修正（[#102](https://github.com/vektor-inc/vk-terminals/issues/102)）

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -49,10 +49,15 @@
     animation: pulse 1.2s ease-in-out infinite; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
   .card-title { flex: 1; min-width: 0; }
+  a.card-title { color: inherit; text-decoration: none; }
   .card-title .name { font-size: 13px; font-weight: 600; white-space: nowrap;
     overflow: hidden; text-overflow: ellipsis; }
+  .card-title.is-link .name { color: #58a6ff; text-decoration: underline;
+    text-underline-offset: 2px; cursor: pointer; }
+  .card-title.is-link .name::after { content: " ↗"; font-size: 10px; opacity: 0.85; }
   .card-title .cwd { font-size: 11px; color: var(--muted); white-space: nowrap;
     overflow: hidden; text-overflow: ellipsis; }
+  .card-title:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; border-radius: 4px; }
   .badge { font-size: 10px; font-weight: 700; padding: 3px 7px; border-radius: 6px;
     text-transform: uppercase; letter-spacing: 0.04em; flex: none; }
   .badge.idle { background: #2a2f37; color: #9aa3ae; }
@@ -375,7 +380,7 @@ function ensureCard(termId) {
   var headMain = document.createElement("div"); headMain.className = "card-head-main";
   var headMeta = document.createElement("div"); headMeta.className = "card-head-meta";
   var dot = document.createElement("span"); dot.className = "dot idle";
-  var title = document.createElement("div"); title.className = "card-title";
+  var title = document.createElement("a"); title.className = "card-title";
   var name = document.createElement("div"); name.className = "name";
   var cwd = document.createElement("div"); cwd.className = "cwd";
   title.appendChild(name); title.appendChild(cwd);
@@ -403,12 +408,13 @@ function ensureCard(termId) {
   head.setAttribute("role", "button");
   head.setAttribute("tabindex", "0");
   function onHeadToggle(e) {
-    if (e.target.closest("button, input, a")) return;
+    if (e.target.closest("button, input, a[href]")) return;
     toggleCollapse(termId);
   }
   head.addEventListener("click", onHeadToggle);
   head.addEventListener("keydown", function(e) {
     if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      if (e.target.closest("button, input, a[href]")) return;
       e.preventDefault();
       onHeadToggle(e);
     }
@@ -462,6 +468,7 @@ function ensureCard(termId) {
   list.appendChild(root);
 
   cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge,
+    title: title,
     prLink: prLink, head: head, chevron: chevron, killBtn: killBtn };
   // 復活時を含め、現在の collapsed 状態を初期反映
   syncCollapseUI(cards[termId], termId);
@@ -600,10 +607,20 @@ function render(data) {
       c.prLink.href = t.apiPrUrl;
       c.prLink.title = t.apiPrUrl;
       c.prLink.classList.add("show");
+      c.title.href = t.apiPrUrl;
+      c.title.target = "_blank";
+      c.title.rel = "noopener noreferrer";
+      c.title.classList.add("is-link");
+      c.title.setAttribute("aria-label", c.name.textContent + " の PR を新しいタブで開く");
     } else {
       c.prLink.removeAttribute("href");
       c.prLink.removeAttribute("title");
       c.prLink.classList.remove("show");
+      c.title.removeAttribute("href");
+      c.title.removeAttribute("target");
+      c.title.removeAttribute("rel");
+      c.title.classList.remove("is-link");
+      c.title.removeAttribute("aria-label");
     }
     c.pre.textContent = sanitizeMobilePreviewText(tail(stripAnsi(t.lastLines || ""), 1400)).replace(/\n{3,}/g, "\n\n").trim();
     // 折り畳み状態を毎回当て直す（再描画・端末の消失→復活をまたいで一致させる）

--- a/tests/e2e/mobile-title-link.smoke.spec.js
+++ b/tests/e2e/mobile-title-link.smoke.spec.js
@@ -1,0 +1,266 @@
+const { test, expect, _electron, chromium } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// issue #103 / PR #108: モバイル版でペインのタイトル（.card-title）を、
+// 状態 apiPrUrl が安全な http(s) URL のときだけ
+// <a target="_blank" rel="noopener noreferrer"> にしてリンク化する変更の end-to-end 確認。
+//   A: 安全な https(http) URL があるとタイトルが href 付きリンク（.is-link）になり、
+//      タイトルタップでは折りたたみがトグルせず新規タブ（popup）が開く。
+//   B: URL が無いとタイトルは href を持たず、タイトルタップで従来どおり折りたたみがトグルする。
+//   C: apiPrUrl が javascript: の場合はリンク化されない（renderer 側 isSafeHttpUrl のガード）。
+//      ※ API 側 /api/set-title は javascript: を 400 で弾くため、C は /api/states を
+//        差し替えて renderer のガード単体を検証する。
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  // 既定ポート 13847 を避け、開発中の通常起動インスタンスと衝突させない。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+// GET /api/states を叩き、terminals（paneId -> state）を返す。
+async function getStates(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/api/states`);
+  if (res.status !== 200) throw new Error(`/api/states returned ${res.status}`);
+  const json = await res.json();
+  return json.terminals || {};
+}
+
+// states 内に存在する termId の一覧（文字列）を返す。
+function termIdsOf(states) {
+  return Object.values(states)
+    .map((t) => (t && t.termId != null ? String(t.termId) : null))
+    .filter(Boolean);
+}
+
+// 指定 termId が states に現れるまで短くリトライして待つ。
+// report-states は renderer 側で 2 秒ごとに送られるため、猶予を持って待機する。
+async function waitForTermId(port, termId, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen = null;
+  while (Date.now() < deadline) {
+    try {
+      const states = await getStates(port);
+      const ids = termIdsOf(states);
+      lastSeen = ids;
+      if (ids.includes(String(termId))) return ids;
+    } catch (_e) {
+      // HTTP サーバー起動前は fetch が失敗する。同じループで吸収する。
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`termId ${termId} did not appear in time. last states: ${JSON.stringify(lastSeen)}`);
+}
+
+async function postJson(port, pathname, payload) {
+  const res = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  let body = null;
+  try { body = await res.json(); } catch (_e) { /* 非 JSON 応答も診断のため許容 */ }
+  return { status: res.status, body };
+}
+
+// 一時 HOME を用意して Electron を素のシェル（--no-claude）で起動する。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-title-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  // 実ユーザーの ~/.vk-terminals/config.json に依存しないよう HOME を一時化する。
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  await app.firstWindow();
+  return { app, tmpRoot };
+}
+
+// ─── A: 安全な URL でタイトルがリンク化され、タップで折りたたみをトグルしない ───
+test('モバイル: apiPrUrl が安全な URL のときタイトルがリンク化され、タップで新規タブが開き折りたたみしない', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1');
+
+    // PR URL を自前サーバー（同一オリジン）に向けておく。
+    //   - isSafeHttpUrl / API バリデーションを通る http(s) URL であること
+    //   - 外部ネットワークに出ず popup が即座に読み込めること
+    // を両立させるため、mobile.html を配信する自サーバーの URL を使う。
+    const prUrl = `http://127.0.0.1:${port}/?pr=103`;
+    const setTitle = await postJson(port, '/api/set-title', {
+      termId: '1',
+      title: 'PR #103 タイトルリンク',
+      prUrl,
+    });
+    expect(setTitle.status).toBe(200);
+    expect(setTitle.body && setTitle.body.prUrl).toBe(prUrl);
+
+    // モバイル Web UI を実ブラウザで開く。popup（新規タブ）検知のため context を明示する。
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    // 対象カードのタイトル要素。set-title → report-states → poll 反映を待つ。
+    const card = page.locator('.card', { hasText: 'PR #103 タイトルリンク' });
+    const title = card.locator('a.card-title');
+    await expect(title).toBeVisible({ timeout: 15_000 });
+
+    // タイトルがリンク化されている（.is-link ＋ 属性一式）ことを確認する。
+    await expect(title).toHaveClass(/\bis-link\b/, { timeout: 15_000 });
+    await expect(title).toHaveAttribute('href', prUrl);
+    await expect(title).toHaveAttribute('target', '_blank');
+    await expect(title).toHaveAttribute('rel', 'noopener noreferrer');
+
+    // クリック前は折りたたまれていないこと（既定状態）。
+    await expect(card).not.toHaveClass(/\bcollapsed\b/);
+
+    // タイトルをクリック → 新規タブ（popup）が開き、かつ折りたたみはトグルしない。
+    const [popup] = await Promise.all([
+      context.waitForEvent('page'),
+      title.click(),
+    ]);
+    // popup が対象 URL を開いていること（別タブ遷移が起きている）。
+    await popup.waitForLoadState('domcontentloaded');
+    expect(popup.url()).toContain('pr=103');
+    await popup.close();
+
+    // 元のカードは折りたたまれていない（リンククリックでトグルしないのが本変更の肝）。
+    await expect(card).not.toHaveClass(/\bcollapsed\b/);
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── B: URL 無しではリンク化されず、タイトルタップで折りたたみがトグルする（従来挙動）───
+test('モバイル: apiPrUrl 無しではタイトルは href を持たず、タップで折りたたみがトグルする', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1');
+
+    // URL は付けずにタイトルだけ設定する（prUrl を送らない = URL なし扱い）。
+    const setTitle = await postJson(port, '/api/set-title', {
+      termId: '1',
+      title: 'リンク無しタイトル',
+    });
+    expect(setTitle.status).toBe(200);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    const card = page.locator('.card', { hasText: 'リンク無しタイトル' });
+    const title = card.locator('.card-title');
+    await expect(title).toBeVisible({ timeout: 15_000 });
+
+    // href を持たず、.is-link も付いていないこと。
+    await expect(title).not.toHaveClass(/\bis-link\b/);
+    await expect(title).not.toHaveAttribute('href', /.+/);
+
+    // 既定は非折りたたみ。
+    await expect(card).not.toHaveClass(/\bcollapsed\b/);
+
+    // タイトルタップ 1 回目 → 折りたたまれる（従来挙動＝デグレ無し）。
+    await title.click();
+    await expect(card).toHaveClass(/\bcollapsed\b/);
+
+    // タイトルタップ 2 回目 → 展開に戻る（トグル動作）。
+    await title.click();
+    await expect(card).not.toHaveClass(/\bcollapsed\b/);
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── C: javascript: スキームはリンク化されない（renderer 側 isSafeHttpUrl ガード）───
+test('モバイル: apiPrUrl が javascript: の場合はタイトルがリンク化されない', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1');
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // /api/states を差し替え、apiPrUrl に javascript: を注入する。
+    // API 側 /api/set-title は javascript: を 400 で弾くため、この不正 URL は
+    // 本来 renderer に到達しないが、多層防御として renderer 単体のガードを検証する。
+    await page.route(`http://127.0.0.1:${port}/api/states`, async (route) => {
+      const injected = {
+        terminals: {
+          '1': {
+            termId: '1',
+            status: 'idle',
+            displayTitle: 'JS スキームタイトル',
+            // eslint-disable-next-line no-script-url
+            apiPrUrl: 'javascript:alert(1)',
+            lastLines: '',
+          },
+        },
+        updatedAt: Date.now(),
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(injected),
+      });
+    });
+
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    const card = page.locator('.card', { hasText: 'JS スキームタイトル' });
+    const title = card.locator('.card-title');
+    await expect(title).toBeVisible({ timeout: 15_000 });
+
+    // javascript: はリンク化されない（href 無し・.is-link 無し）。
+    await expect(title).not.toHaveClass(/\bis-link\b/);
+    await expect(title).not.toHaveAttribute('href', /.+/);
+    // 保険: href 属性自体が存在しないこと。
+    const href = await title.getAttribute('href');
+    expect(href).toBeNull();
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

モバイル版（`renderer/mobile.html`）で、各ペイン（ターミナルカード）の **タイトルをタップしたとき、リンク指定（PR URL）がある場合は別タブでそのリンクに遷移** するようにしました。リンク指定が無いペインは、従来どおりタイトルタップで折りたたみが働きます。

「リンク指定があるとき」の判定は、状態 `t.apiPrUrl` が既存の防御関数 `isSafeHttpUrl()`（http/https スキームのみ許可・issue #53 由来）を通ったときとしています。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/103

## 背景・方針

当初はヘッダ操作構造の再構成（折りたたみをシェブロン専用ボタンに一本化 等）も検討しましたが、#107（[#105](https://github.com/vektor-inc/vk-terminals/issues/105) 対応）でヘッダーが「タイトル行＋操作行」の2段構成になり、タイトルをリンク化しても折りたたみの当たり判定が痩せる問題が解消済みのため、**タイトルへのリンク付与のみの最小変更** としました（作業者判断。決定記録は issue #103 に記載）。

- 旧「PR ↗」バッジ（`a.pr-link`）は廃止せず維持。
- ヘッダ帯タップでの折りたたみ挙動も維持。

## 変更内容

- `.card-title` を `<div>` → `<a>` に変更。
- `render()` で `isSafeHttpUrl(t.apiPrUrl)` が真のときだけ、タイトルに `href` / `target="_blank"` / `rel="noopener noreferrer"` と `.is-link` クラス、`aria-label`（「〜 の PR を新しいタブで開く」＝新規タブ告知）を付与。偽なら全除去して素テキスト＝従来の折りたたみ対象に戻す。
- ヘッダ帯の折りたたみ判定 `onHeadToggle`（および keydown）の除外セレクタを `a` → `a[href]` に変更。これにより「リンク有りタイトル＝遷移（トグルしない）／リンク無しタイトル＝従来どおり折りたたみ」を両立。
- CSS: リンク時のみアクセントカラー（`#58a6ff`）＋下線＋末尾 `↗`（色だけに頼らない視覚キュー）、`:focus-visible` アウトラインを既存 UI と統一。アンカー化に伴う既定リンク装飾は `a.card-title { color: inherit; text-decoration: none }` でリセット。
- `CHANGELOG.md` に #103 のエントリを追記。

## テスト（確認手順）

前提: `npm start` でアプリを起動し、モバイル用画面（`/mobile.html`、実機スマホまたはブラウザのモバイル表示）を開く。ペインの状態は HTTP API（`POST /api/set-status` 等）で用意できる。

### A. リンク指定があるペイン（`apiPrUrl` に安全な https URL がある状態）
1. 対象ペインのタイトル（ペイン名）を見る → 名前が青字＋下線＋末尾に `↗` で表示される（リンクと分かる）。
2. タイトルをタップする → **折りたたまれず、別タブで該当 URL（PR ページ）が開く**。
3. 折りたたみたい場合はヘッダのシェブロン（▾）付近／タイトル以外の帯をタップ → 従来どおり開閉する。
4. キーボード操作: タイトルにフォーカス → フォーカスリング（青アウトライン）が出る。Enter → 別タブで開く（帯の折りたたみは発火しない）。

### B. リンク指定が無いペイン（`apiPrUrl` が無い／不正 URL）
1. タイトルは素テキスト（青字・下線・↗ なし）で表示される。
2. タイトルをタップする → **従来どおり折りたたみがトグルする**（挙動が変わっていないこと＝デグレ無し）。

### C. セキュリティ（スキーム注入の非発火）
1. `apiPrUrl` に `javascript:alert(1)` 等の危険スキームを与える → `isSafeHttpUrl` で弾かれ、タイトルはリンク化されない（href が付かない・素テキストのまま）。

## レビュー

- 🔒 セキュリティ（安藤）: PASS（`isSafeHttpUrl` 再利用でスキーム注入防御、`rel="noopener noreferrer"` 全経路付与、`aria-label` は `textContent` 経由で安全）
- 🎨 UX（植草）: PASS（色だけに頼らない・コントラスト 6.4:1・フォーカス表示統一・新規タブ告知・href 無し時の非フォーカス退化が正しい）

## 備考

- 表示に関わる変更ですが、本フローは自動実行のため Before/After 静止画は添付せず、ブラウザ実機での動作検証は e2e（麗美）で実施します。
- 将来の任意改善（別 issue 推奨）: ヘッダ帯 `role=button` トグルを撤去してシェブロンをボタン化する構造整理（ネストされたインタラクティブ要素の根治）、および旧「PR ↗」バッジ側 aria-label の新規タブ告知の統一。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/329