### PR TITLE
[ 不具合修正 ] モバイル版のペインプレビューで位置指定再描画により直近の本文行が表示されない不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 不具合修正 ] モバイル版のペインプレビューで Claude Code の位置指定再描画により直近の本文行が表示されない不具合を修正（[#132](https://github.com/vektor-inc/vk-terminals/issues/132)）
+
 ## 1.15.4
 
 - [ 仕様変更 ] モバイル版のペインプレビュー表示領域を拡大し、展開時・新着時に最新位置を見やすいように変更（[#130](https://github.com/vektor-inc/vk-terminals/issues/130)）

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -188,27 +188,39 @@
 // CR は TUI の全行再描画向けに扱う。裸の CR は行頭復帰として扱い、後続文字で現在行を列単位に上書きする。CRLF は改行 1 個にする。
 // erase-in-line CSI と基本的なカーソル移動 CSI は表示位置へ反映する。
 function applyCarriageReturns(s) {
+  var MAX_ROWS = 500;
+  var MAX_COLS = 1000;
   var lines = [""];
   var row = 0;
   var col = 0;
 
+  function clampRow(nextRow) {
+    return Math.min(MAX_ROWS - 1, Math.max(0, nextRow));
+  }
+
+  function clampCol(nextCol) {
+    return Math.min(MAX_COLS, Math.max(0, nextCol));
+  }
+
   function ensureRow(nextRow) {
-    row = Math.max(0, nextRow);
+    row = clampRow(nextRow);
     while (lines.length <= row) {
       lines.push("");
     }
   }
 
   function writeChar(ch) {
+    col = clampCol(col);
     var cur = lines[row] || "";
     if (col > cur.length) {
       cur += " ".repeat(col - cur.length);
     }
     lines[row] = cur.slice(0, col) + ch + cur.slice(col + 1);
-    col += 1;
+    col = clampCol(col + 1);
   }
 
   function eraseInLine(mode) {
+    col = clampCol(col);
     var cur = lines[row] || "";
     if (mode === "2") {
       lines[row] = "";
@@ -244,9 +256,9 @@ function applyCarriageReturns(s) {
     } else if (final === "B") {
       ensureRow(row + n);
     } else if (final === "C") {
-      col += n;
+      col = clampCol(col + n);
     } else if (final === "D") {
-      col = Math.max(0, col - n);
+      col = clampCol(col - n);
     } else if (final === "E") {
       ensureRow(row + n);
       col = 0;
@@ -254,14 +266,14 @@ function applyCarriageReturns(s) {
       ensureRow(row - n);
       col = 0;
     } else if (final === "G") {
-      col = Math.max(0, n - 1);
+      col = clampCol(n - 1);
     } else if (final === "H" || final === "f") {
       ensureRow(csiParam(values, 0, 1) - 1);
-      col = Math.max(0, csiParam(values, 1, 1) - 1);
+      col = clampCol(csiParam(values, 1, 1) - 1);
     } else if (final === "d") {
       ensureRow(n - 1);
     } else if (final === "a") {
-      col += n;
+      col = clampCol(col + n);
     } else if (final === "e") {
       ensureRow(row + n);
     }

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -89,7 +89,7 @@
   .pane-order-button:disabled:active { background: #20242b; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; line-height: 1.5;
-    white-space: pre-wrap; word-break: break-word; max-height: min(50vh, 520px); overflow-y: auto;
+    white-space: pre-wrap; word-break: break-word; min-height: 200px; max-height: min(50vh, 520px); overflow-y: auto;
     -webkit-overflow-scrolling: touch; overscroll-behavior: contain;
     border-top: 1px solid var(--card-border); }
   .card.collapsed pre.lines, .card.collapsed .actions { display: none; }
@@ -186,31 +186,85 @@
 "use strict";
 // ANSI エスケープ / 一部制御文字を除去（表示用）
 // CR は TUI の全行再描画向けに扱う。裸の CR は行頭復帰として扱い、後続文字で現在行を列単位に上書きする。CRLF は改行 1 個にする。
-// erase-in-line CSI は列位置に応じて反映するが、カーソル横移動 CSI までは再現しない簡易実装。
+// erase-in-line CSI と基本的なカーソル移動 CSI は表示位置へ反映する。
 function applyCarriageReturns(s) {
   var lines = [""];
+  var row = 0;
   var col = 0;
 
+  function ensureRow(nextRow) {
+    row = Math.max(0, nextRow);
+    while (lines.length <= row) {
+      lines.push("");
+    }
+  }
+
   function writeChar(ch) {
-    var cur = lines[lines.length - 1];
+    var cur = lines[row] || "";
     if (col > cur.length) {
       cur += " ".repeat(col - cur.length);
     }
-    lines[lines.length - 1] = cur.slice(0, col) + ch + cur.slice(col + 1);
+    lines[row] = cur.slice(0, col) + ch + cur.slice(col + 1);
     col += 1;
   }
 
   function eraseInLine(mode) {
-    var cur = lines[lines.length - 1];
+    var cur = lines[row] || "";
     if (mode === "2") {
-      lines[lines.length - 1] = "";
+      lines[row] = "";
       return;
     }
     if (mode === "1") {
-      lines[lines.length - 1] = " ".repeat(col) + cur.slice(col);
+      lines[row] = " ".repeat(col) + cur.slice(col);
       return;
     }
-    lines[lines.length - 1] = cur.slice(0, col);
+    lines[row] = cur.slice(0, col);
+  }
+
+  function csiParams(params) {
+    if (params.indexOf("?") === 0) return null;
+    return params.split(";").map(function(part) {
+      if (part === "") return null;
+      var n = parseInt(part, 10);
+      return isFinite(n) ? n : null;
+    });
+  }
+
+  function csiParam(values, index, fallback) {
+    if (!values || values[index] == null || values[index] === 0) return fallback;
+    return values[index];
+  }
+
+  function applyCursor(params, final) {
+    var values = csiParams(params);
+    if (!values) return;
+    var n = csiParam(values, 0, 1);
+    if (final === "A") {
+      ensureRow(row - n);
+    } else if (final === "B") {
+      ensureRow(row + n);
+    } else if (final === "C") {
+      col += n;
+    } else if (final === "D") {
+      col = Math.max(0, col - n);
+    } else if (final === "E") {
+      ensureRow(row + n);
+      col = 0;
+    } else if (final === "F") {
+      ensureRow(row - n);
+      col = 0;
+    } else if (final === "G") {
+      col = Math.max(0, n - 1);
+    } else if (final === "H" || final === "f") {
+      ensureRow(csiParam(values, 0, 1) - 1);
+      col = Math.max(0, csiParam(values, 1, 1) - 1);
+    } else if (final === "d") {
+      ensureRow(n - 1);
+    } else if (final === "a") {
+      col += n;
+    } else if (final === "e") {
+      ensureRow(row + n);
+    }
   }
 
   for (var i = 0; i < s.length; i += 1) {
@@ -229,6 +283,8 @@ function applyCarriageReturns(s) {
         var final = s[j];
         if (final === "K") {
           eraseInLine(params === "" ? "0" : params);
+        } else {
+          applyCursor(params, final);
         }
         i = j;
         continue;
@@ -276,7 +332,8 @@ function applyCarriageReturns(s) {
     }
     if (ch === "\r") {
       if (s[i + 1] === "\n") {
-        lines.push("");
+        ensureRow(row + 1);
+        lines[row] = lines[row] || "";
         col = 0;
         i += 1;
       } else {
@@ -285,7 +342,8 @@ function applyCarriageReturns(s) {
       continue;
     }
     if (ch === "\n") {
-      lines.push("");
+      ensureRow(row + 1);
+      lines[row] = lines[row] || "";
       col = 0;
       continue;
     }

--- a/tests/e2e/mobile-preview-csi-redraw.smoke.spec.js
+++ b/tests/e2e/mobile-preview-csi-redraw.smoke.spec.js
@@ -1,0 +1,175 @@
+const { test, expect, _electron, chromium } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// issue #132 / PR #133: モバイル版ペインプレビューで、Claude Code の TUI が行う
+// CSI カーソル位置指定による全画面再描画（`\x1b[row;colH` で各行の先頭へ移動し
+// `\x1b[2K` で行を消してから本文を書く）を扱えず、位置移動を無視したまま同一の
+// 内部行を消し続けて「最後の入力ボックス相当の1行」だけになる不具合の
+// end-to-end 確認。
+//
+// 検証手法は既存の mobile-preview-cr-redraw / mobile-preview-order-scroll の
+// smoke spec を踏襲する。一時 HOME + `--no-claude` で Electron を起動し、
+// VK_TERMINALS_API_PORT で空きポートを指定、Playwright の page.route で
+// /api/states 応答を差し替えて任意の lastLines を注入 → 実ブラウザで mobile.html の
+// 実描画（実物の stripAnsi / sanitizeMobilePreviewText を経由した DOM）を検証する。
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function getStates(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/api/states`);
+  if (res.status !== 200) throw new Error(`/api/states returned ${res.status}`);
+  const json = await res.json();
+  return json.terminals || {};
+}
+
+function termIdsOf(states) {
+  return Object.values(states)
+    .map((t) => (t && t.termId != null ? String(t.termId) : null))
+    .filter(Boolean);
+}
+
+async function waitForTermId(port, termId, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen = null;
+  while (Date.now() < deadline) {
+    try {
+      const states = await getStates(port);
+      const ids = termIdsOf(states);
+      lastSeen = ids;
+      if (ids.includes(String(termId))) return ids;
+    } catch (_e) {
+      // HTTP サーバー起動前は fetch が失敗する。同じループで吸収する。
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`termId ${termId} did not appear in time. last states: ${JSON.stringify(lastSeen)}`);
+}
+
+// 一時 HOME を用意して Electron を素のシェル（--no-claude）で起動する。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-csi-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  await app.firstWindow();
+  return { app, tmpRoot };
+}
+
+// Claude Code 風の CSI カーソル位置指定再描画フレームを組み立てる。
+// 各行を `\x1b[row;1H`（絶対位置指定）→ `\x1b[2K`（行消去）→ 本文 の順で書く。
+// 修正前はこの位置移動を無視して同一内部行を消し続けるため、本文がほぼ残らず
+// 最終行だけになっていた。修正後は row/col バッファへ反映され、各本文行が
+// 別々の行として復元される。
+function buildClaudeCodeCsiRedrawFrame() {
+  return [
+    '\x1b[1;1H\x1b[2K実装内容を確認しています',
+    '\x1b[2;1H\x1b[2K- renderer/mobile.html のモバイルプレビューを調査',
+    '\x1b[3;1H\x1b[2K- sanitize の処理順と CSS 高さを確認',
+    '\x1b[4;1H\x1b[2K- 直近の本文出力を最低10行見えるように修正',
+    '\x1b[5;1H\x1b[2Knpm test を実行して回帰を確認します',
+    '\x1b[6;1H\x1b[2K変更後は本文行が消えないことを検証します',
+  ].join('');
+}
+
+test('モバイルプレビュー: CSI 位置指定再描画で直近の本文行が複数行として復元される', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1');
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    const injectedLastLines = buildClaudeCodeCsiRedrawFrame();
+
+    await page.route(`http://127.0.0.1:${port}/api/states`, async (route) => {
+      const injected = {
+        terminals: {
+          '1': {
+            termId: '1',
+            status: 'idle',
+            displayTitle: null,
+            lastLines: injectedLastLines,
+          },
+        },
+        updatedAt: Date.now(),
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(injected),
+      });
+    });
+
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    const card = page.locator('.card', { hasText: 'Terminal 1' });
+    const pre = card.locator('pre.lines');
+    await expect(pre).toBeVisible({ timeout: 15_000 });
+
+    // (1) 本文行の復元: 位置指定再描画でも直近の本文行が複数行として残る。
+    //     修正前は位置移動を無視して同一行を消し続けるため、本文はほぼ残らず
+    //     1 行程度しか表示されなかった。
+    const text = await pre.textContent();
+    expect(text).toContain('実装内容を確認しています');
+    expect(text).toContain('renderer/mobile.html のモバイルプレビューを調査');
+    expect(text).toContain('sanitize の処理順と CSS 高さを確認');
+    expect(text).toContain('直近の本文出力を最低10行見えるように修正');
+    expect(text).toContain('npm test を実行して回帰を確認します');
+    expect(text).toContain('変更後は本文行が消えないことを検証します');
+
+    // 本文が 1 行に潰れず、複数行（≒注入した本文行数）として描画されている。
+    const nonEmptyLineCount = text.split('\n').filter((l) => l.trim()).length;
+    expect(nonEmptyLineCount).toBeGreaterThanOrEqual(5);
+
+    // (2) 最低高さ: 内容が短くてもプレビュー枠が約10行分（min-height: 200px）を確保する。
+    const minHeightPx = await pre.evaluate((el) => parseFloat(getComputedStyle(el).minHeight));
+    expect(minHeightPx).toBeGreaterThanOrEqual(190);
+    // 実効の描画高さも約200px以上（短い内容で枠が潰れない）。
+    const clientHeightPx = await pre.evaluate((el) => el.clientHeight);
+    expect(clientHeightPx).toBeGreaterThanOrEqual(190);
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
+++ b/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
@@ -182,6 +182,12 @@ test('モバイルプレビュー: 末尾に罫線再描画が大量に溜まっ
     expect(maxHeightPx).not.toBe(240);
     expect(maxHeightPx).toBeGreaterThan(240);
 
+    // (2.5) issue #132: 内容が短くても、約10行分の表示領域を確保する。
+    const minHeightPx = await pre.evaluate((el) => {
+      return parseFloat(getComputedStyle(el).minHeight);
+    });
+    expect(minHeightPx).toBeGreaterThanOrEqual(190);
+
     // (3) 長いコンテンツ注入時、初回描画でプレビューが最下部（最新）まで
     //     スクロールされている（scrollTop + clientHeight ≒ scrollHeight）。
     const metrics = await pre.evaluate((el) => ({

--- a/tests/mobilePreviewSanitize.test.js
+++ b/tests/mobilePreviewSanitize.test.js
@@ -31,6 +31,25 @@ function loadMobileStripAnsi() {
   return context.stripAnsi;
 }
 
+function tailString(s, n) {
+  return s.length > n ? s.slice(s.length - n) : s;
+}
+
+function buildClaudeCodeCsiRedrawFrame() {
+  return [
+    '\x1b[1;1H\x1b[2K実装内容を確認しています',
+    '\x1b[2;1H\x1b[2K- renderer/mobile.html のモバイルプレビューを調査',
+    '\x1b[3;1H\x1b[2K- sanitize の処理順と CSS 高さを確認',
+    '\x1b[4;1H\x1b[2K- 直近の本文出力を最低10行見えるように修正',
+    '\x1b[5;1H\x1b[2Knpm test を実行して回帰を確認します',
+    '\x1b[6;1H\x1b[2K変更後は本文行が消えないことを検証します',
+    '\x1b[7;1H\x1b[2K',
+    '\x1b[8;1H\x1b[2K╭────────────────────────────╮',
+    '\x1b[9;1H\x1b[2K│ > 1. Yes                    │',
+    '\x1b[10;1H\x1b[2K╰────────────────────────────╯',
+  ].join('');
+}
+
 test('sanitizeMobilePreviewText: スピナー記号だけの行と数字断片行を除去する', () => {
   const sanitizeMobilePreviewText = loadSanitizeMobilePreviewText();
   const input = [
@@ -148,6 +167,40 @@ test('mobile stripAnsi: erase-in-line CSI を CR 再描画に反映する', () =
     'ペインのリンク付きの部分、B'
   );
   assert.equal(stripAnsi('\x1b[31mred\x1b[0m'), 'red');
+});
+
+test('stripAnsiForDisplay: Claude Code 風の CSI 位置指定再描画を複数行として復元する', () => {
+  assert.equal(
+    stripAnsiForDisplay(buildClaudeCodeCsiRedrawFrame()),
+    [
+      '実装内容を確認しています',
+      '- renderer/mobile.html のモバイルプレビューを調査',
+      '- sanitize の処理順と CSS 高さを確認',
+      '- 直近の本文出力を最低10行見えるように修正',
+      'npm test を実行して回帰を確認します',
+      '変更後は本文行が消えないことを検証します',
+      '',
+      '╭────────────────────────────╮',
+      '│ > 1. Yes                    │',
+      '╰────────────────────────────╯',
+    ].join('\n')
+  );
+});
+
+test('mobile preview: Claude Code 風の CSI 位置指定再描画でも直近本文行を残す', () => {
+  const sanitizeMobilePreviewText = loadSanitizeMobilePreviewText();
+  const stripAnsi = loadMobileStripAnsi();
+  const preview = tailString(
+    sanitizeMobilePreviewText(stripAnsi(buildClaudeCodeCsiRedrawFrame()))
+      .replace(/\n{3,}/g, '\n\n')
+      .trim(),
+    4000
+  );
+
+  assert.match(preview, /renderer\/mobile\.html のモバイルプレビューを調査/);
+  assert.match(preview, /直近の本文出力を最低10行見えるように修正/);
+  assert.match(preview, /変更後は本文行が消えないことを検証します/);
+  assert.ok(preview.split('\n').filter((line) => line.trim()).length >= 6);
 });
 
 test('mobile preview: PTY イベントをまたぐ CR 再描画も同一行として扱う', () => {

--- a/tests/mobilePreviewSanitize.test.js
+++ b/tests/mobilePreviewSanitize.test.js
@@ -11,6 +11,9 @@ const {
   stripAnsiForDisplay,
 } = require('../utils/stripAnsi');
 
+const MAX_DISPLAY_ROWS = 500;
+const MAX_DISPLAY_LINE_LENGTH = 1001;
+
 function loadSanitizeMobilePreviewText() {
   const html = fs.readFileSync(path.join(__dirname, '..', 'renderer', 'mobile.html'), 'utf8');
   const match = html.match(/\/\/ Claude Code[\s\S]*?\nfunction tail/);
@@ -48,6 +51,31 @@ function buildClaudeCodeCsiRedrawFrame() {
     '\x1b[9;1H\x1b[2K│ > 1. Yes                    │',
     '\x1b[10;1H\x1b[2K╰────────────────────────────╯',
   ].join('');
+}
+
+function assertBoundedDisplayControls(name, fn) {
+  const cases = [
+    ['huge absolute row', '\x1b[999999Hrow'],
+    ['huge relative row', `top\x1b[2147483647Bbottom`],
+    ['huge absolute row and col', '\x1b[999999;9999999999999999HX'],
+    ['huge relative col', `start\x1b[9999999999999999CX`],
+    ['negative relative col', `abc\x1b[-5CX`],
+  ];
+
+  for (const [label, input] of cases) {
+    assert.doesNotThrow(() => fn(input), `${name}: ${label} should not throw`);
+    const output = fn(input);
+    const lines = output.split('\n');
+
+    assert.ok(
+      lines.length <= MAX_DISPLAY_ROWS,
+      `${name}: ${label} should clamp rows, got ${lines.length}`
+    );
+    assert.ok(
+      lines.every((line) => line.length <= MAX_DISPLAY_LINE_LENGTH),
+      `${name}: ${label} should clamp line length`
+    );
+  }
 }
 
 test('sanitizeMobilePreviewText: スピナー記号だけの行と数字断片行を除去する', () => {
@@ -185,6 +213,16 @@ test('stripAnsiForDisplay: Claude Code 風の CSI 位置指定再描画を複数
       '╰────────────────────────────╯',
     ].join('\n')
   );
+});
+
+test('stripAnsiForDisplay: 巨大な CSI カーソル移動でも行数と列幅を上限内に収める', () => {
+  assertBoundedDisplayControls('stripAnsiForDisplay', stripAnsiForDisplay);
+});
+
+test('mobile stripAnsi: 巨大な CSI カーソル移動でも行数と列幅を上限内に収める', () => {
+  const stripAnsi = loadMobileStripAnsi();
+
+  assertBoundedDisplayControls('mobile stripAnsi', stripAnsi);
 });
 
 test('mobile preview: Claude Code 風の CSI 位置指定再描画でも直近本文行を残す', () => {

--- a/utils/stripAnsi.js
+++ b/utils/stripAnsi.js
@@ -16,27 +16,34 @@
 // `\r\n` は改行 1 個にする。
 // erase-in-line CSI と基本的なカーソル移動 CSI は表示位置へ反映する。
 function applyDisplayControls(str) {
+  const MAX_ROWS = 500;
+  const MAX_COLS = 1000;
   const lines = [''];
   let row = 0;
   let col = 0;
 
+  const clampRow = (nextRow) => Math.min(MAX_ROWS - 1, Math.max(0, nextRow));
+  const clampCol = (nextCol) => Math.min(MAX_COLS, Math.max(0, nextCol));
+
   const ensureRow = (nextRow) => {
-    row = Math.max(0, nextRow);
+    row = clampRow(nextRow);
     while (lines.length <= row) {
       lines.push('');
     }
   };
 
   const writeChar = (ch) => {
+    col = clampCol(col);
     let cur = lines[row] || '';
     if (col > cur.length) {
       cur += ' '.repeat(col - cur.length);
     }
     lines[row] = cur.slice(0, col) + ch + cur.slice(col + 1);
-    col += 1;
+    col = clampCol(col + 1);
   };
 
   const eraseInLine = (mode) => {
+    col = clampCol(col);
     const cur = lines[row] || '';
     if (mode === '2') {
       lines[row] = '';
@@ -72,9 +79,9 @@ function applyDisplayControls(str) {
     } else if (final === 'B') {
       ensureRow(row + n);
     } else if (final === 'C') {
-      col += n;
+      col = clampCol(col + n);
     } else if (final === 'D') {
-      col = Math.max(0, col - n);
+      col = clampCol(col - n);
     } else if (final === 'E') {
       ensureRow(row + n);
       col = 0;
@@ -82,14 +89,14 @@ function applyDisplayControls(str) {
       ensureRow(row - n);
       col = 0;
     } else if (final === 'G') {
-      col = Math.max(0, n - 1);
+      col = clampCol(n - 1);
     } else if (final === 'H' || final === 'f') {
       ensureRow(csiParam(values, 0, 1) - 1);
-      col = Math.max(0, csiParam(values, 1, 1) - 1);
+      col = clampCol(csiParam(values, 1, 1) - 1);
     } else if (final === 'd') {
       ensureRow(n - 1);
     } else if (final === 'a') {
-      col += n;
+      col = clampCol(col + n);
     } else if (final === 'e') {
       ensureRow(row + n);
     }

--- a/utils/stripAnsi.js
+++ b/utils/stripAnsi.js
@@ -14,31 +14,85 @@
 // CR は TUI の全行書き換え型の再描画として扱う。
 // 裸の `\r` は行頭復帰として扱い、後続文字で現在行を列単位に上書きする。
 // `\r\n` は改行 1 個にする。
-// erase-in-line CSI は列位置に応じて反映するが、カーソル横移動 CSI までは再現しない簡易実装。
+// erase-in-line CSI と基本的なカーソル移動 CSI は表示位置へ反映する。
 function applyDisplayControls(str) {
   const lines = [''];
+  let row = 0;
   let col = 0;
 
+  const ensureRow = (nextRow) => {
+    row = Math.max(0, nextRow);
+    while (lines.length <= row) {
+      lines.push('');
+    }
+  };
+
   const writeChar = (ch) => {
-    let cur = lines[lines.length - 1];
+    let cur = lines[row] || '';
     if (col > cur.length) {
       cur += ' '.repeat(col - cur.length);
     }
-    lines[lines.length - 1] = cur.slice(0, col) + ch + cur.slice(col + 1);
+    lines[row] = cur.slice(0, col) + ch + cur.slice(col + 1);
     col += 1;
   };
 
   const eraseInLine = (mode) => {
-    const cur = lines[lines.length - 1];
+    const cur = lines[row] || '';
     if (mode === '2') {
-      lines[lines.length - 1] = '';
+      lines[row] = '';
       return;
     }
     if (mode === '1') {
-      lines[lines.length - 1] = ' '.repeat(col) + cur.slice(col);
+      lines[row] = ' '.repeat(col) + cur.slice(col);
       return;
     }
-    lines[lines.length - 1] = cur.slice(0, col);
+    lines[row] = cur.slice(0, col);
+  };
+
+  const csiParams = (params) => {
+    if (params.startsWith('?')) return null;
+    return params.split(';').map((part) => {
+      if (part === '') return null;
+      const n = Number.parseInt(part, 10);
+      return Number.isFinite(n) ? n : null;
+    });
+  };
+
+  const csiParam = (values, index, fallback) => {
+    if (!values || values[index] == null || values[index] === 0) return fallback;
+    return values[index];
+  };
+
+  const applyCursor = (params, final) => {
+    const values = csiParams(params);
+    if (!values) return;
+    const n = csiParam(values, 0, 1);
+    if (final === 'A') {
+      ensureRow(row - n);
+    } else if (final === 'B') {
+      ensureRow(row + n);
+    } else if (final === 'C') {
+      col += n;
+    } else if (final === 'D') {
+      col = Math.max(0, col - n);
+    } else if (final === 'E') {
+      ensureRow(row + n);
+      col = 0;
+    } else if (final === 'F') {
+      ensureRow(row - n);
+      col = 0;
+    } else if (final === 'G') {
+      col = Math.max(0, n - 1);
+    } else if (final === 'H' || final === 'f') {
+      ensureRow(csiParam(values, 0, 1) - 1);
+      col = Math.max(0, csiParam(values, 1, 1) - 1);
+    } else if (final === 'd') {
+      ensureRow(n - 1);
+    } else if (final === 'a') {
+      col += n;
+    } else if (final === 'e') {
+      ensureRow(row + n);
+    }
   };
 
   for (let i = 0; i < str.length; i += 1) {
@@ -57,6 +111,8 @@ function applyDisplayControls(str) {
         const final = str[j];
         if (final === 'K') {
           eraseInLine(params === '' ? '0' : params);
+        } else {
+          applyCursor(params, final);
         }
         i = j;
         continue;
@@ -104,7 +160,8 @@ function applyDisplayControls(str) {
     }
     if (ch === '\r') {
       if (str[i + 1] === '\n') {
-        lines.push('');
+        ensureRow(row + 1);
+        lines[row] = lines[row] || '';
         col = 0;
         i += 1;
       } else {
@@ -113,7 +170,8 @@ function applyDisplayControls(str) {
       continue;
     }
     if (ch === '\n') {
-      lines.push('');
+      ensureRow(row + 1);
+      lines[row] = lines[row] || '';
       col = 0;
       continue;
     }


### PR DESCRIPTION
## 概要

モバイル版のペインプレビューが「最後の1行しか表示されず状況が分からない」不具合（issue #132）を修正します。#131（v1.15.4）でも同症状を扱いましたが不十分だったため、根本原因まで踏み込んで対処しました。

## 原因

モバイルプレビュー表示用の ANSI 処理（`renderer/mobile.html` の `applyCarriageReturns` と `utils/stripAnsi.js` の `applyDisplayControls`）が、**CSI カーソル位置指定（CUP `\x1b[row;colH` 等）を無視する一方で `2K`（行消去）だけを処理**していました。Claude Code の TUI はカーソル移動で画面を再描画するため、位置移動を無視したまま同一の内部行を消し続け、本文行がほとんど残らず「最後の入力ボックス相当の1行」だけになっていました。あわせて `pre.lines` に `min-height` が無く、内容が短いと表示領域自体も潰れていました。

## 変更内容

- 表示用 ANSI 処理（上記の双子関数）に **基本カーソル移動 CSI（A/B/C/D/E/F/G/H/f/d/a/e）を行(row)・列(col)バッファへ反映**する処理を追加。位置指定再描画でも直近本文行が複数行として復元されるようにした。
- `pre.lines` に **`min-height: 200px`**（font-size 12px × line-height 1.5 ≒ 18px/行 → 約10行分）を追加し、内容が短くても十分な表示領域を確保（ユーザー要望「最低10行」への対応）。
- **リソース枯渇対策**（セキュリティレビュー指摘）: 上記カーソル処理は行・列の上限が無く、生 PTY 出力（暴走プロセスやバイナリファイルの `cat` 等で `\x1b[999999H` のような巨大値）でメモリ枯渇・UIフリーズを招きうるため、双子関数に `MAX_ROWS=500` / `MAX_COLS=1000` のクランプを追加。`clampRow` は `MAX_ROWS-1` で行数を、`clampCol` は各 col 設定箇所で列を上限内に抑える。

## テスト（確認手順）

### Before（修正前の再現）

1. モバイル端末（またはブラウザのモバイル表示）で vk-terminals のモバイルページを開く。
2. Claude Code を実行中の端末カードのプレビューを見る。
   → **プレビューに最後の1行（入力ボックス相当）しか表示されず**、直近の出力内容が分からない。

### After（修正後の確認）

1. 同じくモバイルページで Claude Code 実行中の端末カードのプレビューを見る。
   → **位置指定再描画を含む出力でも、直近の本文行が複数行（約10行分の高さ）で読める**。
2. 出力が数行しか無い端末カードを見る。
   → プレビュー枠が `min-height: 200px`（約10行分）を確保し、高さが潰れない。

### 自動テスト

- ユニット: `npm test` → **104 tests / 0 fail**（`matchesWaiting` 系の入力待ち検知に回帰なし）。
  - `tests/mobilePreviewSanitize.test.js` に、Claude Code 風の CSI 位置指定再描画で本文複数行が復元されることを検証する red→green テストを追加。
  - あわせて巨大 row/col・負方向 col の境界テスト（`\x1b[999999H` / `\x1b[2147483647B` / `\x1b[9999999999999999C` 等）を追加し、例外・フリーズなく行数≤500・行長≤1001 に収まることを検証。
- e2e: `npx playwright test tests/e2e/mobile-preview-order-scroll.smoke.spec.js tests/e2e/mobile-preview-cr-redraw.smoke.spec.js` → **3 passed**（`min-height` の確保と末尾追従スクロールを検証）。

### スクリーンショット

自動実行フローのため本 PR には静止画を添付していません。実ブラウザでの表示確認は e2e レビュー（麗美）で実施し、結果を PR コメントに記載します。issue #132 に Before の PC / モバイル スクリーンショットがあります。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/132

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/362