### PR TITLE
[ 機能追加 ] HTTP API /api/set-title に prMerged を追加しマージ済み PR ラベルを紫表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [ 機能追加 ] モバイル版でペインの並び順を ▲▼ ボタンで手動変更できるように変更。ステータス変化による自動並び替えを廃止し、指定順を localStorage に保存して維持（[#106](https://github.com/vektor-inc/vk-terminals/issues/106)）
+- [ 機能追加 ] HTTP API `POST /api/set-title` に `prMerged` を追加し、マージ済み PR のラベルを紫で表示できるように（[#113](https://github.com/vektor-inc/vk-terminals/issues/113)）
 - [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）
 

--- a/main.js
+++ b/main.js
@@ -1107,7 +1107,7 @@ function startHttpApi() {
       return;
     }
 
-    // POST /api/set-title  { termId: "1", title: "タスク名", url?: "https://...", prUrl?: "https://..." }
+    // POST /api/set-title  { termId: "1", title: "タスク名", url?: "https://...", prUrl?: "https://...", prMerged?: true }
     //   — ペイン上部のタスクタイトル行に表示する文字列を設定。
     //   空文字や null を title に指定するとタイトル行を非表示に戻す。
     //   url を指定するとタイトル全体をリンク化（クリックで OS の既定ブラウザで開く）。
@@ -1117,6 +1117,7 @@ function startHttpApi() {
     //   prUrl（issue #44）: タイトル右側の独立した [ PR ↗ ] ボタンに紐づける URL。
     //   省略 → PR ボタンなし扱い、空文字 "" → 既存 prUrl をクリア。
     //   バリデーションは url と同一規約（http(s):・2048 文字以内・new URL() parse 可）。
+    //   prMerged: PR ボタンをマージ済み表示にする真偽値。厳密な true のみ true、それ以外は false。
     if (req.method === 'POST' && url.pathname === '/api/set-title') {
       if (isForbiddenOrigin(req)) {
         res.writeHead(403, { 'Content-Type': 'application/json' });
@@ -1194,12 +1195,13 @@ function startHttpApi() {
             }
             prUrlValue = r.value;
           }
+          const prMergedValue = parsed?.prMerged === true;
 
           if (win && !win.isDestroyed()) {
-            win.webContents.send('terminal:title', termId, title, urlValue, prUrlValue);
+            win.webContents.send('terminal:title', termId, title, urlValue, prUrlValue, prMergedValue);
           }
           res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ ok: true, termId, title, url: urlValue, prUrl: prUrlValue }));
+          res.end(JSON.stringify({ ok: true, termId, title, url: urlValue, prUrl: prUrlValue, prMerged: prMergedValue }));
         } catch (e) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'invalid JSON' }));

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -7,6 +7,7 @@ const { stripAnsiForDisplay } = require('../utils/stripAnsi');
 const { AGENT_ORDER, buildScene, resolveAgentStatesFromOutput } = require('./agentRoom');
 const { matchesWaiting, nextWaitingState } = require('./waitingState');
 const { deriveStatus } = require('./statusState');
+const { getPrBadgePresentation } = require('./prBadge');
 
 // ─── xterm.css の注入 ─────────────────────────────────────────────────────────
 // xterm.css は index.html の相対パス <link> ではなく、Node のモジュール解決
@@ -314,6 +315,8 @@ async function createTerminal(paneId, cwd, options = {}) {
     apiTitle: '',
     apiUrl: '',
     apiPrUrl: '',
+    // apiPrMerged: HTTP API（POST /api/set-title）で渡された PR のマージ済み状態。
+    apiPrMerged: false,
     // agentRoom（issue #58）: POST /api/agentroom で受け取ったルーム状態 { name: state }。
     //   null のままなら API 未通知。API が古い（AGENTROOM_API_TTL_MS 超過）場合は
     //   resolveRoomAgents() が PTY 出力ベースのフォールバック表示に切り替える。
@@ -957,7 +960,8 @@ function setupSidebarMenu() {
 // OS の既定ブラウザを開く。
 // 第4引数 prUrl（issue #44）: 非空のとき、タイトル右側に独立した PR ボタン（<a class="pane-task-title-pr">）を追加する。
 //   apiTitle / taskTitle のいずれが表示中でも、prUrl があれば常時表示する（採用: 案A）。
-function renderTaskTitleContent(el, title, url, prUrl) {
+// 第5引数 prMerged: true のとき、PR ボタンをマージ済み表示（紫 + 非色アイコン）にする。
+function renderTaskTitleContent(el, title, url, prUrl, prMerged = false) {
   // 既存の子要素を全消去（innerHTML は使わずに DOM API で組み立てる）
   while (el.firstChild) el.removeChild(el.firstChild);
 
@@ -1015,11 +1019,12 @@ function renderTaskTitleContent(el, title, url, prUrl) {
   // タイトル文字列の有無・apiTitle/taskTitle の選択状態に関わらず、prUrl があれば常時表示。
   // .pane-badge（issue #27 で導入した共通バッジ basis）に乗せて見た目を統一する。
   if (prUrl) {
+    const prPresentation = getPrBadgePresentation(prMerged === true);
     const prLink = document.createElement('a');
-    prLink.className = 'pane-badge pane-task-title-pr';
+    prLink.className = prPresentation.className;
     prLink.href = '#'; // 実 URL は入れない（タイトルリンクと同じ理由）
     prLink.setAttribute('role', 'link');
-    prLink.setAttribute('aria-label', 'プルリクエストを開く（外部ブラウザ）');
+    prLink.setAttribute('aria-label', prPresentation.ariaLabel);
     prLink.title = prUrl;
     prLink.draggable = false;
 
@@ -1031,7 +1036,7 @@ function renderTaskTitleContent(el, title, url, prUrl) {
     const prIcon = document.createElement('span');
     prIcon.className = 'pane-task-title-pr-icon';
     prIcon.setAttribute('aria-hidden', 'true');
-    prIcon.textContent = '↗';
+    prIcon.textContent = prPresentation.icon;
     prLink.appendChild(prIcon);
 
     prLink.addEventListener('click', (e) => {
@@ -1061,7 +1066,8 @@ function updatePaneTitle(paneId) {
   // PR ボタンは apiPrUrl があれば常時表示（採用: 案A）。
   // renderer 側でも http(s) 二段チェックを通してから採用する。
   const prUrl = isSafeExternalUrl(t.apiPrUrl) ? t.apiPrUrl : '';
-  renderTaskTitleContent(el, title, url, prUrl);
+  const prMerged = !!t.apiPrMerged;
+  renderTaskTitleContent(el, title, url, prUrl, prMerged);
   // ホバー時のツールチップは has-link 時は子 <a> 側に集約して親子競合を避ける。
   //   - URL 無し: 親 .pane-task-title に title 属性をセット（従来挙動）
   //   - URL 有り: 親 title 属性を削除し、<a> 側の title（タイトル + URL）のみに任せる
@@ -1749,6 +1755,7 @@ function renderLeaf(node) {
   const taskUrl = getDisplayUrl(t);
   // PR ボタン用 URL（issue #44）。renderer 側でも http(s) 二段チェックを通す。
   const taskPrUrl = isSafeExternalUrl(t?.apiPrUrl) ? t.apiPrUrl : '';
+  const taskPrMerged = !!t?.apiPrMerged;
 
   const el = document.createElement('div');
   el.className = 'pane'
@@ -1770,7 +1777,7 @@ function renderLeaf(node) {
     + (isEmpty ? ' empty' : '')
     + (taskUrl ? ' has-link' : '')
     + (taskPrUrl ? ' has-pr' : '');
-  renderTaskTitleContent(taskTitleEl, taskTitle, taskUrl, taskPrUrl);
+  renderTaskTitleContent(taskTitleEl, taskTitle, taskUrl, taskPrUrl, taskPrMerged);
   // URL 有りのときは子 <a> 側の title 属性に集約するため、親には付けない（親子競合回避）。
   if (taskTitle && !taskUrl) taskTitleEl.title = taskTitle;
   if (canDragPane) {
@@ -2690,6 +2697,7 @@ setInterval(() => {
       apiTitle: t.apiTitle || '',
       apiUrl: t.apiUrl || '',
       apiPrUrl: t.apiPrUrl || '',
+      apiPrMerged: !!t.apiPrMerged,
       displayTitle: getDisplayTitle(t),
       // collapsed: グリッド化で折り畳み機能を撤去したため常に false（後方互換のためキーは維持）。
       collapsed: false,
@@ -2778,8 +2786,9 @@ ipcRenderer.on('terminal:request-close-pane', (event, payload = {}) => {
 //   - undefined → 後方互換のため prUrl 変更なしと解釈（ただし main 側は常に第4引数を送る）
 //   - 空文字  → apiPrUrl をクリア（PR ボタン非表示）
 //   - 文字列 → http(s): スキームのみ（main 側で検証済み）。apiPrUrl にセット
-// title / url / prUrl はペアで都度送る置換セマンティクス。
-ipcRenderer.on('terminal:title', (event, termId, title, url, prUrl) => {
+// 第5引数 prMerged: PR ボタンのマージ済み表示フラグ。boolean のときのみ apiPrMerged に反映する。
+// title / url / prUrl / prMerged はペアで都度送る置換セマンティクス。
+ipcRenderer.on('terminal:title', (event, termId, title, url, prUrl, prMerged) => {
   const paneId = Object.keys(terminals).find(k => terminals[k]?.termId === termId);
   if (!paneId) return;
   terminals[paneId].apiTitle = title || '';
@@ -2790,6 +2799,10 @@ ipcRenderer.on('terminal:title', (event, termId, title, url, prUrl) => {
   // prUrl も同様。後方互換のため string 以外は無視する。
   if (typeof prUrl === 'string') {
     terminals[paneId].apiPrUrl = prUrl;
+  }
+  // prMerged も同様。後方互換のため boolean 以外は無視する。
+  if (typeof prMerged === 'boolean') {
+    terminals[paneId].apiPrMerged = prMerged;
   }
   updatePaneTitle(paneId);
 });

--- a/renderer/prBadge.js
+++ b/renderer/prBadge.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function getPrBadgePresentation(prMerged) {
+  const merged = prMerged === true;
+  return {
+    className: 'pane-badge pane-task-title-pr' + (merged ? ' merged' : ''),
+    ariaLabel: merged
+      ? 'マージ済みのプルリクエストを開く（外部ブラウザ）'
+      : 'プルリクエストを開く（外部ブラウザ）',
+    icon: merged ? '✓' : '↗',
+  };
+}
+
+module.exports = {
+  getPrBadgePresentation,
+};

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -970,6 +970,23 @@ body.resizing-sidebar .sidebar {
   text-decoration: none;
 }
 
+.pane-task-title-pr.merged {
+  background: rgba(130, 80, 223, 0.15);
+  border-color: rgba(130, 80, 223, 0.3);
+  /* GitHub の merged 紫 `#8250df` 系。`.pane-task-title` 背景 `#aaa` 上で
+   * WCAG 2.1 AA テキスト基準（4.5:1）を満たす濃い紫へ落とす。
+   * 実背景は `#aaa` に badge 塗り `rgba(130,80,223,0.15)` を合成した
+   * 約 rgb(164,157,178) で、`#3a1a63` に対し実測コントラスト比 約 5.3:1（AA 達成）。
+   * hover（塗り 0.25）でも約 4.9:1 で 4.5:1 を確保する。 */
+  color: #3a1a63;
+}
+
+.pane-task-title-pr.merged:hover {
+  background: rgba(130, 80, 223, 0.25);
+  border-color: rgba(130, 80, 223, 0.5);
+  color: #3a1a63;
+}
+
 .pane-task-title-pr:focus-visible {
   outline: 2px solid #58a6ff;
   outline-offset: 2px;

--- a/tests/e2e/pr-badge-merged.smoke.spec.js
+++ b/tests/e2e/pr-badge-merged.smoke.spec.js
@@ -1,0 +1,202 @@
+const { test, expect, _electron } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// issue #113 / PR #114: POST /api/set-title に prMerged を渡すと、ペイン上部の
+// PR バッジ（.pane-task-title-pr）がマージ済み表示（紫 + ✓ アイコン + 専用 aria-label）
+// に切り替わることの end-to-end 確認。
+//   A: prMerged: true → .merged クラスが付き、アイコンが ✓、aria-label がマージ済み文言になる
+//   B: prMerged 省略 → 従来どおり緑（.merged 無し、アイコン ↗、従来 aria-label）
+//   C: prMerged が boolean 以外（文字列 "true" 等）→ 厳密な === true 判定により緑のまま
+//      （main.js 側で `parsed?.prMerged === true` により既に boolean へ矯正されるため、
+//        HTTP API 経由ではここまでで多くのケースを検証できる）
+//   D: renderer 側の型ガード自体（IPC 経由で main の矯正をバイパスした場合）も
+//      多層防御として直接確認する（ipcRenderer.on の `typeof prMerged === 'boolean'` ガード）。
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  // 既定ポート 13847 を避けることで、開発中の通常起動インスタンスと衝突させない。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (!port) {
+          reject(new Error('failed to allocate a free port'));
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function postSetTitle(port, payload) {
+  const response = await fetch(`http://127.0.0.1:${port}/api/set-title`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  let body = null;
+  try {
+    body = await response.json();
+  } catch (_e) {
+    // 失敗時の診断用に本文が JSON でないケースも許容する。
+  }
+
+  return { response, body };
+}
+
+async function waitForPtyRegistration(port) {
+  const deadline = Date.now() + 20_000;
+  let lastError = null;
+
+  while (Date.now() < deadline) {
+    try {
+      // termId "1" は起動時に renderer が作る最初のペインの PTY。
+      // PTY 登録前は main 側が 404 を返すため、200 になるまで短くリトライする。
+      const result = await postSetTitle(port, { termId: '1', title: '' });
+      if (result.response.status === 200) return;
+      if (result.response.status !== 404) {
+        throw new Error(`unexpected status ${result.response.status}: ${JSON.stringify(result.body)}`);
+      }
+      lastError = new Error(`terminal 1 not ready: ${JSON.stringify(result.body)}`);
+    } catch (e) {
+      // HTTP サーバー起動前は fetch 自体が失敗するため、同じ待機ループで吸収する。
+      lastError = e;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw lastError || new Error('terminal 1 was not registered in time');
+}
+
+test('POST /api/set-title の prMerged が renderer の PR バッジへ反映される', async () => {
+  const port = await getFreePort();
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-pr-merged-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  let app;
+
+  fs.mkdirSync(configDir, { recursive: true });
+
+  // loadUserConfig() は HOME 配下の config.json を読むため、HOME 自体を一時化して
+  // 実ユーザーの ~/.vk-terminals/config.json（Tailscale IP 等）に依存しないようにする。
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  try {
+    app = await _electron.launch({
+      // このテストは HTTP API と renderer 反映の統合パスだけを見る。
+      // Claude CLI の有無に依存させないため、起動時は素のシェルにしておく。
+      args: ['.', '--no-claude'],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        USERPROFILE: tmpHome,
+        VK_TERMINALS_API_PORT: String(port),
+      },
+    });
+
+    const win = await app.firstWindow();
+
+    await waitForPtyRegistration(port);
+
+    // prUrl は http(s) の schema・new URL() parse・2048 文字以内であればよく、
+    // 実際にネットワークへ出る必要はない（クリックしない）ため自サーバーの URL を使う。
+    const prUrl = `http://127.0.0.1:${port}/?pr=113`;
+
+    const prBadge = win.locator('.pane .pane-task-title-pr').first();
+    const prIcon = prBadge.locator('.pane-task-title-pr-icon');
+
+    // ─── A: prMerged: true → 紫（.merged）・✓・マージ済み aria-label ───
+    const mergedResult = await postSetTitle(port, {
+      termId: '1',
+      title: 'PR #113 マージ済みバッジ確認',
+      prUrl,
+      prMerged: true,
+    });
+    expect(mergedResult.response.status).toBe(200);
+    expect(mergedResult.body && mergedResult.body.prMerged).toBe(true);
+
+    await expect(prBadge).toBeVisible();
+    await expect(prBadge).toHaveClass(/\bmerged\b/);
+    await expect(prBadge).toHaveAttribute('aria-label', 'マージ済みのプルリクエストを開く（外部ブラウザ）');
+    await expect(prIcon).toHaveText('✓');
+
+    // ─── B: prMerged 省略 → 従来どおり緑（.merged 無し・↗・従来 aria-label） ───
+    const omittedResult = await postSetTitle(port, {
+      termId: '1',
+      title: 'PR #113 省略時は緑のまま',
+      prUrl,
+    });
+    expect(omittedResult.response.status).toBe(200);
+    expect(omittedResult.body && omittedResult.body.prMerged).toBe(false);
+
+    await expect(prBadge).not.toHaveClass(/\bmerged\b/);
+    await expect(prBadge).toHaveAttribute('aria-label', 'プルリクエストを開く（外部ブラウザ）');
+    await expect(prIcon).toHaveText('↗');
+
+    // ─── C: prMerged が boolean 以外（文字列 "true"）→ 厳密な === true 判定で緑のまま ───
+    // 先に一度 merged: true にしてから非 boolean を送り、緑へ戻ることを確認する
+    // （「非 boolean は無視されて直前の状態を維持する」誤りではなく、明示的に false 扱いになることを見る）。
+    await postSetTitle(port, { termId: '1', title: 'PR #113 一旦マージ済みに', prUrl, prMerged: true });
+    await expect(prBadge).toHaveClass(/\bmerged\b/);
+
+    const nonBooleanResult = await postSetTitle(port, {
+      termId: '1',
+      title: 'PR #113 非 boolean は緑扱い',
+      prUrl,
+      prMerged: 'true',
+    });
+    expect(nonBooleanResult.response.status).toBe(200);
+    expect(nonBooleanResult.body && nonBooleanResult.body.prMerged).toBe(false);
+
+    await expect(prBadge).not.toHaveClass(/\bmerged\b/);
+    await expect(prBadge).toHaveAttribute('aria-label', 'プルリクエストを開く（外部ブラウザ）');
+    await expect(prIcon).toHaveText('↗');
+
+    // ─── D: 多層防御 — renderer 側 `typeof prMerged === 'boolean'` ガード自体の確認 ───
+    // main.js は HTTP 経由では常に prMerged を boolean へ矯正して IPC 送信するため、
+    // 上記 A〜C だけでは renderer 側ガードの分岐を直接踏めない。
+    // ここでは main プロセス側から直接 'terminal:title' を送出し、
+    // 矯正前の非 boolean（文字列）が来た場合でも renderer が無視して
+    // 直前の apiPrMerged（true）を維持することを確認する。
+    await postSetTitle(port, { termId: '1', title: 'PR #113 IPC 直接テスト前準備', prUrl, prMerged: true });
+    await expect(prBadge).toHaveClass(/\bmerged\b/);
+
+    await app.evaluate(({ BrowserWindow }, injectedPrUrl) => {
+      const target = BrowserWindow.getAllWindows()[0];
+      // 非 boolean（文字列 'true'）を第5引数に直接送出し、main.js の矯正を経由しない
+      // renderer 側ガード単体を突く。prUrl には非空文字列を渡し PR バッジ自体は表示され続けるようにする。
+      target.webContents.send('terminal:title', '1', 'PR #113 IPC 直接非 boolean', '', injectedPrUrl, 'true');
+    }, prUrl);
+
+    // renderer 実装（app.js の ipcRenderer.on('terminal:title', ...)）は
+    // `typeof prMerged === 'boolean'` のときだけ apiPrMerged を上書きする。
+    // 文字列 'true' は boolean ではないため上書きされず、直前の apiPrMerged（true）が
+    // そのまま維持される＝ .merged クラスが付いたままになるはず。
+    // ここが崩れて「非 boolean を merged 判定に使ってしまう」実装に変わっていないかを確認する。
+    await expect(prBadge).toHaveClass(/\bmerged\b/);
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/prBadge.test.js
+++ b/tests/prBadge.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getPrBadgePresentation } = require('../renderer/prBadge');
+
+test('getPrBadgePresentation: prMerged true で merged クラス・aria・非色アイコンを返す', () => {
+  const presentation = getPrBadgePresentation(true);
+
+  assert.match(presentation.className, /\bmerged\b/);
+  assert.equal(presentation.ariaLabel, 'マージ済みのプルリクエストを開く（外部ブラウザ）');
+  assert.equal(presentation.icon, '✓');
+});
+
+test('getPrBadgePresentation: prMerged true 以外は従来 PR 表示を返す', () => {
+  const presentation = getPrBadgePresentation('true');
+
+  assert.equal(presentation.className, 'pane-badge pane-task-title-pr');
+  assert.equal(presentation.ariaLabel, 'プルリクエストを開く（外部ブラウザ）');
+  assert.equal(presentation.icon, '↗');
+});


### PR DESCRIPTION
## 概要

ペイン上部の PR ラベル（`.pane-task-title-pr`）は現在つねに緑で表示されます。対象 PR が **マージ済み** のときにラベルを紫にして、マージ済みだと一目で分かるようにするための **案B（VK Terminals 側先行実装）** です。

本 PR では VK Terminals 側の **受け口とレンダリング** のみを実装します。オーケストレーター（vk-orchestrator）が実際に `prMerged` を送る連携は別 issue（vektor-inc/vk-orchestrator#73）で対応するため、本 PR 単体では通常運用の見た目は変わりません。`POST /api/set-title` に `prMerged: true` を送れば紫で表示される状態になることがゴールです。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/113
元要望: https://github.com/vektor-inc/vk-orchestrator/issues/71
連携（後続）: https://github.com/vektor-inc/vk-orchestrator/issues/73

## 変更点

- `main.js`: `POST /api/set-title` に `prMerged`（boolean）を追加。省略時は `false`（後方互換）。厳密に `true` のときのみ真として IPC 第5引数・レスポンス JSON に反映。
- `renderer/app.js`: 端末状態に `apiPrMerged` を追加。IPC `terminal:title` の第5引数を受領。両レンダーパス（`updatePaneTitle` / `renderLeaf`）と `getStates` 出力に反映。
- `renderer/prBadge.js`（新規）: PR バッジの表示（クラス名・aria-label・アイコン）を返す純関数 `getPrBadgePresentation` を切り出し、テスト可能に。
- `renderer/style.css`: マージ済み用 `.pane-task-title-pr.merged` を追加（GitHub の merged 紫 `#8250df` 系）。
- 色のみに依存しない（WCAG 1.4.1）よう、マージ済みは末尾アイコンを `↗`→`✓`、aria-label を「マージ済みのプルリクエストを開く（外部ブラウザ）」に変更。
- `tests/prBadge.test.js`（新規）: `getPrBadgePresentation` のユニットテスト。

### アクセシビリティ

- 紫文字色 `#3a1a63` は、`.pane-task-title` 背景 `#aaa` に badge 塗り `rgba(130,80,223,0.15)` を合成した実背景（約 rgb(164,157,178)）上でコントラスト比 約 5.3:1（hover 時 約 4.9:1）。いずれも WCAG 2.1 AA（4.5:1）を満たす。

## テスト（確認手順）

前提: `npm start` で VK Terminals を起動し、ペインが1つ以上ある状態（`termId` を控える。既定のペインは `1`）。HTTP API はデフォルト `http://127.0.0.1:13847`。

### 1. 未マージ（従来どおり緑）であることの確認（デグレ確認）

1. 以下を実行する（`termId` は環境に合わせる）:
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/set-title \
     -H 'Content-Type: application/json' \
     -d '{"termId":"1","title":"テストタスク","prUrl":"https://github.com/vektor-inc/vk-terminals/pull/1"}'
   ```
   → 該当ペインのタイトル右に **緑の「PR ↗」** バッジが表示される（従来どおり）。

### 2. マージ済み（紫）表示の確認

1. 同じペインに `prMerged: true` を付けて送る:
   ```bash
   curl -s -X POST http://127.0.0.1:13847/api/set-title \
     -H 'Content-Type: application/json' \
     -d '{"termId":"1","title":"テストタスク","prUrl":"https://github.com/vektor-inc/vk-terminals/pull/1","prMerged":true}'
   ```
   → バッジが **紫** に変わり、末尾アイコンが `↗` から **`✓`** に変わる。ラベル文字は「PR」のまま。
   → バッジをクリックすると従来どおり PR ページが既定ブラウザで開く。
   → スクリーンリーダーでは「マージ済みのプルリクエストを開く（外部ブラウザ）」と読み上げられる。

### 3. 後方互換の確認

1. `prMerged` を送らない（手順1の状態）→ 緑のまま。
2. `prMerged` に boolean 以外（例 `"true"` / `1`）を送っても紫にならず緑のまま（`=== true` 厳密判定）。

### 4. ユニットテスト

```bash
node --test tests/
```
→ 92 件すべて green（`tests/prBadge.test.js` の 2 ケースを含む）。

## スクリーンショット

UI（バッジの色・アイコン）変更を含みます。実機での緑（未マージ）/ 紫（マージ済み）の Before / After は、後続の e2e/UI 確認（麗美）で取得・添付します。

## 補足（今回スコープ外・UX レビューでの申し送り）

- モバイル版（`renderer/mobile.html`）の PR バッジは別実装のため、マージ済み表示は未対応（後続で揃える想定）。
- 緑・紫バッジの border コントラスト（WCAG 1.4.11）引き上げは既存踏襲事項のため別途検討。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/338