### PR TITLE
[ 機能追加 ] モバイル版でペインの並び順を▲▼ボタンで手動変更できる機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 機能追加 ] モバイル版でペインの並び順を ▲▼ ボタンで手動変更できるように変更。ステータス変化による自動並び替えを廃止し、指定順を localStorage に保存して維持（[#106](https://github.com/vektor-inc/vk-terminals/issues/106)）
+
 ## 1.14.0
 
 - [ 機能追加 ] モバイル版でペインのタイトルをタップすると、リンク指定（PR URL）がある場合に別タブで開くように変更（[#103](https://github.com/vektor-inc/vk-terminals/issues/103)）

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -448,8 +448,11 @@ function movePane(termId, delta) {
   visiblePaneOrder.splice(nextIdx, 0, id);
   var visible = {};
   visiblePaneOrder.forEach(function(visibleId) { visible[visibleId] = true; });
-  var hidden = paneOrder.filter(function(orderId) { return !visible[orderId]; });
-  paneOrder = visiblePaneOrder.concat(hidden);
+  var nextVisibleIndex = 0;
+  paneOrder = paneOrder.map(function(orderId) {
+    if (!visible[orderId]) return orderId;
+    return visiblePaneOrder[nextVisibleIndex++];
+  });
   savePaneOrder();
   applyPaneOrder();
 }

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -75,14 +75,17 @@
   a.pr-link:active { background: rgba(63,185,80,0.28); border-color: rgba(63,185,80,0.5); }
   a.pr-link:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
   a.pr-link .pr-icon { font-size: 10px; opacity: 0.85; line-height: 1; flex: none; }
-  .pane-order-controls { display: inline-flex; align-items: center; gap: 4px; flex: none; }
+  .pane-order-controls { display: inline-flex; align-items: center; gap: 8px; flex: none; }
   .pane-order-button { display: inline-flex; align-items: center; justify-content: center;
+    position: relative;
     width: 32px; min-width: 32px; height: 32px; padding: 0; border-radius: 6px;
-    border: 1px solid var(--card-border); background: #262b33; color: var(--fg);
+    border: 1px solid #606c7c; background: #2f353e; color: var(--fg);
     font-size: 12px; line-height: 1; font-weight: 700; cursor: pointer; }
-  .pane-order-button:active { background: #323843; }
+  .pane-order-button::before { content: ""; position: absolute; inset: -6px; }
+  .pane-order-button:active { background: #3a424d; }
   .pane-order-button:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
-  .pane-order-button:disabled { color: var(--idle); background: #20242b; cursor: default; opacity: 0.62; }
+  .pane-order-button:disabled { color: var(--idle); border-color: var(--card-border);
+    background: #20242b; cursor: default; opacity: 0.62; }
   .pane-order-button:disabled:active { background: #20242b; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 1.45;
@@ -342,7 +345,7 @@ var QUICK = [
 ];
 
 var list = document.getElementById("list");
-var cards = {}; // termId -> { root, pre, name, cwd, dot, badge, head, chevron, moveUpBtn, moveDownBtn }
+var cards = {}; // termId -> { root, pre, name, cwd, dot, badge, head, chevron, orderControls, moveUpBtn, moveDownBtn }
 
 var PANE_ORDER_KEY = "vkt_mobile_pane_order";
 var paneOrder = []; // termId の表示順。保存値に無い新規端末は末尾へ追加する。
@@ -424,10 +427,12 @@ function syncPaneOrder(terms) {
 }
 
 function applyPaneOrder() {
+  var showOrderControls = visiblePaneOrder.length > 1;
   visiblePaneOrder.forEach(function(termId, idx) {
     var c = cards[termId];
     if (!c) return;
     c.root.style.order = String(idx);
+    c.orderControls.style.display = showOrderControls ? "" : "none";
     c.moveUpBtn.disabled = idx === 0;
     c.moveDownBtn.disabled = idx === visiblePaneOrder.length - 1;
   });
@@ -593,7 +598,7 @@ function ensureCard(termId) {
 
   cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge,
     title: title,
-    prLink: prLink, head: head, chevron: chevron, killBtn: killBtn,
+    prLink: prLink, head: head, chevron: chevron, orderControls: orderControls, killBtn: killBtn,
     moveUpBtn: moveUpBtn, moveDownBtn: moveDownBtn };
   // 復活時を含め、現在の collapsed 状態を初期反映
   syncCollapseUI(cards[termId], termId);

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -75,6 +75,15 @@
   a.pr-link:active { background: rgba(63,185,80,0.28); border-color: rgba(63,185,80,0.5); }
   a.pr-link:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
   a.pr-link .pr-icon { font-size: 10px; opacity: 0.85; line-height: 1; flex: none; }
+  .pane-order-controls { display: inline-flex; align-items: center; gap: 4px; flex: none; }
+  .pane-order-button { display: inline-flex; align-items: center; justify-content: center;
+    width: 32px; min-width: 32px; height: 32px; padding: 0; border-radius: 6px;
+    border: 1px solid var(--card-border); background: #262b33; color: var(--fg);
+    font-size: 12px; line-height: 1; font-weight: 700; cursor: pointer; }
+  .pane-order-button:active { background: #323843; }
+  .pane-order-button:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
+  .pane-order-button:disabled { color: var(--idle); background: #20242b; cursor: default; opacity: 0.62; }
+  .pane-order-button:disabled:active { background: #20242b; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 1.45;
     white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow-y: auto;
@@ -333,7 +342,112 @@ var QUICK = [
 ];
 
 var list = document.getElementById("list");
-var cards = {}; // termId -> { root, pre, name, cwd, dot, badge, head, chevron }
+var cards = {}; // termId -> { root, pre, name, cwd, dot, badge, head, chevron, moveUpBtn, moveDownBtn }
+
+var PANE_ORDER_KEY = "vkt_mobile_pane_order";
+var paneOrder = []; // termId の表示順。保存値に無い新規端末は末尾へ追加する。
+var visiblePaneOrder = []; // 現在描画対象の termId だけに絞った表示順。
+try {
+  var savedOrder = localStorage.getItem(PANE_ORDER_KEY);
+  if (savedOrder) {
+    var parsedOrder = JSON.parse(savedOrder);
+    if (Array.isArray(parsedOrder)) {
+      var orderSeen = {};
+      paneOrder = parsedOrder.reduce(function(next, termId) {
+        var id = String(termId);
+        if (!orderSeen[id]) {
+          orderSeen[id] = true;
+          next.push(id);
+        }
+        return next;
+      }, []);
+    }
+  }
+} catch (e) { /* 壊れた JSON でも落とさない */ }
+
+function savePaneOrder() {
+  try { localStorage.setItem(PANE_ORDER_KEY, JSON.stringify(paneOrder)); }
+  catch (e) { /* 保存失敗は無視（プライベートモード等） */ }
+}
+
+function getTermId(paneId, terminal) {
+  return String(terminal && terminal.termId != null ? terminal.termId : paneId);
+}
+
+function sortTerminalKeysByStatus(keys, terms) {
+  // 新規端末を初めて末尾に足すときだけ、従来のステータス順で安定化する。
+  var rank = { waiting: 0, running: 1, idle: 2 };
+  return keys.slice().sort(function(a, b) {
+    var ra = rank[terms[a].status] != null ? rank[terms[a].status] : 3;
+    var rb = rank[terms[b].status] != null ? rank[terms[b].status] : 3;
+    if (ra !== rb) return ra - rb;
+    return getTermId(a, terms[a]).localeCompare(getTermId(b, terms[b]), undefined, { numeric: true });
+  });
+}
+
+function syncPaneOrder(terms) {
+  var keys = Object.keys(terms);
+  var present = {};
+  keys.forEach(function(paneId) {
+    present[getTermId(paneId, terms[paneId])] = true;
+  });
+
+  var used = {};
+  var next = [];
+  paneOrder.forEach(function(termId) {
+    var id = String(termId);
+    if (!used[id]) {
+      used[id] = true;
+      next.push(id);
+    }
+  });
+
+  var changed = next.length !== paneOrder.length;
+  sortTerminalKeysByStatus(keys, terms).forEach(function(paneId) {
+    var id = getTermId(paneId, terms[paneId]);
+    if (!used[id]) {
+      used[id] = true;
+      next.push(id);
+      changed = true;
+    }
+  });
+
+  if (!changed) {
+    for (var i = 0; i < next.length; i++) {
+      if (next[i] !== paneOrder[i]) { changed = true; break; }
+    }
+  }
+  paneOrder = next;
+  if (changed) savePaneOrder();
+  visiblePaneOrder = paneOrder.filter(function(termId) { return !!present[termId]; });
+  return visiblePaneOrder;
+}
+
+function applyPaneOrder() {
+  visiblePaneOrder.forEach(function(termId, idx) {
+    var c = cards[termId];
+    if (!c) return;
+    c.root.style.order = String(idx);
+    c.moveUpBtn.disabled = idx === 0;
+    c.moveDownBtn.disabled = idx === visiblePaneOrder.length - 1;
+  });
+}
+
+function movePane(termId, delta) {
+  var id = String(termId);
+  var idx = visiblePaneOrder.indexOf(id);
+  if (idx < 0) return;
+  var nextIdx = idx + delta;
+  if (nextIdx < 0 || nextIdx >= visiblePaneOrder.length) return;
+  visiblePaneOrder.splice(idx, 1);
+  visiblePaneOrder.splice(nextIdx, 0, id);
+  var visible = {};
+  visiblePaneOrder.forEach(function(visibleId) { visible[visibleId] = true; });
+  var hidden = paneOrder.filter(function(orderId) { return !visible[orderId]; });
+  paneOrder = visiblePaneOrder.concat(hidden);
+  savePaneOrder();
+  applyPaneOrder();
+}
 
 // 折り畳み状態は cards とは独立した plain object で持つ（termId -> bool）。
 // 理由: render() 末尾で states から消えた端末は cards[termId].root.remove() され
@@ -397,10 +511,20 @@ function ensureCard(termId) {
   var prIcon = document.createElement("span"); prIcon.className = "pr-icon";
   prIcon.setAttribute("aria-hidden", "true"); prIcon.textContent = "↗";
   prLink.appendChild(prLabel); prLink.appendChild(prIcon);
+  var orderControls = document.createElement("span"); orderControls.className = "pane-order-controls";
+  var moveUpBtn = document.createElement("button");
+  moveUpBtn.type = "button"; moveUpBtn.className = "pane-order-button";
+  moveUpBtn.textContent = "▲"; moveUpBtn.setAttribute("aria-label", "1つ上へ移動");
+  moveUpBtn.addEventListener("click", function() { movePane(termId, -1); });
+  var moveDownBtn = document.createElement("button");
+  moveDownBtn.type = "button"; moveDownBtn.className = "pane-order-button";
+  moveDownBtn.textContent = "▼"; moveDownBtn.setAttribute("aria-label", "1つ下へ移動");
+  moveDownBtn.addEventListener("click", function() { movePane(termId, 1); });
+  orderControls.appendChild(moveUpBtn); orderControls.appendChild(moveDownBtn);
   var chevron = document.createElement("span"); chevron.className = "chevron";
   chevron.setAttribute("aria-hidden", "true"); chevron.textContent = "▾";
   headMain.appendChild(dot); headMain.appendChild(title);
-  headMeta.appendChild(badge); headMeta.appendChild(prLink); headMeta.appendChild(chevron);
+  headMeta.appendChild(badge); headMeta.appendChild(prLink); headMeta.appendChild(orderControls); headMeta.appendChild(chevron);
   head.appendChild(headMain); head.appendChild(headMeta);
 
   // ヘッダ帯全体をタップで開閉トグル。将来ヘッダ内に
@@ -469,7 +593,8 @@ function ensureCard(termId) {
 
   cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge,
     title: title,
-    prLink: prLink, head: head, chevron: chevron, killBtn: killBtn };
+    prLink: prLink, head: head, chevron: chevron, killBtn: killBtn,
+    moveUpBtn: moveUpBtn, moveDownBtn: moveDownBtn };
   // 復活時を含め、現在の collapsed 状態を初期反映
   syncCollapseUI(cards[termId], termId);
   return cards[termId];
@@ -575,19 +700,16 @@ function render(data) {
   renderUsage(data.usage);
   var terms = data.terminals || {};
   var keys = Object.keys(terms);
-  // 並び順: waiting > running > idle、その中は termId 昇順
-  var rank = { waiting: 0, running: 1, idle: 2 };
-  keys.sort(function(a, b) {
-    var ra = rank[terms[a].status] != null ? rank[terms[a].status] : 3;
-    var rb = rank[terms[b].status] != null ? rank[terms[b].status] : 3;
-    if (ra !== rb) return ra - rb;
-    return String(terms[a].termId).localeCompare(String(terms[b].termId), undefined, { numeric: true });
+  var termById = {};
+  keys.forEach(function(paneId) {
+    termById[getTermId(paneId, terms[paneId])] = terms[paneId];
   });
+  var orderedTermIds = syncPaneOrder(terms);
 
   var seen = {};
-  keys.forEach(function(paneId, idx) {
-    var t = terms[paneId];
-    var termId = String(t.termId);
+  orderedTermIds.forEach(function(termId) {
+    var t = termById[termId];
+    if (!t) return;
     seen[termId] = true;
     var c = ensureCard(termId);
     var st = t.status || "idle";
@@ -625,13 +747,13 @@ function render(data) {
     c.pre.textContent = sanitizeMobilePreviewText(tail(stripAnsi(t.lastLines || ""), 1400)).replace(/\n{3,}/g, "\n\n").trim();
     // 折り畳み状態を毎回当て直す（再描画・端末の消失→復活をまたいで一致させる）
     syncCollapseUI(c, termId);
-    // CSS order で並び替え（DOM移動をやめてモバイルでの入力フォーカス消失を防ぐ）
-    c.root.style.order = String(idx);
   });
   // 消えた端末のカードを削除
   Object.keys(cards).forEach(function(termId) {
     if (!seen[termId]) { cards[termId].root.remove(); delete cards[termId]; }
   });
+  // CSS order で並び替え（DOM移動をやめてモバイルでの入力フォーカス消失を防ぐ）
+  applyPaneOrder();
 
   if (keys.length === 0) {
     if (!document.getElementById("empty")) {


### PR DESCRIPTION
## 概要

モバイル版（`renderer/mobile.html`）のペイン一覧は、これまで 2 秒ごとの再描画のたびにステータス順（waiting > running > idle → その中は termId 昇順）へ自動ソートしていました。そのため端末の状態が変わるたびにカードの順番が勝手に入れ替わり、どれがどれか分からなくなる問題がありました（issue #106）。

本 PR で、ステータス依存の自動並び替えを廃止し、各カードのヘッダ帯に追加した **▲▼ ボタン**でユーザーが手動で並び順を制御できるようにします。並び順は端末（termId）をキーに `localStorage` へ保存し、状態変化・再描画・端末の消失→復活をまたいでも維持します。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/106

## 変更内容

- ステータス自動ソートを廃止し、ユーザー指定の並び順でカードを表示。
- 各カードのヘッダ帯（badge・PR リンク・chevron が並ぶ meta 行）に ▲／▼ ボタンを追加。押すとそのカードを 1 つ上／下へ移動。
- 並び順は termId 配列として `localStorage`（キー `vkt_mobile_pane_order`）に永続化。JSON 破損・非配列・プライベートモード等でも落ちないよう防御。
- 新規に現れた端末は既存の並びの末尾に追加（初回のみ従来のステータス順で安定化）。以後は手動並びを尊重し、勝手に動かさない。
- 先頭カードの ▲、末尾カードの ▼ は `disabled`。並び替えは DOM 移動をせず CSS `order` の再適用で行い、モバイルでの入力フォーカス消失を回避。
- 可視ペインが 1 つ以下のときは ▲▼ コントロールを非表示。
- アクセシビリティ対応: `aria-label`（「1つ上へ移動」「1つ下へ移動」）、`focus-visible` アウトライン、有効時ボタン境界コントラストを WCAG 2.1 AA 1.4.11（3:1）以上に、`::before` でタップ当たり判定を約 44px に拡張。

## テスト（確認手順）

前提: PC 側でこのアプリ（`npm start`）を起動し、ターミナル（ペイン）を **3 つ以上**開いておく。モバイル UI は同一 LAN のスマホ／別ブラウザから `http://<ホスト>:13847/mobile.html`（またはローカルで `http://127.0.0.1:13847/mobile.html`）を開いて確認する。

### Before（修正前の挙動 / main ブランチ）

1. モバイル UI を開き、複数ペインが一覧表示される。
2. いずれかのペインで処理を実行し、ステータスを変化させる（例: 入力待ち → 実行中）。
   → カードの並び順がステータスに応じて **勝手に入れ替わる**（本 PR で解消したい問題）。

### After（本 PR）

1. モバイル UI（`/mobile.html`）を開く。各カードのヘッダ右側（バッジ・PR リンクの隣）に **▲ / ▼ ボタン**が表示される。
   → 端末が 1 つだけのときは ▲▼ は表示されない。2 つ以上で表示される。
2. あるカードの **▼** を押す。
   → そのカードが 1 つ下へ移動する。**▲** を押すと 1 つ上へ移動する。
3. 先頭カードの **▲**、末尾カードの **▼** がグレーアウト（`disabled`）で押せないことを確認する。
4. 並び替えた状態で、いずれかのペインのステータスを変化させる（入力待ち↔実行中など）。
   → **並び順が変わらない**（自動ソートされない）。
5. ブラウザをリロードする。
   → 並び順が保持されている（`localStorage` 永続化）。
6. ペインを 1 つ閉じて再度開く／端末が一時的に消えて復活する。
   → 残ったカードの相対順序が保たれ、復活端末は元の位置または末尾に収まる。
7. ヘッダ帯全体をタップすると従来どおりカードの開閉トグルが動作し、▲▼ ボタンのタップでは開閉トグルされないことを確認する。

### デグレ確認

- 折り畳み（collapse）状態・スクロール位置復元・ペイン終了（✕）ボタン・PR リンク・タスク名表示など既存機能が従来どおり動作すること。

## スクリーンショット

UI 変更を含むため、e2e/UI 検証（麗美）での実機ブラウザ確認とあわせて Before / After を添付予定です。

## レビュー

- 🔒 セキュリティ（安藤）: PASS 済み（localStorage 入出力の防御・XSS 非該当・並び替えロジック健全）
- 🎨 UX（植草）: 判定「問題なし」。中優先度の指摘（ボタン境界コントラスト 3:1・タップ間隔・1ペイン時非表示）は本 PR で取り込み済み。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - モバイル版で、端末カードの表示順を▲▼ボタンで手動変更できるようになりました。
  - 変更した表示順は保存され、再表示後も維持されます。
  - 端末の状態が変化しても、設定した表示順が自動で入れ替わらなくなりました。
  - 先頭・末尾では移動ボタンが自動的に無効化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->