### PR TITLE
[ デザイン不具合修正 ] ペイン上部のタスク表示行がダーク UI で浮く問題をダークテーマ整合で修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [ 機能追加 ] HTTP API `POST /api/set-title` に `prMerged` を追加し、マージ済み PR のラベルを紫で表示できるように（[#113](https://github.com/vektor-inc/vk-terminals/issues/113)）
 - [ 仕様変更 ] Claude 使用量表示をサイドバー最上部の常時表示に統合し、クリックで開く使用量モーダルを廃止（[#109](https://github.com/vektor-inc/vk-terminals/issues/109)）
 - [ デザイン不具合修正 ] 設定ダイアログの入力欄の境界線色をダーク背景で WCAG 2.1 AA（3:1）を満たす明度（#6e7681）に変更（[#86](https://github.com/vektor-inc/vk-terminals/issues/86)）
+- [ デザイン不具合修正 ] ペイン上部のタスク表示行が明るいグレー背景で周囲のダーク UI から浮く問題を、背景・文字色をダークテーマに整合させて修正
 
 ## 1.14.0
 

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -874,9 +874,9 @@ body.resizing-sidebar .sidebar {
   align-items: center;
   height: 22px;
   padding: 15px 10px;
-  background: #aaa;
+  background: #101015;
   border-bottom: 1px solid #21262d;
-  color: #000;
+  color: #f5f5f5;
   font-size: 14px;
   font-weight: 600;
   letter-spacing: 0.01em;


### PR DESCRIPTION
## 概要

各ペイン上部の固定タスク表示行（`.pane-task-title`）が、明るいグレー背景（`#aaa`）＋黒文字（`#000`）で描画されており、周囲のダーク基調の UI（境界線 `#21262d` など）から 1 行だけ明るく浮いていました。

デザインルールの「テーマ整合」に反する状態のため、背景・文字色をダークテーマに合わせて修正します。

| 項目 | Before | After |
|---|---|---|
| 背景 | `#aaa`（明るいグレー） | `#101015`（ダーク） |
| 文字色 | `#000`（黒） | `#f5f5f5`（オフホワイト） |

- 変更後のコントラスト比は `#101015` / `#f5f5f5` で約 18:1 となり、WCAG 2.1 AA（本文 4.5:1）を満たします。

## 変更内容

- `renderer/style.css` の `.pane-task-title` の `background` と `color` をダークテーマ整合の値に変更

## 確認手順

1. このブランチをチェックアウトしてアプリを起動する
   → `git checkout design/pane-task-title-dark` → アプリ（Electron）を起動
2. ペインを開き、上部にタスクタイトル（`apiTitle`）が表示される状態にする
   （例: HTTP API `POST /api/set-title` でタイトルを設定する、またはタイトルが設定済みのペインを表示する）
   → ペイン上部にタスク表示行が現れる
3. タスク表示行の背景・文字色を確認する
   → **After:** 背景が周囲と同じダーク（`#101015`）、文字がオフホワイト（`#f5f5f5`）で、UI から浮かずに馴染んでいる
   → **Before（main）:** 背景が明るいグレー、文字が黒で、その 1 行だけが明るく浮いて見える

### デグレ確認

- タイトル未設定時にタスク表示行が非表示（`.pane-task-title.empty { display: none }`）になること
- タイトルが長い場合に末尾が省略表示（`…`）されること
- タイトルがリンク（`apiTitle` + `apiUrl`）の場合、ホバーで下線・色変化が従来どおり機能すること

## スクリーンショット

> 表示変更のため Before / After のスクリーンショット添付を推奨します（本 PR は自動キャプチャ環境がないため未添付。レビュー時にご確認ください）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
