### PR TITLE
[ デザイン不具合修正 ] 設定ダイアログの文字サイズ・コントラストをダーク背景で読みやすいように調整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - [ デザイン不具合修正 ] 設定ダイアログ入力欄のプレースホルダー文字色をダーク背景で読める配色に調整（[#116](https://github.com/vektor-inc/vk-terminals/issues/116)）
-- [ デザイン不具合修正 ] 設定ダイアログと Claude 使用状況の文字サイズ・コントラストをダーク背景で読みやすいように調整（[#125](https://github.com/vektor-inc/vk-terminals/issues/125)）
+- [ デザイン不具合修正 ] 設定ダイアログの文字サイズ・コントラストをダーク背景で読みやすいように調整（[#125](https://github.com/vektor-inc/vk-terminals/issues/125)）
 
 ## 1.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [ デザイン不具合修正 ] 設定ダイアログ入力欄のプレースホルダー文字色をダーク背景で読める配色に調整（[#116](https://github.com/vektor-inc/vk-terminals/issues/116)）
+- [ デザイン不具合修正 ] 設定ダイアログと Claude 使用状況の文字サイズ・コントラストをダーク背景で読みやすいように調整（[#125](https://github.com/vektor-inc/vk-terminals/issues/125)）
 
 ## 1.15.2
 

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -194,12 +194,12 @@ html, body {
   margin-bottom: 6px;
 }
 .usage-section-title {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   color: #c9d1d9;
 }
 .usage-value {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   color: #e6edf3;
   white-space: nowrap;
@@ -220,20 +220,20 @@ html, body {
 .usage-bar-fill.level-crit { background: #f85149; }
 .usage-reset {
   margin-top: 5px;
-  font-size: 12px;
+  font-size: 11px;
   color: #8b949e;
 }
 .usage-note {
   margin-top: 3px;
   /* ダーク背景 #0d1117 上で WCAG AA（4.5:1）を満たすよう .usage-reset と同じ
-   * #8b949e / 12px に揃える（旧 #6e7681 / 10px は約 4.1:1 で AA 不達のため変更）。 */
-  font-size: 12px;
+   * #8b949e / 11px に揃える（旧 #6e7681 / 10px は約 4.1:1 で AA 不達のため変更）。 */
+  font-size: 11px;
   color: #8b949e;
 }
 .usage-empty {
   margin: 0;
   padding: 6px 0;
-  font-size: 13px;
+  font-size: 12px;
   color: #8b949e;
   line-height: 1.6;
 }

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -150,9 +150,9 @@ html, body {
   gap: 8px;
 }
 .settings-version {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 400;
-  color: #6e7681;
+  color: #8b949e;
 }
 .settings-close {
   background: transparent;
@@ -194,12 +194,12 @@ html, body {
   margin-bottom: 6px;
 }
 .usage-section-title {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   color: #c9d1d9;
 }
 .usage-value {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   color: #e6edf3;
   white-space: nowrap;
@@ -220,20 +220,20 @@ html, body {
 .usage-bar-fill.level-crit { background: #f85149; }
 .usage-reset {
   margin-top: 5px;
-  font-size: 11px;
+  font-size: 12px;
   color: #8b949e;
 }
 .usage-note {
   margin-top: 3px;
   /* ダーク背景 #0d1117 上で WCAG AA（4.5:1）を満たすよう .usage-reset と同じ
-   * #8b949e / 11px に揃える（旧 #6e7681 / 10px は約 4.1:1 で AA 不達のため変更）。 */
-  font-size: 11px;
+   * #8b949e / 12px に揃える（旧 #6e7681 / 10px は約 4.1:1 で AA 不達のため変更）。 */
+  font-size: 12px;
   color: #8b949e;
 }
 .usage-empty {
   margin: 0;
   padding: 6px 0;
-  font-size: 12px;
+  font-size: 13px;
   color: #8b949e;
   line-height: 1.6;
 }
@@ -241,14 +241,14 @@ html, body {
   margin: 0;
   padding: 10px 18px 0;
   color: #d29922;
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.5;
 }
 .settings-target {
   margin: 0;
   padding: 8px 18px 0;
-  color: #6e7681;
-  font-size: 11px;
+  color: #8b949e;
+  font-size: 12px;
   word-break: break-all;
 }
 .settings-target code { color: #8b949e; }
@@ -272,7 +272,7 @@ html, body {
 .settings-group legend {
   padding: 0 6px;
   color: #58a6ff;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
 }
 .settings-row {
@@ -284,13 +284,13 @@ html, body {
 .settings-row:first-of-type { margin-top: 2px; }
 .settings-label {
   color: #c9d1d9;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   white-space: nowrap;
 }
 .settings-help {
   color: #8b949e;
-  font-size: 11px;
+  font-size: 12px;
 }
 .settings-row input[type="text"],
 .settings-row input[type="number"],
@@ -304,7 +304,7 @@ html, body {
   border-radius: 5px;
   color: #e6edf3;
   padding: 6px 8px;
-  font-size: 12px;
+  font-size: 13px;
   font-family: inherit;
 }
 .settings-row input[type="text"]::placeholder,
@@ -364,15 +364,15 @@ html, body {
 }
 .settings-msg {
   flex: 1;
-  font-size: 12px;
-  color: #6e7681;
+  font-size: 13px;
+  color: #8b949e;
 }
 .settings-msg.ok { color: #3fb950; }
 .settings-msg.err { color: #f85149; }
 .settings-footer button {
   padding: 6px 14px;
   border-radius: 5px;
-  font-size: 12px;
+  font-size: 13px;
   cursor: pointer;
   border: 1px solid #30363d;
 }


### PR DESCRIPTION
## 概要

設定ダイアログ（⚙ から開くモーダル）の文字がかすれて読みにくい問題を修正します。

- ダーク背景 `#0d1117` 上で WCAG 2.1 AA（コントラスト比 4.5:1）を満たさない文字色 `#6e7681`（約 4.1:1）を `#8b949e`（約 6.2:1）に変更（`.settings-version` / `.settings-target` / `.settings-msg` 既定色の 3 箇所）
- 設定ダイアログ内の 11px / 12px のテキストを一律 +1px（ラベル・説明文・legend・入力欄・フッターボタン等の 14 セレクタ相当のうち `.settings-*` 9 箇所）
- ベースの `font-size: 13px`（`.settings-modal`）と見出し（h2 15px）は据え置き（カスケード波及によるレイアウト崩れ回避のため）

過去の同種是正（#86 の入力欄境界線・#116 のプレースホルダー）と同じく、既存ダークテーマパレット内の色のみで対応し、新色は追加していません。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/125

## 変更内容

- `renderer/style.css`: 設定モーダル（`.settings-*`）の文字色 3 箇所・font-size 9 箇所を調整
- `CHANGELOG.md`: 未リリース領域にエントリを追記

※ サイドバーの Claude 使用量表示（`.usage-*`）は本 PR の対象外です。UX レビューの指摘（`.usage-*` はモーダルではなくサイドバー専用のため、文字サイズ変更がサイドバーへ漏れて情報階層が逆転する）を受け、`.usage-*` への変更はすべて取り消し済みで、main との差分はありません。

## テスト（確認手順）

### 前提

1. リポジトリをクローンし `npm install` を実行する
2. 本ブランチ `fix/issue-125-settings-readability` をチェックアウトする

### Before（修正前の再現手順）

1. `main` ブランチで `npm start` でアプリを起動する
2. タイトルバー右上の ⚙（設定）ボタンをクリックして設定ダイアログを開く
→ 各項目の説明文（11px）やバージョン表記・保存対象パス（`#6e7681`）がかすれて読みにくいことを確認

### After（修正後の確認手順）

1. 本ブランチで `npm start` でアプリを起動する
2. タイトルバー右上の ⚙（設定）ボタンをクリックして設定ダイアログを開く
→ ラベル・説明文・入力欄の文字が一段大きくなり、バージョン表記（ヘッダーの「設定」右横）・「保存先」のパス表記・フッターのメッセージ文字色が明るくなって読みやすいことを確認
3. 設定ダイアログ内で入力欄・セレクト・チェックボックスのラベルが不自然な位置で改行していないこと、モーダルから要素がはみ出していないことを確認
4. フッターの「保存」「キャンセル」ボタンの文字が 13px で表示されることを確認

### デグレ確認

1. サイドバー（☰ メニュー）を開き、最上部の Claude 使用量カードを確認する
→ 使用量カードの文字サイズ・色が従来どおり（タイトル・数値 11px 等）変わっていないこと
2. 設定ダイアログの入力欄のプレースホルダー（例: 未入力の欄）の色が従来どおり（#8b949e）であること
3. 入力欄の境界線の色（#6e7681）が変わっていないこと

## スクリーンショット

同条件（ビルトイン descriptor＋ダミー設定・同スケール）で撮影した Before / After です。

#### Before

![before](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-127/before-settings.png?raw=true)

#### After

![after](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/pr-127/after-settings.png?raw=true)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/350
