### PR TITLE
[ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [ 機能追加 ] モバイル版でペインのタイトルをタップすると、リンク指定（PR URL）がある場合に別タブで開くように変更（[#103](https://github.com/vektor-inc/vk-terminals/issues/103)）
 - [ 機能追加 ] モバイル版で各ターミナル（ペイン）を終了するボタンを追加（[#100](https://github.com/vektor-inc/vk-terminals/issues/100)）
 - [ 仕様変更 ] モバイル版でペインヘッダーをタイトル行と操作行の2段表示に変更（[#105](https://github.com/vektor-inc/vk-terminals/issues/105)）
+- [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ 不具合修正 ] モバイル版のペインプレビューにスピナー記号や数字断片だけの意味がない行が表示される不具合を修正（[#102](https://github.com/vektor-inc/vk-terminals/issues/102)）
 - [ 開発環境 ] Playwright + Electron による e2e スモークテスト基盤を追加し、`POST /api/set-status` から renderer のステータス反映までを実行時に検証
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [ 機能追加 ] モバイル版でペインの並び順を ▲▼ ボタンで手動変更できるように変更。ステータス変化による自動並び替えを廃止し、指定順を localStorage に保存して維持（[#106](https://github.com/vektor-inc/vk-terminals/issues/106)）
+- [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）
 
 ## 1.14.0
@@ -8,7 +9,6 @@
 - [ 機能追加 ] モバイル版でペインのタイトルをタップすると、リンク指定（PR URL）がある場合に別タブで開くように変更（[#103](https://github.com/vektor-inc/vk-terminals/issues/103)）
 - [ 機能追加 ] モバイル版で各ターミナル（ペイン）を終了するボタンを追加（[#100](https://github.com/vektor-inc/vk-terminals/issues/100)）
 - [ 仕様変更 ] モバイル版でペインヘッダーをタイトル行と操作行の2段表示に変更（[#105](https://github.com/vektor-inc/vk-terminals/issues/105)）
-- [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ 不具合修正 ] モバイル版のペインプレビューにスピナー記号や数字断片だけの意味がない行が表示される不具合を修正（[#102](https://github.com/vektor-inc/vk-terminals/issues/102)）
 - [ 開発環境 ] Playwright + Electron による e2e スモークテスト基盤を追加し、`POST /api/set-status` から renderer のステータス反映までを実行時に検証
 

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ const SEND_ENTER_SPLIT_DELAY_MS = 150;
 let cachedStates = {};  // renderer から受け取った状態キャッシュ
 let httpServer = null;
 
-const MENU_ACTION_TYPES = new Set(['open-settings', 'open-usage', 'open-url']);
+const MENU_ACTION_TYPES = new Set(['open-settings', 'open-url']);
 const MENU_MAX_SECTIONS = 20;
 const MENU_MAX_ITEMS = 50;
 const MENU_MAX_CHILDREN = 20;
@@ -139,8 +139,6 @@ function validateMenuItem(raw, source, depth, seenIds) {
     }
     if (raw.action.type === 'open-settings') {
       item.action = { type: 'open-settings' };
-    } else if (raw.action.type === 'open-usage') {
-      item.action = { type: 'open-usage' };
     } else if (raw.action.type === 'open-url') {
       const r = validateUrlField(raw.action.url, 'action.url');
       if (!r.ok || !r.value) {
@@ -234,12 +232,6 @@ function builtinMenuSection() {
   return {
     source: 'builtin',
     items: [
-      {
-        id: 'usage',
-        label: 'Claude使用量',
-        icon: '📊',
-        action: { type: 'open-usage' },
-      },
       {
         id: 'settings',
         label: '設定',

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -513,10 +513,6 @@ function runMenuAction(action) {
     openSettingsModal();
     return;
   }
-  if (action.type === 'open-usage') {
-    openUsageModal();
-    return;
-  }
   if (action.type === 'open-url') {
     openExternalUrlSafe(action.url);
   }
@@ -533,7 +529,7 @@ function createMenuActionElement(item) {
       event.preventDefault();
       runMenuAction(action);
     });
-  } else if (action?.type === 'open-settings' || action?.type === 'open-usage') {
+  } else if (action?.type === 'open-settings') {
     el = document.createElement('button');
     el.className = 'sidebar-menu-button';
     el.type = 'button';
@@ -618,16 +614,18 @@ function renderSidebarMenu() {
     }
   }
 
-  applyUsageBadge(); // 再描画で消えた使用率警告ドットを貼り直す
+  applyUsageBadge();
 }
 
 // サイドバーのラッパー（.sidebar）を組み立てる（issue #89）。
-// 中身は「スクロールする nav（メニュー内側 + 格納ペインセクション）」と「幅リサイズハンドル」。
-// 開閉トランジション・可変幅の基準はこのラッパー側に持たせる。
+// 中身は「固定ヘッダーの使用量カード」「スクロールする nav（メニュー内側 + 格納ペイン
+// セクション）」と「幅リサイズハンドル」。開閉トランジション・可変幅の基準はこのラッパー側に持たせる。
 function createSidebar() {
   const aside = document.createElement('aside');
   aside.id = 'sidebar';
   aside.className = 'sidebar';
+
+  aside.appendChild(createSidebarUsageCard());
 
   const nav = document.createElement('nav');
   nav.id = 'sidebar-menu';
@@ -645,6 +643,25 @@ function createSidebar() {
   aside.appendChild(nav);
   aside.appendChild(createSidebarResizer());
   return aside;
+}
+
+function createSidebarUsageCard() {
+  const section = document.createElement('section');
+  section.id = 'sidebar-usage';
+  section.className = 'sidebar-usage';
+  section.hidden = true;
+  section.setAttribute('aria-label', 'Claude使用量');
+
+  const title = document.createElement('div');
+  title.className = 'sidebar-usage-title';
+  title.textContent = 'Claude使用量';
+
+  const body = document.createElement('div');
+  body.className = 'sidebar-usage-body';
+
+  section.appendChild(title);
+  section.appendChild(body);
+  return section;
 }
 
 // 格納ペインを収めるセクション（見出し＋リスト）。中身は renderPaneStash が更新する。
@@ -688,6 +705,7 @@ function ensureSidebar(root) {
   if (!el) {
     el = createSidebar();
     renderSidebarMenu();
+    renderSidebarUsage(lastUsageSnapshot);
     renderPaneStash();
   }
   return el;
@@ -2142,9 +2160,8 @@ window.addEventListener('resize', () => setSidebarWidth(getSidebarWidth()));
 // ─── 設定パネル（汎用）────────────────────────────────────────────────────────
 // main プロセス（settings:describe / settings:save）経由で、呼び出し側が env
 // VK_TERMINALS_SETTINGS で指定した config ファイルをこの GUI から編集する。
-// 歯車ボタンは設定モーダル（設定項目のみ）を開く。Claude の使用状況はサイドバーの
-// 「Claude使用量」項目（openUsageModal）へ分離した。describe が使えない環境では
-// モーダル側で「設定項目なし」を表示する。
+// 歯車ボタンは設定モーダル（設定項目のみ）を開く。Claude の使用状況はサイドバー上部の
+// 常時表示カードへ統合した。describe が使えない環境ではモーダル側で「設定項目なし」を表示する。
 function setupSettingsPanel() {
   const btn = document.getElementById('settings-btn');
   if (!btn) return;
@@ -2157,7 +2174,9 @@ function setupSettingsPanel() {
 //   - source: 'transcript' … トランスクリプト集計（describeUsage の整形済み値）
 // percent は百分率（17 = 17%）。トークン等の秘匿情報は main から一切渡らない。
 
-const USAGE_POLL_INTERVAL_MS = 60000; // モーダル表示中・バッジ共通（main 側 60s TTL に相乗り）
+const USAGE_POLL_INTERVAL_MS = 60000; // 使用量バッジ・サイドバーカード共通（main 側 60s TTL に相乗り）
+const USAGE_SIDEBAR_TICK_INTERVAL_MS = 30000;
+let lastUsageSnapshot = null;
 
 // 公式% の閾値カラー（〜70% 青 / 70〜90% アンバー / 90%〜 赤）。
 // フォールバックの自己ピーク比バーには適用しない（上限比ではないため）。
@@ -2190,9 +2209,9 @@ function formatResetDateTimeJa(ms) {
 
 // 公式データ 1 区分（セッション / 週間）のセクションを組み立てる。
 //   resetMode: 'remaining' … 「◯時間◯分後にリセット」。data-reset-at を付け、
-//              モーダルの毎秒ティッカーがポーリングを待たずライブ再計算する。
+//              サイドバーの低頻度ティッカーがポーリングを待たず再計算する。
 //   resetMode: 'datetime'  … 「金 18:59 にリセット」（週間制限向け・静的表示）。
-function buildOauthUsageSection(title, entry, resetMode) {
+function buildOauthUsageSection(title, entry, resetMode, options = {}) {
   const sec = document.createElement('div');
   sec.className = 'usage-section';
 
@@ -2200,7 +2219,11 @@ function buildOauthUsageSection(title, entry, resetMode) {
   head.className = 'usage-section-head';
   const titleEl = document.createElement('span');
   titleEl.className = 'usage-section-title';
-  titleEl.textContent = title;
+  titleEl.textContent = options.titleLabel || title;
+  if (options.titleLabel && options.titleLabel !== title) {
+    titleEl.title = title;
+    titleEl.setAttribute('aria-label', title);
+  }
   const valueEl = document.createElement('span');
   valueEl.className = 'usage-value';
   valueEl.textContent = Number.isFinite(entry.percent) ? `${Math.round(entry.percent)}% 使用済み` : '—';
@@ -2292,7 +2315,7 @@ function buildTranscriptUsageSection(u) {
 }
 
 // 使用状況ビュー全体を描画する（読み取り専用）。
-function renderUsageView(container, usage) {
+function renderUsageView(container, usage, options = {}) {
   container.innerHTML = '';
   if (!usage) {
     const p = document.createElement('p');
@@ -2311,10 +2334,14 @@ function renderUsageView(container, usage) {
       container.appendChild(note);
     }
     if (usage.session) {
-      container.appendChild(buildOauthUsageSection('現在のセッション', usage.session, 'remaining'));
+      container.appendChild(buildOauthUsageSection('現在のセッション', usage.session, 'remaining', {
+        titleLabel: options.compact ? 'セッション' : '',
+      }));
     }
     if (usage.weekly) {
-      container.appendChild(buildOauthUsageSection('週間制限（すべてのモデル）', usage.weekly, 'datetime'));
+      container.appendChild(buildOauthUsageSection('週間制限（すべてのモデル）', usage.weekly, 'datetime', {
+        titleLabel: options.compact ? '週間' : '',
+      }));
     }
     return;
   }
@@ -2322,7 +2349,33 @@ function renderUsageView(container, usage) {
   container.appendChild(buildTranscriptUsageSection(usage));
 }
 
-// 歯車ボタンの警告ドットバッジ（issue #73）。
+function renderSidebarUsage(usage) {
+  lastUsageSnapshot = usage || null;
+  const section = document.getElementById('sidebar-usage');
+  if (!section) return;
+  const body = section.querySelector('.sidebar-usage-body');
+  if (!body) return;
+
+  if (!usage) {
+    section.hidden = true;
+    body.replaceChildren();
+    return;
+  }
+
+  renderUsageView(body, usage, { compact: true });
+  section.hidden = false;
+}
+
+function tickSidebarUsageReset() {
+  const section = document.getElementById('sidebar-usage');
+  if (!section || section.hidden) return;
+  section.querySelectorAll('[data-reset-at]').forEach((el) => {
+    const at = Number(el.dataset.resetAt);
+    if (Number.isFinite(at)) el.textContent = formatRemainingJa(at - Date.now());
+  });
+}
+
+// ☰ メニューボタンの警告ドットバッジ（issue #73）。
 // 公式の使用率（セッション・週間のいずれか）が 80% を超えたときだけドットを重ねる
 // （80〜90%: アンバー / 90%〜: 赤）。フォールバック（自己ピーク比）は上限比ではないため
 // バッジ対象にしない。ポーリングは 60 秒間隔で main 側 60s TTL キャッシュに相乗りする。
@@ -2333,18 +2386,16 @@ const USAGE_ALERT_LABELS = {
   'crit': 'Claude使用量: 危険（90%超）',
 };
 
-// 直近の使用率警告レベル（'' / 'warn' / 'crit'）。サイドバーは menu:update で
-// 作り直されるため、レベルはモジュール変数で保持し renderSidebarMenu から貼り直す。
+// 直近の使用率警告レベル（'' / 'warn' / 'crit'）。
 let usageAlertLevel = '';
 
-// 使用率の警告ドットを ☰ メニューボタン（常時表示）とサイドバーの「Claude使用量」
-// 項目の両方に反映する。サイドバー閉時でも ☰ 側で警告に気付けるようにする。
+// 使用率の警告ドットを ☰ メニューボタン（常時表示）に反映する。
+// サイドバー閉時でも警告に気付けるようにし、開いているときは使用量カードのバー色で示す。
 function applyUsageBadge() {
   const level = usageAlertLevel;
   const menuBtn = document.getElementById('menu-btn');
   const targets = [];
   if (menuBtn) targets.push(menuBtn);
-  document.querySelectorAll('[data-menu-action="open-usage"]').forEach((el) => targets.push(el));
   for (const el of targets) {
     el.classList.toggle('usage-alert-warn', level === 'warn');
     el.classList.toggle('usage-alert-crit', level === 'crit');
@@ -2360,10 +2411,11 @@ function applyUsageBadge() {
 function setupUsageBadge() {
   const refresh = async () => {
     let level = '';
+    let usage = null;
     try {
-      const u = await ipcRenderer.invoke('usage:get');
-      if (u && u.source === 'oauth') {
-        const pcts = [u.session && u.session.percent, u.weekly && u.weekly.percent]
+      usage = await ipcRenderer.invoke('usage:get');
+      if (usage && usage.source === 'oauth') {
+        const pcts = [usage.session && usage.session.percent, usage.weekly && usage.weekly.percent]
           .filter((p) => Number.isFinite(p));
         const max = pcts.length ? Math.max(...pcts) : null;
         if (max !== null && max > 80) level = max >= 90 ? 'crit' : 'warn';
@@ -2371,11 +2423,13 @@ function setupUsageBadge() {
     } catch (_e) {
       level = ''; // 取得失敗時はバッジを消す（古い警告を残さない）
     }
+    renderSidebarUsage(usage);
     usageAlertLevel = level;
     applyUsageBadge();
   };
   refresh();
   setInterval(refresh, USAGE_POLL_INTERVAL_MS);
+  setInterval(tickSidebarUsageReset, USAGE_SIDEBAR_TICK_INTERVAL_MS);
 }
 
 // 1 フィールド分の入力 HTML を組み立てる。
@@ -2444,85 +2498,18 @@ function renderSettingsField(f, value, id) {
   </div>`;
 }
 
-// モーダルを開き、「Claude使用状況｜設定」のタブ構成で描画する（issue #73）。
-//   - 既定タブは「Claude使用状況」（読み取り専用。フッターの保存/キャンセルは出さない）
-//   - 「設定」タブは settings:describe が使えるときだけ描画し、従来どおり保存できる
-//   - 使用状況のポーリングは「Claude使用状況タブ表示中のみ」初回即時＋60秒間隔。
-//     残り時間表示（◯時間◯分後にリセット）は毎秒ライブ再計算する
-// 設定モーダル・使用量モーダルの同時オープンを防ぐ共有ロック。settings:describe の
-// await 中は overlay がまだ DOM に無いため、.settings-overlay の有無チェックだけでは
-// もう一方のモーダルがすり抜けて二重生成されうる。await より前に同期で立てるこのフラグ
-// で「チェック〜生成」を原子的に守り、モーダルを閉じた／生成に失敗した時に必ず戻す。
+// 設定モーダルの二重オープンを防ぐロック。settings:describe の await 中は overlay がまだ
+// DOM に無いため、.settings-overlay の有無チェックだけでは二重生成されうる。await より前に
+// 同期で立てるこのフラグで「チェック〜生成」を原子的に守り、モーダルを閉じた／生成に
+// 失敗した時に必ず戻す。
 let modalOpen = false;
 
-// ─── Claude使用量モーダル ─────────────────────────────────────────────────────
-// 設定から切り離した読み取り専用の使用状況ビュー。サイドバーの「Claude使用量」項目
-// （builtin メニューの open-usage アクション）から起動する。設定モーダルとは別物で、
-// 保存フッターは持たず、表示中のみ 60 秒ポーリング＋リセット残時間の毎秒再計算を行う。
-async function openUsageModal() {
-  // 二重オープン防止（設定モーダルと共通の同期ロックで 1 枚に限定）
-  if (modalOpen) return;
-  modalOpen = true;
-
-  const overlay = document.createElement('div');
-  overlay.className = 'settings-overlay usage-overlay';
-  overlay.innerHTML = `
-    <div class="settings-modal usage-modal" role="dialog" aria-modal="true" aria-label="Claude使用量">
-      <div class="settings-header">
-        <h2>Claude使用量</h2>
-        <button class="settings-close" title="閉じる">✕</button>
-      </div>
-      <div class="settings-view settings-view-usage" role="region">
-        <p class="usage-empty">Claude の使用状況を取得中…</p>
-      </div>
-    </div>`;
-  document.body.appendChild(overlay);
-
-  const modal = overlay.querySelector('.usage-modal');
-  const usageView = modal.querySelector('.settings-view-usage');
-
-  // 使用状況のポーリング（main 側 60s TTL キャッシュに相乗り）と、リセット残時間の
-  // 毎秒ライブ再計算。モーダルを閉じたら両方止める。
-  let usagePollTimer = null;
-  let usageTickTimer = null;
-  const refreshUsage = async () => {
-    let u = null;
-    try {
-      u = await ipcRenderer.invoke('usage:get');
-    } catch (_e) {
-      u = null;
-    }
-    if (!overlay.isConnected) return; // 取得中に閉じられたら何もしない
-    renderUsageView(usageView, u);
-  };
-  refreshUsage(); // 初回即時（ポーリング待ちにしない）
-  usagePollTimer = setInterval(refreshUsage, USAGE_POLL_INTERVAL_MS);
-  usageTickTimer = setInterval(() => {
-    usageView.querySelectorAll('[data-reset-at]').forEach((el) => {
-      const at = Number(el.dataset.resetAt);
-      if (Number.isFinite(at)) el.textContent = formatRemainingJa(at - Date.now());
-    });
-  }, 1000);
-
-  const close = () => {
-    if (usagePollTimer) { clearInterval(usagePollTimer); usagePollTimer = null; }
-    if (usageTickTimer) { clearInterval(usageTickTimer); usageTickTimer = null; }
-    document.removeEventListener('keydown', onKey);
-    overlay.remove();
-    modalOpen = false;
-  };
-  const onKey = (e) => { if (e.key === 'Escape') close(); };
-  document.addEventListener('keydown', onKey);
-  overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) close(); });
-  modal.querySelector('.settings-close').addEventListener('click', close);
-}
-
 async function openSettingsModal() {
-  // 二重オープン防止（使用量モーダルと共通の同期ロック。describe の await より前に立てる）
+  // 二重オープン防止（describe の await より前に立てる）
   if (modalOpen) return;
   modalOpen = true;
 
-  // 設定ディスクリプタが無い環境でも空の設定モーダルとして開く（使用量は別モーダル）。
+  // 設定ディスクリプタが無い環境でも空の設定モーダルとして開く（使用量はサイドバー上部）。
   let desc = null;
   try {
     desc = await ipcRenderer.invoke('settings:describe');
@@ -2660,10 +2647,10 @@ initApp().then(() => {
   ipcRenderer.send('terminal:renderer-ready');
 });
 
-// 設定モーダルの歯車ボタンを配線する（設定のみ。使用量はサイドバーの別モーダルへ）。
+// 設定モーダルの歯車ボタンを配線する（設定のみ。使用量はサイドバー上部へ常時表示）。
 setupSettingsPanel();
 
-// 使用率警告ドットバッジ（☰ メニューボタン＋サイドバーの「Claude使用量」項目）を配線する。
+// 使用率警告ドットバッジ（☰ メニューボタン）とサイドバー使用量カードを配線する。
 setupUsageBadge();
 
 // ─── State reporting to main process ─────────────────────────────────────────

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -658,6 +658,7 @@ function createSidebarUsageCard() {
 
   const body = document.createElement('div');
   body.className = 'sidebar-usage-body';
+  body.setAttribute('aria-live', 'polite');
 
   section.appendChild(title);
   section.appendChild(body);
@@ -2207,6 +2208,11 @@ function formatResetDateTimeJa(ms) {
   return `${wd} ${hh}:${mm} にリセット`;
 }
 
+function setTextWithTitle(el, text) {
+  el.textContent = text;
+  el.title = text;
+}
+
 // 公式データ 1 区分（セッション / 週間）のセクションを組み立てる。
 //   resetMode: 'remaining' … 「◯時間◯分後にリセット」。data-reset-at を付け、
 //              サイドバーの低頻度ティッカーがポーリングを待たず再計算する。
@@ -2251,9 +2257,9 @@ function buildOauthUsageSection(title, entry, resetMode, options = {}) {
   if (Number.isFinite(entry.resetAtMs)) {
     if (resetMode === 'remaining') {
       reset.dataset.resetAt = String(entry.resetAtMs);
-      reset.textContent = formatRemainingJa(entry.resetAtMs - Date.now());
+      setTextWithTitle(reset, formatRemainingJa(entry.resetAtMs - Date.now()));
     } else {
-      reset.textContent = formatResetDateTimeJa(entry.resetAtMs);
+      setTextWithTitle(reset, formatResetDateTimeJa(entry.resetAtMs));
     }
   }
   sec.appendChild(reset);
@@ -2302,13 +2308,13 @@ function buildTranscriptUsageSection(u) {
 
   const reset = document.createElement('div');
   reset.className = 'usage-reset';
-  reset.textContent = `リセット ${u.resetText}（残り${u.remainingText}）`;
+  setTextWithTitle(reset, `リセット ${u.resetText}（残り${u.remainingText}）`);
   sec.appendChild(reset);
 
   if (u.peakNote) {
     const note = document.createElement('div');
     note.className = 'usage-note';
-    note.textContent = u.peakNote;
+    setTextWithTitle(note, u.peakNote);
     sec.appendChild(note);
   }
   return sec;
@@ -2330,7 +2336,7 @@ function renderUsageView(container, usage, options = {}) {
     if (usage.stale === true) {
       const note = document.createElement('div');
       note.className = 'usage-note';
-      note.textContent = '直近に取得した値を表示しています（最新の取得に一時的に失敗しました）';
+      setTextWithTitle(note, '直近に取得した値を表示しています（最新の取得に一時的に失敗しました）');
       container.appendChild(note);
     }
     if (usage.session) {
@@ -2371,7 +2377,7 @@ function tickSidebarUsageReset() {
   if (!section || section.hidden) return;
   section.querySelectorAll('[data-reset-at]').forEach((el) => {
     const at = Number(el.dataset.resetAt);
-    if (Number.isFinite(at)) el.textContent = formatRemainingJa(at - Date.now());
+    if (Number.isFinite(at)) setTextWithTitle(el, formatRemainingJa(at - Date.now()));
   });
 }
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -13,9 +13,8 @@
     <button id="menu-btn" class="titlebar-menu-btn" type="button" aria-label="メニュー" aria-expanded="false" aria-controls="sidebar-menu" title="メニュー">☰</button>
     <span class="app-title">VK Terminals</span>
     <!-- 歯車は常時表示。設定モーダル（設定項目のみ）を開く。Claude の使用量は
-         サイドバーの「Claude使用量」項目へ分離した。使用率 80% 超過時の警告ドットは
-         app.js が ☰ メニューボタンとサイドバー項目に .usage-alert-warn /
-         .usage-alert-crit を付与して表示する。 -->
+         サイドバー最上部のカードへ統合した。使用率 80% 超過時の警告ドットは
+         app.js が ☰ メニューボタンに .usage-alert-warn / .usage-alert-crit を付与して表示する。 -->
     <button id="settings-btn" class="titlebar-btn" title="設定">⚙</button>
   </div>
   <div id="root"></div>

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -93,20 +93,13 @@ html, body {
 
 /* 使用率の警告ドットバッジ。公式の使用率（セッション・週間のいずれか）が 80% を
    超えたときだけ app.js が .usage-alert-warn（80〜90%: アンバー）/ .usage-alert-crit
-   （90%〜: 赤）を付与する。使用量表示を設定から分離したため、常時見える ☰ メニュー
-   ボタンと、サイドバーの「Claude使用量」項目の両方に表示する。 */
+   （90%〜: 赤）を ☰ メニューボタンに付与する。 */
 .titlebar-menu-btn.usage-alert-warn,
-.titlebar-menu-btn.usage-alert-crit,
-.sidebar-menu-button.usage-alert-warn,
-.sidebar-menu-button.usage-alert-crit {
+.titlebar-menu-btn.usage-alert-crit {
   position: relative;
 }
-.titlebar-btn.usage-alert-warn::after,
-.titlebar-btn.usage-alert-crit::after,
 .titlebar-menu-btn.usage-alert-warn::after,
-.titlebar-menu-btn.usage-alert-crit::after,
-.sidebar-menu-button.usage-alert-warn::after,
-.sidebar-menu-button.usage-alert-crit::after {
+.titlebar-menu-btn.usage-alert-crit::after {
   content: "";
   position: absolute;
   top: 3px;
@@ -116,12 +109,8 @@ html, body {
   border-radius: 50%;
   border: 1px solid #0d1117;
 }
-.titlebar-btn.usage-alert-warn::after,
-.titlebar-menu-btn.usage-alert-warn::after,
-.sidebar-menu-button.usage-alert-warn::after { background: #d29922; }
-.titlebar-btn.usage-alert-crit::after,
-.titlebar-menu-btn.usage-alert-crit::after,
-.sidebar-menu-button.usage-alert-crit::after { background: #f85149; }
+.titlebar-menu-btn.usage-alert-warn::after { background: #d29922; }
+.titlebar-menu-btn.usage-alert-crit::after { background: #f85149; }
 
 /* ─── 設定パネル（モーダル）──────────────────────────────────────────────────── */
 .settings-overlay {
@@ -177,9 +166,6 @@ html, body {
 }
 .settings-close:hover { background: #21262d; color: #e6edf3; }
 
-/* ─── 設定モーダルのタブ（Claude使用状況｜設定, issue #73）─────────────────────
- * ヘッダー直下のセグメント切替。既定タブは「Claude使用状況」（読み取り専用ビュー）。
- * 設定ディスクリプタが使えない環境では「設定」タブ自体を描画しない。 */
 /* モーダル（flex column・max-height 制限）内でビュー単位にスクロールさせる。
  * hidden 属性で非表示切替。 */
 .settings-view {
@@ -196,9 +182,6 @@ html, body {
  *   #d29922 / 90%〜 赤 #f85149）。緑は「実行中」の意味で使用済みのため使わない。
  *   フォールバック（自己ピーク比）のバーは単色青・閾値カラーなし（上限比ではないため）。
  *   バーには必ず数値ラベルを併記し、色だけに依存しない。 */
-.settings-view-usage {
-  padding: 14px 18px;
-}
 .usage-section {
   margin-bottom: 18px;
 }
@@ -242,7 +225,7 @@ html, body {
 }
 .usage-note {
   margin-top: 3px;
-  /* モーダル背景 #0d1117 上で WCAG AA（4.5:1）を満たすよう .usage-reset と同じ
+  /* ダーク背景 #0d1117 上で WCAG AA（4.5:1）を満たすよう .usage-reset と同じ
    * #8b949e / 11px に揃える（旧 #6e7681 / 10px は約 4.1:1 で AA 不達のため変更）。 */
   font-size: 11px;
   color: #8b949e;
@@ -412,14 +395,16 @@ html, body {
 
 /* ─── Sidebar ──────────────────────────────────────────────────────────────── */
 /* ラッパー（.sidebar）が flex 子・開閉トランジション・可変幅（--vktm-sidebar-width）の基準。
- * 内側の nav（.sidebar-menu）がメニューと格納ペインをスクロール表示し、
- * 右端の .sidebar-resizer で幅をドラッグ変更する（issue #89）。 */
+ * 固定ヘッダーの使用量カードの下で、内側の nav（.sidebar-menu）がメニューと格納ペインを
+ * スクロール表示し、右端の .sidebar-resizer で幅をドラッグ変更する（issue #89）。 */
 .sidebar {
   position: relative;
   flex: 0 0 0;
   width: var(--vktm-sidebar-width, 330px);
   min-width: 0;
   height: 100%;
+  display: flex;
+  flex-direction: column;
   transform: translateX(-100%);
   transition: flex-basis 0.18s ease, transform 0.18s ease;
   z-index: 900;
@@ -438,14 +423,67 @@ body.resizing-sidebar .sidebar {
   transition: none;
 }
 .sidebar-menu {
+  flex: 1 1 auto;
   width: 100%;
-  height: 100%;
+  min-height: 0;
   min-width: 0;
   overflow: hidden auto;
 }
 .sidebar-menu-inner {
   width: 100%;
   padding: 10px 8px;
+}
+
+.sidebar-usage {
+  flex: 0 0 auto;
+  width: 100%;
+  padding: 10px 12px 12px;
+  border-bottom: 1px solid #21262d;
+  background: #0d1117;
+}
+.sidebar-usage[hidden] {
+  display: none;
+}
+.sidebar-usage-title {
+  margin-bottom: 8px;
+  color: #8b949e;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.sidebar-usage .usage-section {
+  margin-bottom: 12px;
+}
+.sidebar-usage .usage-section:last-child {
+  margin-bottom: 0;
+}
+.sidebar-usage .usage-section-head {
+  gap: 6px;
+  margin-bottom: 5px;
+}
+.sidebar-usage .usage-section-title,
+.sidebar-usage .usage-value,
+.sidebar-usage .usage-reset,
+.sidebar-usage .usage-note {
+  white-space: nowrap;
+}
+.sidebar-usage .usage-section-title,
+.sidebar-usage .usage-value {
+  font-size: 11px;
+}
+.sidebar-usage .usage-section-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-usage .usage-value {
+  flex: 0 0 auto;
+}
+.sidebar-usage .usage-reset,
+.sidebar-usage .usage-note {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* サイドバー右端の幅リサイズハンドル。グリッドの .grid-handle と同じく、

--- a/tests/e2e/sidebar-usage.smoke.spec.js
+++ b/tests/e2e/sidebar-usage.smoke.spec.js
@@ -1,0 +1,94 @@
+const { test, expect, _electron } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-sidebar-usage-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  const win = await app.firstWindow();
+  return { app, win, tmpRoot };
+}
+
+test('デスクトップの Claude 使用量はサイドバー最上部に常時表示され、旧モーダル項目は無い', async () => {
+  const port = await getFreePort();
+  const { app, win, tmpRoot } = await launchApp(port);
+  try {
+    await win.waitForSelector('#sidebar', { state: 'attached' });
+
+    await win.evaluate(() => {
+      window.renderSidebarUsage({
+        source: 'oauth',
+        session: {
+          percent: 42,
+          resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        },
+        weekly: {
+          percent: 76,
+          resetAtMs: Date.now() + 3 * 24 * 60 * 60 * 1000,
+        },
+      });
+    });
+
+    await win.locator('#menu-btn').click();
+
+    const usage = win.locator('#sidebar-usage');
+    await expect(usage).toBeVisible();
+    await expect(usage).toContainText('Claude使用量');
+    await expect(usage.locator('.usage-section-title').nth(0)).toHaveText('セッション');
+    await expect(usage.locator('.usage-section-title').nth(0)).toHaveAttribute('title', '現在のセッション');
+    await expect(usage.locator('.usage-section-title').nth(1)).toHaveText('週間');
+    await expect(usage.locator('.usage-section-title').nth(1)).toHaveAttribute('title', '週間制限（すべてのモデル）');
+
+    const sidebarOrder = await win.evaluate(() => {
+      const sidebar = document.getElementById('sidebar');
+      return Array.from(sidebar.children).map((el) => el.id || el.className);
+    });
+    expect(sidebarOrder.slice(0, 2)).toEqual(['sidebar-usage', 'sidebar-menu']);
+
+    await expect(win.locator('[data-menu-action="open-usage"]')).toHaveCount(0);
+    await expect(win.locator('.usage-overlay, .usage-modal')).toHaveCount(0);
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/e2e/sidebar-usage.smoke.spec.js
+++ b/tests/e2e/sidebar-usage.smoke.spec.js
@@ -73,11 +73,17 @@ test('デスクトップの Claude 使用量はサイドバー最上部に常時
 
     const usage = win.locator('#sidebar-usage');
     await expect(usage).toBeVisible();
+    await expect(usage.locator('.sidebar-usage-body')).toHaveAttribute('aria-live', 'polite');
     await expect(usage).toContainText('Claude使用量');
     await expect(usage.locator('.usage-section-title').nth(0)).toHaveText('セッション');
     await expect(usage.locator('.usage-section-title').nth(0)).toHaveAttribute('title', '現在のセッション');
     await expect(usage.locator('.usage-section-title').nth(1)).toHaveText('週間');
     await expect(usage.locator('.usage-section-title').nth(1)).toHaveAttribute('title', '週間制限（すべてのモデル）');
+    const resetLabels = await usage.locator('.usage-reset').evaluateAll((els) => els.map((el) => ({
+      text: el.textContent,
+      title: el.getAttribute('title'),
+    })));
+    expect(resetLabels.every(({ text, title }) => text === title)).toBe(true);
 
     const sidebarOrder = await win.evaluate(() => {
       const sidebar = document.getElementById('sidebar');
@@ -87,6 +93,39 @@ test('デスクトップの Claude 使用量はサイドバー最上部に常時
 
     await expect(win.locator('[data-menu-action="open-usage"]')).toHaveCount(0);
     await expect(win.locator('.usage-overlay, .usage-modal')).toHaveCount(0);
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test('使用量データが null のときサイドバー使用量カードは hidden になる', async () => {
+  const port = await getFreePort();
+  const { app, win, tmpRoot } = await launchApp(port);
+  try {
+    await win.waitForSelector('#sidebar', { state: 'attached' });
+
+    await win.evaluate(() => {
+      window.renderSidebarUsage({
+        source: 'transcript',
+        tokensText: '1,234',
+        percentText: '42%',
+        resetText: '18:59',
+        remainingText: '2時間',
+        peakNote: '直近の履歴から推定しています',
+      });
+    });
+    const usage = win.locator('#sidebar-usage');
+    await expect(usage).toBeVisible();
+    await expect(usage.locator('.usage-reset')).toHaveAttribute('title', 'リセット 18:59（残り2時間）');
+    await expect(usage.locator('.usage-note')).toHaveAttribute('title', '直近の履歴から推定しています');
+
+    await win.evaluate(() => {
+      window.renderSidebarUsage(null);
+    });
+
+    await expect(usage).toHaveAttribute('hidden', '');
+    await expect(usage).toBeHidden();
   } finally {
     if (app) await app.close();
     fs.rmSync(tmpRoot, { recursive: true, force: true });


### PR DESCRIPTION
## 概要

デスクトップ版の Claude 使用量表示を、サイドバーメニューの「Claude使用量」項目をクリックして開くモーダルから、**サイドバー最上部の常時表示カード**へ統合しました（モバイル版の常時表示に合わせる）。仕様は issue でユーザー承認済みの A案（モーダル廃止・常時表示に一本化）です。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/109

## 変更内容

- `aside#sidebar` を縦 flex（固定ヘッダー＋スクロール本体）に変更し、最上部に使用量カード `#sidebar-usage` を常時表示。中身は既存の `renderUsageView()` を再利用（`renderSidebarMenu()` の再描画対象外の独立セクションとして保持。issue #89 と同種の再生成・点滅を回避）。
- 狭いサイドバー幅向けにラベルを「セッション」「週間」へ短縮し、正式名称は `title` / `aria-label` に温存。省略される reset / note 行にもフルテキストを `title` で退避（`aria-live="polite"` も付与）。
- データ無し・取得失敗・表示無効時はカードごと非表示（`section.hidden`）。
- ポーリングを `setupUsageBadge()`（60 秒間隔・main 側 60s TTL キャッシュに相乗り）に一本化。バッジ更新と使用量カード更新を同一の `usage:get` で行い、リセット残時間のライブ更新は 30 秒間隔。
- 既存モーダル（`open-usage` メニュー項目・`openUsageModal`・関連 CSS・`main.js` の `MENU_ACTION_TYPES` の `open-usage`）を廃止。
- 使用率 80% 超の警告ドットは、サイドバー閉時（完全オフキャンバス）の気づき用に ☰ ボタンのみへ整理。サイドバー内は使用量バーの色分け（`level-warn` / `level-crit`）が閾値表示を担う。

## テスト（確認手順）

前提: `npm install` 済み。`npm start` でアプリを起動。

1. アプリ起動後、タイトルバーの ☰ ボタンをクリックしてサイドバーを開く。
   → サイドバー**最上部**に「Claude使用量」カードが表示される（クリック操作不要）。使用量データが取得できる環境では、セッション% / 週間% の 2 バー（またはトークン量のフォールバック 1 バー）が出る。
2. 旧「Claude使用量」メニュー項目が**存在しない**ことを確認する。
   → サイドバーのメニューに「📊 Claude使用量」項目が無く、クリックしてもモーダルは開かない。
3. サイドバー右端をドラッグして最小幅（200px 付近）まで狭める。
   → ラベル・数値・バーが折り返しで崩れず、はみ出す行は末尾が省略（…）される。省略された行にマウスを重ねると `title` でフルテキストが確認できる。
4. 使用量が取得できない環境（未ログイン / オフライン）で起動する。
   → 使用量カードごと非表示になり、空の枠が残らない。
5. サイドバー内メニューの項目数が多い場合、メニュー部だけがスクロールし、使用量カードは上部に固定されたままになる。

### 自動テスト

- `npx playwright test tests/e2e/sidebar-usage.smoke.spec.js` … 2 passed（常時表示・コンパクトラベルの `title` 退避・旧モーダル項目/オーバーレイの不在・`null` 時の非表示を検証）
- `npm test` … 90 passed

## レビュー

- 🔒 セキュリティ（安藤）: PASS（XSS 経路なし・`open-usage` 削除でバリデーション後退なし・ポーリング多重登録/リークなし・例外時安全側）
- 🎨 UX（植草）: PASS（必須指摘「省略行の `title` 退避」を反映済み）

> UI 変更のため Before / After スクリーンショットの添付が望ましいですが、自動実行環境のため未添付です。レビュー時に手動確認のうえ添付をお願いします。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/332