### PR TITLE
[ 機能追加 ] サイドバーに格納したペインのヘッダーを2段化し、メインエリア同様に PR リンク・タイトルリンクを表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 機能追加 ] サイドバーに格納したペインのツールバー（ヘッダー）にも、メインエリアのペイン同様 PR リンク（およびタイトルリンク）を表示するように追加（[#112](https://github.com/vektor-inc/vk-terminals/issues/112)）
+- [ 仕様変更 ] サイドバーに格納したペインのヘッダーを、メインエリアのペイン同様タイトル行と操作アイコン行の2段表示に変更（[#112](https://github.com/vektor-inc/vk-terminals/issues/112)）
 - [ 機能追加 ] モバイル版でペインの並び順を ▲▼ ボタンで手動変更できるように変更。ステータス変化による自動並び替えを廃止し、指定順を localStorage に保存して維持（[#106](https://github.com/vektor-inc/vk-terminals/issues/106)）
 - [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -789,7 +789,8 @@ function stashToggleGlyph(open) { return open ? '▾' : '▸'; }
 function stashToggleLabel(open) { return open ? 'ターミナルを隠す' : 'ターミナルを表示'; }
 
 // 格納ペイン 1 件分（コンパクトカード）を生成する。
-//   - ヘッダ: 状態バッジ + タスク名 + アクション（▲ ▼ 表示トグル(▸/▾) →(復帰) ✕）
+//   - タイトル行: タスク名 / タイトルリンク / PR リンク
+//   - 操作行: 状態バッジ + アクション（▲ ▼ 表示トグル(▸/▾) →(復帰) ✕）
 //   - cwd 行
 //   - term-container（xterm。既定は非表示、― で開閉）
 function renderStashItem(id, idx, count) {
@@ -805,15 +806,28 @@ function renderStashItem(id, idx, count) {
 
   const status = t?.status || 'idle';
   const { label: statusLabel, ariaLabel: statusAriaLabel } = getStatusPresentation(status);
-  const title = getDisplayTitle(t) || '(無題)';
+  const title = getDisplayTitle(t);
+  const taskUrl = getDisplayUrl(t);
+  const taskPrUrl = isSafeExternalUrl(t?.apiPrUrl) ? t.apiPrUrl : '';
   const cwd = t?.cwd || '~';
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'pane-task-title stash-item-title-row'
+    + (!title && !taskPrUrl ? ' empty' : '')
+    + (taskUrl ? ' has-link' : '')
+    + (taskPrUrl ? ' has-pr' : '');
+  renderTaskTitleContent(titleEl, title, taskUrl, taskPrUrl);
+  if (taskUrl) {
+    titleEl.removeAttribute('title');
+  } else {
+    titleEl.title = title;
+  }
 
   const head = document.createElement('div');
   head.className = 'stash-item-head';
   // セキュリティ: cwd（OS 由来）・status 等は escAttr / escText でエスケープする（renderLeaf と同流儀）。
   head.innerHTML = `
     <span class="pane-badge pane-status" data-status="${escAttr(status)}" role="status" aria-live="polite"${statusAriaLabel ? ` aria-label="${escAttr(statusAriaLabel)}"` : ''}>${escText(statusLabel)}</span>
-    <span class="stash-item-title" title="${escAttr(title)}">${escText(title)}</span>
     <div class="stash-item-actions">
       <button class="btn btn-stash-up" title="上へ移動" aria-label="上へ移動">▲</button>
       <button class="btn btn-stash-down" title="下へ移動" aria-label="下へ移動">▼</button>
@@ -832,6 +846,7 @@ function renderStashItem(id, idx, count) {
   const termContainer = document.createElement('div');
   termContainer.className = 'term-container';
 
+  li.appendChild(titleEl);
   li.appendChild(head);
   li.appendChild(cwdEl);
   li.appendChild(termContainer);
@@ -867,11 +882,20 @@ function updateStashItem(paneId) {
     if (ariaLabel) badge.setAttribute('aria-label', ariaLabel);
     else badge.removeAttribute('aria-label');
   }
-  const titleEl = li.querySelector('.stash-item-title');
+  const titleEl = li.querySelector('.stash-item-title-row');
   if (titleEl) {
-    const title = getDisplayTitle(t) || '(無題)';
-    titleEl.textContent = title;
-    titleEl.title = title;
+    const title = getDisplayTitle(t);
+    const url = getDisplayUrl(t);
+    const prUrl = isSafeExternalUrl(t.apiPrUrl) ? t.apiPrUrl : '';
+    renderTaskTitleContent(titleEl, title, url, prUrl);
+    if (url) {
+      titleEl.removeAttribute('title');
+    } else {
+      titleEl.title = title;
+    }
+    titleEl.classList.toggle('empty', title.length === 0 && !prUrl);
+    titleEl.classList.toggle('has-link', !!url);
+    titleEl.classList.toggle('has-pr', !!prUrl);
   }
 }
 

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -628,29 +628,42 @@ body.resizing-sidebar .sidebar {
 .stash-item-head {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 6px;
   padding: 4px 6px;
   background: #161b22;
+}
+/* 1段目タイトル行を格納カード（暗背景・コンパクト）向けに派生させる。 */
+.stash-item .pane-task-title {
+  background: #161b22;
+  color: #c9d1d9;
+  height: 20px;
+  padding: 10px 8px;
+  font-size: 12px;
+  letter-spacing: 0;
 }
 /* コンパクトカードでは幅が限られるため、idle 時のステータスバッジは
  * （グリッドのように幅を予約せず）畳んでタスク名の表示幅を優先する。 */
 .stash-item-head .pane-status[data-status="idle"] {
   display: none;
 }
-.stash-item-title {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: #c9d1d9;
-  font-size: 12px;
-  font-weight: 600;
+.stash-item .pane-task-title-pr {
+  color: #3fb950;
+}
+/* hover 時、基底クラスが背景オーバーレイを rgba(63,185,80,.15)→.25 に強める分
+ * 文字色 #3fb950 では実効コントラストが約 4.37:1 に落ち AA（4.5:1）未達になる。
+ * hover 時だけ文字色を明るい緑 #56d364 に上げて AA を確保する（暗背景で約 5.7:1）。 */
+.stash-item .pane-task-title-pr:hover {
+  color: #56d364;
+}
+.stash-item .pane-task-title-link:hover {
+  color: #58a6ff;
 }
 .stash-item-actions {
   display: flex;
   align-items: center;
   gap: 0;
+  margin-left: auto;
   flex-shrink: 0;
 }
 /* 格納カードはコンパクトなのでボタンをやや小さめにする。 */

--- a/tests/e2e/stash-header.smoke.spec.js
+++ b/tests/e2e/stash-header.smoke.spec.js
@@ -1,0 +1,263 @@
+const { test, expect, _electron } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// PR #117 / issue #112: サイドバー格納ペインのヘッダーを2段化
+// （1段目=タイトル行 / 2段目=ステータスバッジ＋操作アイコン行）し、
+// 格納カードにも PR リンク・タイトルリンクを表示するようにした変更の e2e 確認。
+//   - 格納カードのヘッダーが2段になっているか（タイトル行と操作行が別要素か）
+//   - prUrl 設定時に PR バッジが出るか
+//   - url 設定時にタイトルがリンク化されるか
+//   - 既存の操作ボタン（▲▼／xterm開閉／グリッドへ戻す／閉じる）が機能するか（デグレ確認）
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function postJson(port, pathname, payload) {
+  const res = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  let body = null;
+  try { body = await res.json(); } catch (_e) { /* 非 JSON 応答も診断のため許容 */ }
+  return { status: res.status, body };
+}
+
+async function getStates(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/api/states`);
+  if (res.status !== 200) throw new Error(`/api/states returned ${res.status}`);
+  const json = await res.json();
+  return json.terminals || {};
+}
+
+function termIdsOf(states) {
+  return Object.values(states)
+    .map((t) => (t && t.termId != null ? String(t.termId) : null))
+    .filter(Boolean);
+}
+
+async function waitForTermId(port, termId, shouldExist, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen = null;
+  while (Date.now() < deadline) {
+    try {
+      const states = await getStates(port);
+      const ids = termIdsOf(states);
+      lastSeen = ids;
+      const exists = ids.includes(String(termId));
+      if (exists === shouldExist) return ids;
+    } catch (_e) {
+      // HTTP サーバー起動前は fetch が失敗する。同じループで吸収する。
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(
+    `termId ${termId} did not reach exists=${shouldExist} in time. last states: ${JSON.stringify(lastSeen)}`
+  );
+}
+
+// サイドバーを確実に開いた状態にする。
+// stashPane()（ペイン格納時）は自動でサイドバーを開くため、既に開いている状態で
+// #menu-btn を無条件にクリックすると逆に閉じてしまう。現在の開閉状態を見てから
+// 必要な場合だけクリックする。
+async function ensureSidebarOpen(win) {
+  const isOpen = await win.evaluate(() => document.getElementById('root').classList.contains('sidebar-open'));
+  if (!isOpen) {
+    await win.locator('#menu-btn').click();
+  }
+  await win.waitForFunction(() => document.getElementById('root').classList.contains('sidebar-open'));
+}
+
+// 一時 HOME を用意して Electron を素のシェル（--no-claude）で起動する。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-stash-header-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  const win = await app.firstWindow();
+  return { app, win, tmpRoot };
+}
+
+test('格納カードのヘッダーが2段（タイトル行/操作行）になり、PRバッジ・タイトルリンクが表示される', async () => {
+  const port = await getFreePort();
+  const { app, win, tmpRoot } = await launchApp(port);
+  try {
+    // 起動直後の最初のペイン（termId "1"）が登録されるまで待つ。
+    await waitForTermId(port, '1', true);
+
+    // stashed: true を指定して格納状態のペインを作成する。
+    const created = await postJson(port, '/api/new-pane', { noClaude: true, stashed: true });
+    expect(created.status).toBe(200);
+    expect(created.body?.ok).toBe(true);
+    const termId = String(created.body.termId);
+    await waitForTermId(port, termId, true);
+    // renderer 内部の paneId は "pane-<termId>" 形式（li[data-id] はこちらを使う）。
+    // /api/* が返す termId とは別の値なので、DOM セレクタでは変換して使う。
+    const paneDomId = `pane-${termId}`;
+
+    // タイトル・URL・PR URL を設定する。
+    const setTitleRes = await postJson(port, '/api/set-title', {
+      termId,
+      title: 'テストタスク',
+      url: 'https://example.com/task/1',
+      prUrl: 'https://github.com/vektor-inc/vk-terminals/pull/117',
+    });
+    expect(setTitleRes.status).toBe(200);
+
+    // renderer 側の反映を待つ（サイドバーを開いて格納カードを表示状態にする）。
+    await ensureSidebarOpen(win);
+    const stashItem = win.locator(`.stash-item[data-id="${paneDomId}"]`);
+    await expect(stashItem).toBeVisible({ timeout: 10_000 });
+
+    // ── (1) ヘッダーが2段構造か ─────────────────────────────
+    // 1段目: タイトル行（.stash-item-title-row）
+    // 2段目: 操作行（.stash-item-head、ステータスバッジ＋アクションボタン群）
+    const titleRow = stashItem.locator('.stash-item-title-row');
+    const actionHead = stashItem.locator('.stash-item-head');
+    await expect(titleRow).toBeVisible();
+    await expect(actionHead).toBeVisible();
+
+    // 2つの行が別要素（DOM 上で兄弟）であり、同一要素に統合されていないことを確認する。
+    const isSeparateRows = await win.evaluate((id) => {
+      const li = document.querySelector(`.stash-item[data-id="${id}"]`);
+      const t = li.querySelector('.stash-item-title-row');
+      const h = li.querySelector('.stash-item-head');
+      return !!(t && h && t !== h && t.parentElement === li && h.parentElement === li);
+    }, paneDomId);
+    expect(isSeparateRows).toBe(true);
+
+    // タイトル行の bounding box が操作行より上にある（2段構造として視覚的にも上下に並んでいる）。
+    const titleBox = await titleRow.boundingBox();
+    const headBox = await actionHead.boundingBox();
+    expect(titleBox).toBeTruthy();
+    expect(headBox).toBeTruthy();
+    expect(titleBox.y).toBeLessThan(headBox.y);
+
+    // ── (2) タイトルがリンク化されているか ─────────────────────
+    await expect(titleRow.locator('.pane-task-title-link')).toHaveCount(1);
+    await expect(titleRow).toContainText('テストタスク');
+
+    // ── (3) PR バッジが出るか ─────────────────────────────
+    const prBadge = titleRow.locator('.pane-task-title-pr');
+    await expect(prBadge).toHaveCount(1);
+    await expect(prBadge).toContainText('PR');
+
+    // ── (4) 操作行にステータスバッジと操作アイコンがあるか（従来どおり） ──
+    await expect(actionHead.locator('.pane-status')).toHaveCount(1);
+    await expect(actionHead.locator('.btn-stash-up')).toHaveCount(1);
+    await expect(actionHead.locator('.btn-stash-down')).toHaveCount(1);
+    await expect(actionHead.locator('.btn-stash-toggle')).toHaveCount(1);
+    await expect(actionHead.locator('.btn-stash-restore')).toHaveCount(1);
+    await expect(actionHead.locator('.btn-close')).toHaveCount(1);
+
+    // ── (5) 操作ボタンのデグレ確認: xterm 開閉トグル ──────────────
+    const toggleBtn = actionHead.locator('.btn-stash-toggle');
+    await expect(toggleBtn).toHaveAttribute('aria-expanded', 'false');
+    await toggleBtn.click();
+    await expect(toggleBtn).toHaveAttribute('aria-expanded', 'true');
+    await expect(stashItem).toHaveClass(/\bstash-xterm-open\b/);
+    await expect(stashItem.locator('.term-container')).toBeVisible();
+    // 元に戻す。
+    await toggleBtn.click();
+    await expect(toggleBtn).toHaveAttribute('aria-expanded', 'false');
+    await expect(stashItem.locator('.term-container')).toBeHidden();
+
+    // ── (6) 操作ボタンのデグレ確認: グリッドへ戻す（→） ─────────────
+    const restoreBtn = actionHead.locator('.btn-stash-restore');
+    await restoreBtn.click();
+    // 復帰後は格納カードとして存在しなくなる（グリッド側の .pane に変わる）。
+    await expect(win.locator(`.stash-item[data-id="${paneDomId}"]`)).toHaveCount(0);
+    await expect(win.locator(`.pane[data-id="${paneDomId}"]`)).toBeVisible({ timeout: 10_000 });
+
+    // ── (7) 操作ボタンのデグレ確認: 閉じる（✕） ─────────────────
+    // グリッド側の閉じるボタンから閉じ、states から消えることを確認する。
+    const gridPane = win.locator(`.pane[data-id="${paneDomId}"]`);
+    await gridPane.locator('.btn-close').click();
+    await waitForTermId(port, termId, false);
+    // 最初のペインは残っている。
+    expect(termIdsOf(await getStates(port))).toContain('1');
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test('格納カード: ▲▼で並べ替えできる（デグレ確認）', async () => {
+  const port = await getFreePort();
+  const { app, win, tmpRoot } = await launchApp(port);
+  try {
+    await waitForTermId(port, '1', true);
+
+    // 2件のペインを stashed で作成する。
+    const created1 = await postJson(port, '/api/new-pane', { noClaude: true, stashed: true });
+    const termId1 = String(created1.body.termId);
+    await waitForTermId(port, termId1, true);
+    const paneDomId1 = `pane-${termId1}`;
+
+    const created2 = await postJson(port, '/api/new-pane', { noClaude: true, stashed: true });
+    const termId2 = String(created2.body.termId);
+    await waitForTermId(port, termId2, true);
+    const paneDomId2 = `pane-${termId2}`;
+
+    await ensureSidebarOpen(win);
+    await expect(win.locator(`.stash-item[data-id="${paneDomId1}"]`)).toBeVisible({ timeout: 10_000 });
+    await expect(win.locator(`.stash-item[data-id="${paneDomId2}"]`)).toBeVisible({ timeout: 10_000 });
+
+    // 並び順を取得するヘルパー。
+    const getOrder = () => win.evaluate(() => {
+      return Array.from(document.querySelectorAll('.stash-item')).map((li) => li.dataset.id);
+    });
+
+    const before = await getOrder();
+    const idx1 = before.indexOf(paneDomId1);
+    const idx2 = before.indexOf(paneDomId2);
+    expect(idx1).toBeGreaterThanOrEqual(0);
+    expect(idx2).toBeGreaterThan(idx1); // termId2 は後から stashed されたので termId1 の下にいるはず
+
+    // termId2（下側）を上へ移動する。
+    await win.locator(`.stash-item[data-id="${paneDomId2}"] .btn-stash-up`).click();
+
+    const after = await getOrder();
+    expect(after.indexOf(paneDomId2)).toBeLessThan(after.indexOf(paneDomId1));
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

サイドバーに格納したペイン（`.stash-item` コンパクトカード）のヘッダーを、メインエリアのペイン同様に **タイトル行** と **操作アイコン行** の2段構成に変更し、あわせて格納カードにも **PR リンク**（および OSC/API タイトルのリンク）を表示できるようにしました。

メインエリア用の既存関数 `renderTaskTitleContent()` を格納カードでも再利用しているため、タイトルのリンク化（↗）・PR バッジ（PR ↗）・省略表示・フォーカスリングの挙動はメインエリアと完全に共有されます。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/112

## 変更内容

- **`renderer/app.js`**
  - `renderStashItem()`: DOM を3行構成（1段目=タイトル行 / 2段目=`.stash-item-head`（ステータスバッジ＋操作アイコン）/ 3段目=`.stash-item-cwd`）に変更。1段目は `pane-task-title stash-item-title-row` として `renderTaskTitleContent(el, title, taskUrl, taskPrUrl)` で描画し、`has-link` / `has-pr` / `empty` クラスと `title` 属性もメインエリアと同流儀で付与
  - `updateStashItem()`: タイトル・URL・PR URL の動的更新（`POST /api/set-title` で後から届くケース）に追従できるよう、`renderTaskTitleContent()` を呼び直してクラス・`title` 属性も更新
- **`renderer/style.css`**
  - `.stash-item .pane-task-title` を暗背景（カード `#0d1117` / ヘッダ `#161b22`）向けの派生バリアントとして上書き（背景・文字色・コンパクトな高さ）
  - PR バッジ文字色をメインエリアの明背景専用値 `#0a3d1b` から、暗背景で WCAG 2.1 AA を満たす `#3fb950` にスコープ限定で上書き。タイトルリンク hover 色も暗背景で消えないよう `#58a6ff` に上書き
  - `.stash-item-head` を `justify-content: space-between` にし、タイトルを1段目へ移した分の再配置
- **`CHANGELOG.md`**: 未リリース領域に #112 のエントリ2件を追記

## レビュー状況

- 🔒 セキュリティ（安藤）: PASS — `renderTaskTitleContent` は DOM API 組み立て（`innerHTML` 不使用）で XSS 経路は増えず、URL は `isSafeExternalUrl`（http(s) チェック）でゲート。むしろ従来 innerHTML だったタイトル描画が DOM API に置き換わり攻撃面は縮小
- 🎨 UX（植草）: PASS — 案B（タイトル＋PR / ステータス＋操作 / cwd）と暗背景配色を推奨どおり実装。a11y 上の修正必須欠陥なし

## 確認手順

前提: `npm start` で Electron アプリを起動する。

1. 任意のペインで作業させ、タイトル（OSC もしくは `POST /api/set-title`）を設定する
2. ペインヘッダーの `←`（サイドバーに格納）ボタンでペインをサイドバーに格納する
3. サイドバーの格納カードを確認する
   - → ヘッダーが **2段**（上段: タイトル / 下段: ステータスバッジ＋操作アイコン ▲▼ ― → ✕）になっている
   - → その下に cwd 行が従来どおり表示される
4. PR リンクの確認: `POST /api/set-title` で `prUrl` に GitHub の PR URL（http(s)）を指定したペインを格納する
   - → 格納カードのタイトル行右端に緑の **`PR ↗` バッジ** が表示される
   - → バッジをクリックすると外部ブラウザで PR が開く（`openExternalUrlSafe` 経由）
5. タイトルに `apiUrl` を指定した場合
   - → タイトルが `<a>`（末尾 ↗）としてリンク化され、クリックで外部ブラウザで開く
6. デグレ確認: 格納カードの `▲` `▼`（並べ替え）・`―`（xterm 開閉）・`→`（グリッドへ戻す）・`✕`（閉じる）が従来どおり動作する

### スクリーンショット

Electron 実機での撮影が必要なため、視覚確認（2段レイアウト・PR バッジの暗背景コントラスト・最小幅での省略/段落ち）は e2e（麗美）で実施します。`#3fb950` / `#58a6ff` の暗背景 AA コントラストは実測で確定予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/337