### PR TITLE
[ デザイン不具合修正 ] 設定ダイアログ入力欄のプレースホルダー文字色をダーク背景で WCAG 2.1 AA（4.5:1）を満たす配色（#8b949e）に調整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ デザイン不具合修正 ] 設定ダイアログ入力欄のプレースホルダー文字色をダーク背景で読める配色に調整（[#116](https://github.com/vektor-inc/vk-terminals/issues/116)）
+
 ## 1.15.2
 
 - [ 不具合修正 ] モバイル版のペインプレビューでターミナルの再描画が改行として残り、日本語出力が数文字ごとに分断されて表示される不具合を修正（[#121](https://github.com/vektor-inc/vk-terminals/issues/121)）

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -307,6 +307,13 @@ html, body {
   font-size: 12px;
   font-family: inherit;
 }
+.settings-row input[type="text"]::placeholder,
+.settings-row input[type="number"]::placeholder,
+.settings-row input[type="password"]::placeholder,
+.settings-row textarea::placeholder {
+  color: #8b949e;
+  opacity: 1;
+}
 .settings-row select {
   appearance: none;
   -webkit-appearance: none;


### PR DESCRIPTION
## 概要

設定ダイアログ（ダークテーマ）の入力欄プレースホルダーは `renderer/style.css` に `::placeholder` の色指定がなく、UA（Chromium/Electron）デフォルトの半透明色に依存していました。プレースホルダーは本文テキスト扱いで WCAG 2.1 AA の 4.5:1 が必要なため、既存の muted 文字色トークン `#8b949e` を明示指定して UA 依存を解消します。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/116

## 変更内容

- `renderer/style.css`: 入力共通ブロック直後に `.settings-row input[type="text"/"number"/"password"]::placeholder` / `.settings-row textarea::placeholder` を追加し、`color: #8b949e; opacity: 1;` を指定
  - `#8b949e` は `.settings-help` 等で既に muted 文字色として使用中の確立済みトークン（新色は導入しない）
  - `opacity: 1` は UA デフォルトの半透明 opacity が乗って実効コントラストが下がるのを防ぐ防御的指定
  - `select` は placeholder 非対応のため対象外
- `CHANGELOG.md`: 未リリース領域にエントリを追記

## コントラスト計測結果（WCAG 相対輝度）

| 対象 | 比 | 判定 |
|---|---|---|
| プレースホルダー `#8b949e` vs 地色 `#010409` | **6.68:1** | AA 4.5:1 クリア ✓ |
| 実入力値 `#e6edf3` vs 地色 `#010409` | 17.38:1 | — |
| プレースホルダー vs 実入力値 | 2.60:1 | 入力済み文字と明確に区別可 |

## 確認手順

### 前提条件

- 本ブランチを checkout し `npm install` 済みであること

### 手順

#### Before（修正前の再現手順）

1. `main` ブランチで `npm start` でアプリを起動する
2. タイトルバー右端の ⚙ ボタンで設定ダイアログを開く
3. placeholder が設定されているテキスト入力欄（値が空のフィールド）を確認する
   → ✗ プレースホルダー文字が UA デフォルトの半透明色で表示され、地色 `#010409` に沈んで読みづらい（4.5:1 未達の懸念）

#### After（修正後）

1. 本ブランチで `npm start` でアプリを起動する
2. タイトルバー右端の ⚙ ボタンで設定ダイアログを開く
3. placeholder が設定されているテキスト入力欄（値が空のフィールド）を確認する
   → ✓ プレースホルダー文字が `#8b949e`（グレー）で表示され、はっきり読める（DevTools の Styles パネルで `::placeholder` ルールの適用を確認できる。なお Electron 28 の `getComputedStyle(el, '::placeholder')` は author 色を返さないため、機械検証は実描画ピクセルの測定で行う — e2e テストコメント参照）
4. 同じ入力欄に任意の文字を入力する
   → ✓ 入力した文字は従来どおり `#e6edf3`（明るい白系）で表示され、プレースホルダーと明確に区別できる（デグレなし）
5. `npm test` を実行する
   → ✓ 既存テストが全件通過する（実装時点で 100 件通過を確認済み）

## スクリーンショット

実アプリ（Electron）の設定ダイアログを同一条件（placeholder 付きカスタムディスクリプタ）で撮影。撮影・実測は e2e テスト工程で実施（詳細は PR コメントの麗美の報告を参照）。

### Before（UA デフォルト・実測 約4.4:1 で AA 未達）

![Before](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-126/before-settings-placeholder.png?raw=true)

### After（`#8b949e`・実測 約6.5:1 で AA 達成）

![After](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-126/after-settings-placeholder.png?raw=true)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ダークテーマの設定ダイアログで、入力欄やテキストエリアのプレースホルダーが読みやすく表示されるよう改善しました。

* **ドキュメント**
  * プレースホルダーの配色調整に関する変更履歴を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
