### PR TITLE
[ デザイン不具合修正 ] 設定ダイアログ入力欄の境界線がダーク背景に埋没し輪郭が視認しづらい不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）
+
 ## 1.14.0
 
 - [ 機能追加 ] モバイル版でペインのタイトルをタップすると、リンク指定（PR URL）がある場合に別タブで開くように変更（[#103](https://github.com/vektor-inc/vk-terminals/issues/103)）

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -317,7 +317,7 @@ html, body {
   width: 100%;
   box-sizing: border-box;
   background: #010409;
-  border: 1px solid #30363d;
+  border: 1px solid #6e7681;
   border-radius: 5px;
   color: #e6edf3;
   padding: 6px 8px;


### PR DESCRIPTION
## 概要

設定ダイアログ（ダークテーマ）の入力欄の境界線色 `#30363d` が、入力欄の地色 `#010409` に対して WCAG 2.1 AA の UI コンポーネント境界に求められる **3:1** を満たしていなかった（実測 **1.68:1**）不具合を修正。全入力欄（text / number / password / textarea / select）の共通ブロックの境界線色を、3:1 を安全に満たす **`#6e7681`（実測 4.47:1）** に変更する。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/86

## 変更内容

- `renderer/style.css` の入力共通ブロック（`.settings-row input[type="text"] / [type="number"] / [type="password"] / select / textarea`）の `border` を `#30363d` → `#6e7681` に変更（1箇所のみ）
- フォーカス枠 `#58a6ff` は十分なコントラストがあるため変更なし
- モーダル外周（`#30363d`）・ヘッダ/フッタ仕切り（`#21262d`）はエレベーション表現の控えめな仕切りのため据え置き（AA の affordance が必要なのは操作対象の入力欄枠のみ）

### 採用色の選定根拠（植草・UX）

| 色 | 対 `#010409` コントラスト比 | 判定 |
|---|---|---|
| `#30363d`（変更前） | 1.68:1 | ❌ |
| `#484f58`（issue 例示） | 2.48:1 | ❌（例示値では未達） |
| `#6e7681`（**採用**） | 4.47:1 | ✅（3:1 の約1.5倍のマージン） |

`#6e7681` はモーダル内で既に使用中（`.settings-version` / `.settings-msg`）の GitHub Primer neutral-emphasis 相当トークンで、新規グレーを増やさずパレット整合が取れる。`#8b949e`(6.68:1) は muted 文字色トークンで境界線転用は「囲みすぎ」＆意味の濁りになるため回避。

## テスト（確認手順）

### Before（修正前の再現）
1. `git checkout main` して `npm start` でアプリを起動する
2. 設定ダイアログを開く（設定アイコン）
3. text / number / password / textarea / select の各入力欄の枠線を確認する
   → 枠線（`#30363d`）が地色（`#010409`）にほぼ埋没し、輪郭が視認しづらい（コントラスト 1.68:1）

### After（修正後の確認）
1. 本ブランチ（`fix/issue-86-input-border-contrast`）で `npm start` する
2. 同じ設定ダイアログを開く
3. 各入力欄の枠線を確認する
   → 枠線（`#6e7681`）が地色に対してはっきり視認でき、フォーム要素の輪郭が明瞭になる（コントラスト 4.47:1 = WCAG 2.1 AA 3:1 達成）
4. 入力欄をクリック（フォーカス）する
   → フォーカス枠が青（`#58a6ff`）に変化し、休息時グレーとの状態差が明確に読める（従来どおり）
5. デグレ確認: モーダル外周・ヘッダ/フッタの仕切り線・リビール/キャンセルボタンの枠の見え方が従来と変わっていないこと

### コントラスト計測
地色 `#010409` に対し、変更後 `#6e7681` = 4.47:1（WCAG 2.1 AA・非テキスト UI 要件 3:1 を達成）。

## スクリーンショット

設定ダイアログの Before / After（麗美による Electron 実機撮影）。

| Before（`#30363d` / 1.68:1） | After（`#6e7681` / 4.47:1） |
|---|---|
| ![before](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-110/before-settings-dialog.png?raw=true) | ![after](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-110/after-settings-dialog.png?raw=true) |

## テスト結果（麗美 / e2e・UIテスト）

- 回帰: `npm test` 90/90 PASS、`npx playwright test`（Electron スモーク）7/7 PASS
- 実機 computed style 検証: 入力欄5種（text/number/password/select/textarea）すべて `rgb(110, 118, 129)` = `#6e7681` を確認
- デグレ: スコープ外の `#30363d`（外周・表示切替/キャンセルボタン・仕切り線）は不変