### PR TITLE
[ 不具合修正 ] モバイル版のペインプレビューが末尾の罫線再描画に埋もれて直近の出力がほとんど表示されない不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 仕様変更 ] モバイル版のペインプレビュー表示領域を拡大し、展開時・新着時に最新位置を見やすいように変更（[#130](https://github.com/vektor-inc/vk-terminals/issues/130)）
+- [ 不具合修正 ] モバイル版のペインプレビューで末尾の罫線再描画により直近の出力がほとんど表示されない不具合を修正（[#130](https://github.com/vektor-inc/vk-terminals/issues/130)）
 - [ その他 ] モバイルページの閲覧・操作のセットアップ手順（apiHost 設定・スマートフォンからのアクセス方法・セキュリティ注意）を README に追記（[#128](https://github.com/vektor-inc/vk-terminals/issues/128)）
 
 ## 1.15.3

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -88,8 +88,9 @@
     background: #20242b; cursor: default; opacity: 0.62; }
   .pane-order-button:disabled:active { background: #20242b; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
-    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 1.45;
-    white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow-y: auto;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; line-height: 1.5;
+    white-space: pre-wrap; word-break: break-word; max-height: min(50vh, 520px); overflow-y: auto;
+    -webkit-overflow-scrolling: touch; overscroll-behavior: contain;
     border-top: 1px solid var(--card-border); }
   .card.collapsed pre.lines, .card.collapsed .actions { display: none; }
   .actions { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 7px; }
@@ -598,6 +599,7 @@ function toggleCollapse(termId) {
   if (!c) return;
   collapsed[termId] = !collapsed[termId];
   syncCollapseUI(c, termId);
+  if (!collapsed[termId]) c.pre.scrollTop = c.pre.scrollHeight;
   saveCollapsed();
 }
 
@@ -859,7 +861,17 @@ function render(data) {
       c.title.classList.remove("is-link");
       c.title.removeAttribute("aria-label");
     }
-    c.pre.textContent = sanitizeMobilePreviewText(tail(stripAnsi(t.lastLines || ""), 1400)).replace(/\n{3,}/g, "\n\n").trim();
+    // 罫線・装飾行を除去してから末尾を切り出し、読める直近出力を残す。
+    var cleaned = sanitizeMobilePreviewText(stripAnsi(t.lastLines || ""))
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+    var next = tail(cleaned, 4000);
+    if (next !== c.lastText) {
+      var stick = (c.pre.scrollHeight - c.pre.scrollTop - c.pre.clientHeight) <= 24;
+      c.pre.textContent = next;
+      c.lastText = next;
+      if (stick) c.pre.scrollTop = c.pre.scrollHeight;
+    }
     // 折り畳み状態を毎回当て直す（再描画・端末の消失→復活をまたいで一致させる）
     syncCollapseUI(c, termId);
   });

--- a/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
+++ b/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
@@ -1,0 +1,287 @@
+const { test, expect, _electron, chromium } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// PR #131 / issue #130: モバイル版ペインプレビューの検証。
+//
+// 修正の本丸は sanitize の処理順の入れ替え。従来は「末尾1400文字に切り詰め →
+// 装飾行除去」だったため、Claude Code TUI のプロンプト枠（罫線）の再描画が
+// 末尾に大量に溜まると、切り詰め窓が罫線だらけになり sanitize 後に読める行が
+// ほぼ残らなかった。修正後は「ANSI 除去 → 装飾行除去 → 空行圧縮 → 末尾4000文字」の
+// 順にしたため、罫線が末尾に溜まっても読める本文が残る。
+//
+// あわせて表示高さの拡大（max-height 240px → min(50vh, 520px)）と、末尾追従
+// スクロール（最下部付近だけ新着に追従 / 上スクロール中は位置保持 / 展開時に
+// 最下部表示）を追加している。
+//
+// 検証手法は既存の mobile-preview-cr-redraw.smoke.spec.js を踏襲する。
+// 一時 HOME + `--no-claude` で Electron を起動し、VK_TERMINALS_API_PORT で
+// 空きポートを指定、Playwright の page.route で /api/states 応答を差し替えて
+// 任意の lastLines を注入 → 実ブラウザで mobile.html の実描画を検証する。
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function getStates(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/api/states`);
+  if (res.status !== 200) throw new Error(`/api/states returned ${res.status}`);
+  const json = await res.json();
+  return json.terminals || {};
+}
+
+function termIdsOf(states) {
+  return Object.values(states)
+    .map((t) => (t && t.termId != null ? String(t.termId) : null))
+    .filter(Boolean);
+}
+
+async function waitForTermId(port, termId, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen = null;
+  while (Date.now() < deadline) {
+    try {
+      const states = await getStates(port);
+      const ids = termIdsOf(states);
+      lastSeen = ids;
+      if (ids.includes(String(termId))) return ids;
+    } catch (_e) {
+      // HTTP サーバー起動前は fetch が失敗する。同じループで吸収する。
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`termId ${termId} did not appear in time. last states: ${JSON.stringify(lastSeen)}`);
+}
+
+// 一時 HOME を用意して Electron を素のシェル（--no-claude）で起動する。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-order-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  await app.firstWindow();
+  return { app, tmpRoot };
+}
+
+// Claude Code TUI のプロンプト枠（罫線）の再描画が末尾に溜まった状態を模した
+// lastLines を組み立てる。先頭に読める本文を置き、その後に罫線 / スピナー行だけを
+// 大量に連ねる（合計で旧切り詰め窓 1400 文字を大きく超える量）。
+function buildRedrawHeavyLastLines() {
+  const readable = [
+    '実行結果: ビルドに成功しました',
+    'Build completed successfully in 3.2s',
+    'テスト 42 件がすべてパスしました',
+    'Next step: デプロイを実行してください',
+  ];
+  // 罫線 + スピナーのみの装飾行ブロック（読める文字を含まない）。
+  const decorativeBlock = [
+    '╭────────────────────────────────────────────────────╮',
+    '│ >                                                    │',
+    '╰────────────────────────────────────────────────────╯',
+    '✻ Compacting conversation…',
+    '·······································',
+  ];
+  const lines = readable.slice();
+  // 装飾ブロックを繰り返して末尾窓を罫線だらけにする。
+  for (let i = 0; i < 60; i++) {
+    for (const l of decorativeBlock) lines.push(l);
+  }
+  return lines.join('\n');
+}
+
+test('モバイルプレビュー: 末尾に罫線再描画が大量に溜まっても直近の読める本文が残り、最新（末尾）まで表示される', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1');
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    const injectedLastLines = buildRedrawHeavyLastLines();
+    // 注入する罫線ブロックだけで旧切り詰め窓（1400 文字）を超えていることを前提確認。
+    const decorativeTailLen = injectedLastLines.length -
+      injectedLastLines.indexOf('╭'); // 最初の罫線以降の長さ
+    expect(decorativeTailLen).toBeGreaterThan(1400);
+
+    await page.route(`http://127.0.0.1:${port}/api/states`, async (route) => {
+      const injected = {
+        terminals: {
+          '1': {
+            termId: '1',
+            status: 'idle',
+            displayTitle: null,
+            lastLines: injectedLastLines,
+          },
+        },
+        updatedAt: Date.now(),
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(injected),
+      });
+    });
+
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    const card = page.locator('.card', { hasText: 'Terminal 1' });
+    const pre = card.locator('pre.lines');
+    await expect(pre).toBeVisible({ timeout: 15_000 });
+
+    // (1) 修正の本丸: 末尾が罫線だらけでも、読める本文が残っている。
+    //     修正前は tail(1400) が末尾の罫線窓だけを掴み、sanitize 後にほぼ空だった。
+    const text = await pre.textContent();
+    expect(text).toContain('ビルドに成功しました');
+    expect(text).toContain('テスト 42 件がすべてパスしました');
+    // 罫線・スピナー行は sanitize で除去されているので表示に含まれない。
+    expect(text).not.toContain('╭');
+    expect(text).not.toContain('│');
+    expect(text).not.toContain('✻');
+
+    // (2) 表示高さの拡大: max-height が 240px 固定でない（min(50vh, 520px) 相当）。
+    const maxHeightPx = await pre.evaluate((el) => {
+      return parseFloat(getComputedStyle(el).maxHeight);
+    });
+    expect(maxHeightPx).not.toBe(240);
+    expect(maxHeightPx).toBeGreaterThan(240);
+
+    // (3) 長いコンテンツ注入時、初回描画でプレビューが最下部（最新）まで
+    //     スクロールされている（scrollTop + clientHeight ≒ scrollHeight）。
+    const metrics = await pre.evaluate((el) => ({
+      scrollTop: el.scrollTop,
+      clientHeight: el.clientHeight,
+      scrollHeight: el.scrollHeight,
+    }));
+    // そもそもスクロール可能な高さがあること（拡大高さでも収まりきらない本文量）。
+    expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
+    const distanceFromBottom = metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
+    expect(distanceFromBottom).toBeLessThanOrEqual(24);
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test('モバイルプレビュー: 上スクロール中は更新で位置が引き戻されず、折り畳み→展開で最下部が表示される', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1');
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // route ハンドラが参照する可変の lastLines。テスト中に内容を差し替えて
+    // 2 秒ポーリングでの再描画をシミュレートする。
+    let currentLastLines = buildRedrawHeavyLastLines();
+
+    await page.route(`http://127.0.0.1:${port}/api/states`, async (route) => {
+      const injected = {
+        terminals: {
+          '1': {
+            termId: '1',
+            status: 'idle',
+            displayTitle: null,
+            lastLines: currentLastLines,
+          },
+        },
+        updatedAt: Date.now(),
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(injected),
+      });
+    });
+
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    const card = page.locator('.card', { hasText: 'Terminal 1' });
+    const pre = card.locator('pre.lines');
+    await expect(pre).toBeVisible({ timeout: 15_000 });
+
+    // 前提: スクロール可能な本文量があること。
+    await expect.poll(async () => pre.evaluate((el) => el.scrollHeight - el.clientHeight))
+      .toBeGreaterThan(24);
+
+    // プレビューを一番上までスクロールして「古い出力を読んでいる」状態にする。
+    await pre.evaluate((el) => { el.scrollTop = 0; });
+
+    // 内容を変えて（末尾に本文を追記）、次の 2 秒ポーリングでの再描画を待つ。
+    // 内容が変わるので DOM は更新されるが、上スクロール中なので stick=false となり
+    // scrollTop は最下部へ引き戻されないはず。
+    currentLastLines = currentLastLines + '\n追加の新しい出力行です new appended output line';
+
+    // ポーリング（2秒間隔）で scrollTop が引き戻されないことを確認する。
+    // 3 秒ほど観測し続けて、その間ずっと上部（引き戻されていない）に留まること。
+    let maxScrollTopSeen = 0;
+    const observeDeadline = Date.now() + 3500;
+    while (Date.now() < observeDeadline) {
+      const st = await pre.evaluate((el) => el.scrollTop);
+      if (st > maxScrollTopSeen) maxScrollTopSeen = st;
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    // 引き戻されていれば scrollTop は scrollHeight 付近まで飛ぶ。上部に留まっていれば 24px 以内。
+    expect(maxScrollTopSeen).toBeLessThanOrEqual(24);
+
+    // 追記した本文が反映されている（＝この間に再描画は走っている）ことも確認。
+    const textAfter = await pre.textContent();
+    expect(textAfter).toContain('new appended output line');
+
+    // 折り畳み → 展開で最下部（最新）が表示されること。
+    // card-head のタップで折りたたみをトグルする（既存挙動）。
+    const head = card.locator('.card-head');
+    await head.click(); // 折り畳み
+    await expect(card).toHaveClass(/collapsed/);
+    await head.click(); // 展開
+    await expect(card).not.toHaveClass(/collapsed/);
+
+    // 展開直後は最下部（最新）にスクロールされている。
+    await expect.poll(async () => pre.evaluate((el) =>
+      el.scrollHeight - el.scrollTop - el.clientHeight
+    )).toBeLessThanOrEqual(24);
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

モバイル版（HTTP API サーバーが返すスマートフォン向けページ）のペインプレビューが、実質1行程度しか読めない不具合を修正します。

原因は `renderer/mobile.html` のプレビュー生成の処理順で、**末尾1400文字に切り詰めてから**罫線・装飾行を除去していたため、Claude Code TUI のプロンプト枠（罫線）の再描画が溜まった末尾窓ではフィルタ後に読める行がほとんど残りませんでした。

あわせて、表示領域の高さ拡大と「最下部付近にいるときだけ新着に追従する」スクロール挙動を追加し、直近の出力を追いやすくしています。

## 変更内容

- **処理順の入れ替え（本丸）**: 「ANSI 除去 → 装飾行の除去 → 空行圧縮 → 末尾切り出し」の順に変更し、切り出し窓を 1400 → 4000 文字に拡大（サーバー側の保持量 80行/8000文字は無変更）
- **表示高さの拡大**: `pre.lines` の `max-height: 240px` → `min(50vh, 520px)`、font-size 11px → 12px、line-height 1.45 → 1.5。iOS 慣性スクロール（`-webkit-overflow-scrolling: touch`）とスクロールチェーン抑止（`overscroll-behavior: contain`）を追加
- **末尾追従スクロール**: 最下部付近（24px 以内）にいるときだけ新着で最下部へ自動追従。上へスクロールして読んでいる最中は位置を保持（2秒ポーリングで引き戻さない）。内容が前回と同一なら DOM を更新しない。折り畳み → 展開時は最下部（最新）を表示
- 既存の装飾行除去フィルタ（#104）・ページ全体のスクロール保存復元・PR リンク・並び替え機能は無変更

## 確認手順

> スクリーンショット添付は `org.review_assets_repo` 未設定のためスキップし、確認要点をテキストで記載しています。

### 修正前の再現手順（Before）

1. `main` ブランチで `npm install` し、`npm start` で vk-terminals を起動する
2. ペインで claude を起動し、しばらく対話して出力（プロンプト枠の再描画）を溜める
3. 同じマシンのブラウザで `http://127.0.0.1:13847/` を開く（スマートフォン実機の場合は README の「スマートフォンから開く手順」を参照）
   → 該当ペインのカードのプレビューに、読める行が1〜数行しか表示されない
   → プレビュー領域の高さが最大 240px 固定で狭い

### 修正後の確認手順（After）

1. 本ブランチで `npm start` し、同様に `http://127.0.0.1:13847/` を開く
   → プレビューに直近の出力がまとまった行数（画面の約半分の高さまで）表示され、最新（末尾）が見えている
2. プレビュー内を上方向にスクロールして古い出力を読む
   → 2秒ごとの更新が来ても、読んでいる位置が引き戻されない
3. プレビューを最下部までスクロールした状態で、ペインに新しい出力を発生させる（例: claude に何か入力する）
   → プレビューが自動で最下部（最新）に追従する
4. カードヘッダをタップして折り畳み、もう一度タップして展開する
   → 展開した瞬間に最下部（最新の出力）が表示される

### デグレ確認

1. モバイルページを深い位置までスクロールしてからリロードする
   → ページ全体のスクロール位置が復元される（既存挙動の維持）
2. スピナー記号（✻ 等）だけの行や数字断片だけの行がプレビューに表示されない（#104 の既存仕様の維持）
3. `npm test` を実行する
   → 100件すべて PASS

## 関連 issue

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/130

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - モバイル版のペインプレビュー表示領域を拡大し、より多くの端末出力を確認できるようにしました。
  - 出力表示の折り返しや行間を調整し、読みやすさを改善しました。
  - プレビューを展開した際、自動的に最新の出力位置へ移動するようにしました。

- **バグ修正**
  - 末尾の罫線再描画によって直近の出力がほとんど表示されなくなる問題を修正しました。
  - 不要な表示更新を抑え、最新出力付近にいる場合はスクロール位置を維持します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->