### PR TITLE
[ デザイン不具合修正 ] サイドバーを閉じても使用量カードがメイン領域に重なって表示される不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [ 機能追加 ] HTTP API `POST /api/set-title` に `prMerged` を追加し、マージ済み PR のラベルを紫で表示できるように（[#113](https://github.com/vektor-inc/vk-terminals/issues/113)）
 - [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）
+
 ## 1.14.0
 
 - [ 機能追加 ] モバイル版でペインのタイトルをタップすると、リンク指定（PR URL）がある場合に別タブで開くように変更（[#103](https://github.com/vektor-inc/vk-terminals/issues/103)）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [ 機能追加 ] HTTP API `POST /api/set-title` に `prMerged` を追加し、マージ済み PR のラベルを紫で表示できるように（[#113](https://github.com/vektor-inc/vk-terminals/issues/113)）
 - [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）
+- [ デザイン不具合修正 ] サイドバーを閉じた状態でも使用量カードがメイン領域に重なって表示される不具合を修正（[#118](https://github.com/vektor-inc/vk-terminals/issues/118)）
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 - [ 機能追加 ] HTTP API `POST /api/set-title` に `prMerged` を追加し、マージ済み PR のラベルを紫で表示できるように（[#113](https://github.com/vektor-inc/vk-terminals/issues/113)）
 - [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）
-- [ デザイン不具合修正 ] サイドバーを閉じた状態でも使用量カードがメイン領域に重なって表示される不具合を修正（[#118](https://github.com/vektor-inc/vk-terminals/issues/118)）
-
 ## 1.14.0
 
 - [ 機能追加 ] モバイル版でペインのタイトルをタップすると、リンク指定（PR URL）がある場合に別タブで開くように変更（[#103](https://github.com/vektor-inc/vk-terminals/issues/103)）

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -411,6 +411,9 @@ html, body {
   background: #0d1117;
   color: #e6edf3;
 }
+#root:not(.sidebar-open) .sidebar {
+  overflow: hidden;
+}
 /* 閉時（実幅 0）は境界線・リサイズハンドルが画面左端に残って見えるため、
  * どちらも開いているときだけ有効化する（CodeRabbit 指摘）。 */
 #root.sidebar-open .sidebar {

--- a/tests/e2e/sidebar-collapsed-leak.smoke.spec.js
+++ b/tests/e2e/sidebar-collapsed-leak.smoke.spec.js
@@ -1,0 +1,83 @@
+const { test, expect, _electron } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-sidebar-collapsed-leak-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  const win = await app.firstWindow();
+  return { app, win, tmpRoot };
+}
+
+test('閉じたサイドバーの使用量カードはビューポートへ漏れず、開くと表示される', async () => {
+  const port = await getFreePort();
+  const { app, win, tmpRoot } = await launchApp(port);
+  try {
+    await win.waitForSelector('#sidebar', { state: 'attached' });
+
+    // 起動直後は sidebarOpen=false なので、この時点で使用量カードを描画して漏れを検証する。
+    await win.evaluate(() => {
+      window.renderSidebarUsage({
+        source: 'oauth',
+        session: {
+          percent: 81,
+          resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        },
+        weekly: {
+          percent: 40,
+          resetAtMs: Date.now() + 3 * 24 * 60 * 60 * 1000,
+        },
+      });
+    });
+
+    const usage = win.locator('#sidebar-usage');
+    await expect(usage).not.toBeInViewport();
+
+    // サイドバーを開いたときは、同じ使用量カードが通常どおり見えることも担保する。
+    await win.locator('#menu-btn').click();
+    await expect(usage).toBeInViewport();
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

サイドバーを閉じた（格納した）状態でも、サイドバー内の使用量カード（「Claude使用量」「◯% 使用済み」）やスプライト画像がメインのグリッド領域の上に重なって表示されてしまう不具合を修正します。アプリ起動直後はサイドバーが閉じた状態のため、この時点で漏れが発生していました。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/118

## 原因

`renderer/style.css` の `.sidebar` は、閉じた状態では `flex: 0 0 0`（レイアウト上の実幅0）＋ `transform: translateX(-100%)` で画面外へ退避する設計でした。しかし flex-basis が 0 のため要素の実幅も 0 になり、`translateX(-100%)`（＝実幅の -100%）が 0px 移動となって実際には退避しません。さらに `.sidebar` 自身に `overflow` 指定がなく既定の `visible` のため、幅0のボックスから子要素（特に `white-space: nowrap` の `.sidebar-usage`）がはみ出し、`z-index: 900` によってグリッドの上に重なって見えていました。

## 修正内容

- `renderer/style.css`: `#root:not(.sidebar-open) .sidebar { overflow: hidden; }` を追加し、**サイドバーが閉じている時だけ**子要素のはみ出しを clip する。
  - 開いている時のリサイズハンドル `.sidebar-resizer`（`right:0; transform: translateX(50%)` で右端外へ4px飛び出す）を切らないよう、clip 対象を閉状態（`:not(.sidebar-open)`）に限定している。
- `tests/e2e/sidebar-collapsed-leak.smoke.spec.js`: 回帰防止の e2e を追加。

> changelog は追記していません。修正対象のサイドバー使用量表示（#109）自体がまだ未リリース領域（`CHANGELOG.md` の `## 1.14.0` より上）にある機能であり、changelog.md の「未リリース機能の不具合修正は追記不要」規定に該当するためです。

## テスト（確認手順）

### 前提
- `npm run test:e2e -- tests/e2e/sidebar-collapsed-leak.smoke.spec.js` で自動検証できます。

### Before（修正前の再現）
1. アプリを起動する（サイドバーは閉じた初期状態）。
2. Claude 使用量が取得できている状態にする（使用量カードが描画される）。
   → **不具合**: サイドバーを閉じているのに、画面左上に「Claude使用量」「◯% 使用済み」やスプライト画像がグリッドに重なって表示される。

### After（修正後の確認）
1. 同じ手順でアプリを起動する。
   → 閉じた状態では使用量カードが一切表示されない（ビューポート外に clip される）。
2. 左上のハンバーガーメニュー（☰ / `#menu-btn`）をクリックしてサイドバーを開く。
   → 使用量カード・メニューが従来どおり表示される。
3. もう一度 ☰ をクリックして閉じる。
   → カードは残らず、きれいに格納される。

### デグレ確認
- サイドバーの開閉トランジション（0.18s）中に不自然なクリップ・ちらつきがないこと。
- サイドバーを開いた状態で右端のリサイズハンドルをドラッグして幅変更ができること（clip されていないこと）。

## スクリーンショット

### Before
<img width="850" src="https://github.com/user-attachments/assets/bfa3ad85-68f2-4d82-9974-dfaf81e0c4ad" />

（赤枠部分＝サイドバー格納中にもかかわらず使用量カード／スプライトがグリッド上に漏れている状態）

### After
e2e テスト（`sidebar-collapsed-leak.smoke.spec.js`）で「閉時にビューポート外」「開くと表示」を検証済み。実機スクリーンショットは e2e レビュー（麗美）で確認・添付します。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/341