### PR TITLE
[ 機能追加 ] モバイル版の最下部に VK Terminals のバージョンを表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 機能追加 ] モバイル版の最下部に VK Terminals のバージョンを表示（[#135](https://github.com/vektor-inc/vk-terminals/issues/135)）
+
 ## 1.15.5
 
 - [ 不具合修正 ] モバイル版のペインプレビューで Claude Code の位置指定再描画により直近の本文行が表示されない不具合を修正（[#132](https://github.com/vektor-inc/vk-terminals/issues/132)）

--- a/main.js
+++ b/main.js
@@ -1049,6 +1049,7 @@ function startHttpApi() {
             updatedAt: new Date().toISOString(),
             terminals: cachedStates,
             usage,
+            version: require('./package.json').version,
           }));
         });
       return;

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -151,7 +151,8 @@
   #usage-oauth .u-fill.level-warn { background: #d29922; }
   #usage-oauth .u-fill.level-crit { background: #f85149; }
   #usage-oauth .u-reset { margin-top: 4px; font-size: 10px; color: var(--muted); }
-  #app-version-footer { display: none; padding: 4px 12px 18px; color: var(--muted);
+  #app-version-footer { display: none; padding: 4px 12px;
+    padding-bottom: max(18px, env(safe-area-inset-bottom)); color: var(--muted);
     font-size: 11px; line-height: 1.4; text-align: center; }
   #app-version-footer.show { display: block; }
 </style>

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -151,6 +151,9 @@
   #usage-oauth .u-fill.level-warn { background: #d29922; }
   #usage-oauth .u-fill.level-crit { background: #f85149; }
   #usage-oauth .u-reset { margin-top: 4px; font-size: 10px; color: var(--muted); }
+  #app-version-footer { display: none; padding: 4px 12px 18px; color: var(--muted);
+    font-size: 11px; line-height: 1.4; text-align: center; }
+  #app-version-footer.show { display: block; }
 </style>
 </head>
 <body>
@@ -181,6 +184,7 @@
   <div class="u-note" id="usage-note"></div>
 </div>
 <div id="list"></div>
+<footer id="app-version-footer"></footer>
 
 <script>
 "use strict";
@@ -794,6 +798,19 @@ function ensureCard(termId) {
 //   - それ以外（source === 'transcript' フォールバック）: 従来表示のまま。
 // 文字列は textContent で入れるので XSS 面も安全。
 var usageCard = document.getElementById("usage-card");
+var appVersionFooter = document.getElementById("app-version-footer");
+
+function renderAppVersion(version) {
+  if (!appVersionFooter) return;
+  var v = typeof version === "string" ? version.trim() : "";
+  if (!v) {
+    appVersionFooter.textContent = "";
+    appVersionFooter.classList.remove("show");
+    return;
+  }
+  appVersionFooter.textContent = "VK Terminals v" + v;
+  appVersionFooter.classList.add("show");
+}
 
 // 残り時間（ms）→「◯時間◯分後にリセット」
 function fmtRemainingJa(ms) {
@@ -884,6 +901,7 @@ function renderUsage(usage) {
 }
 
 function render(data) {
+  renderAppVersion(data.version);
   renderUsage(data.usage);
   var terms = data.terminals || {};
   var keys = Object.keys(terms);

--- a/tests/e2e/mobile-app-version.smoke.spec.js
+++ b/tests/e2e/mobile-app-version.smoke.spec.js
@@ -1,0 +1,146 @@
+const { test, expect, _electron, chromium } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// issue #135 / PR #136: モバイル版の最下部に VK Terminals のバージョンを表示する変更の
+// end-to-end 確認。
+//   - GET /api/states のレスポンス JSON に version（= package.json の version）が含まれる。
+//   - モバイルページを開くと最下部の #app-version-footer に
+//     「VK Terminals v<version>」が表示され、.show クラスが付いて可視になる。
+//   - 既存フィールド（terminals / usage / updatedAt）がデグレせず従来どおり返る（回帰確認）。
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+// package.json の version を真実源として読む（main.js も同じ値を返す想定）。
+const pkgVersion = require(path.join(repoRoot, 'package.json')).version;
+
+async function getFreePort() {
+  // OS に空きポートを割り当てさせ、取得後に閉じて Electron 側で再利用する。
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+// GET /api/states を叩き、レスポンス JSON をそのまま返す。
+async function fetchStates(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/api/states`);
+  if (res.status !== 200) throw new Error(`/api/states returned ${res.status}`);
+  return await res.json();
+}
+
+// /api/states が version を返し始めるまで短くリトライして待つ。
+// HTTP サーバー起動直後は fetch が失敗するため、猶予を持って待機する。
+async function waitForStatesWithVersion(port, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastJson = null;
+  while (Date.now() < deadline) {
+    try {
+      const json = await fetchStates(port);
+      lastJson = json;
+      if (typeof json.version === 'string' && json.version) return json;
+    } catch (_e) {
+      // 起動前の fetch 失敗は同じループで吸収する。
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`/api/states did not return version in time. last json: ${JSON.stringify(lastJson)}`);
+}
+
+// 一時 HOME を用意して Electron を素のシェル（--no-claude）で起動する。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-version-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  // 実ユーザーの ~/.vk-terminals/config.json に依存しないよう HOME を一時化する。
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  await app.firstWindow();
+  return { app, tmpRoot };
+}
+
+// ─── GET /api/states のレスポンスに version（= package.json の version）が含まれ、
+//     既存フィールドもデグレしていない（回帰確認）───
+test('GET /api/states のレスポンスに version が含まれ、既存フィールドも維持されている', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  try {
+    const json = await waitForStatesWithVersion(port);
+
+    // version が package.json と一致すること（本 PR の追加フィールド）。
+    expect(json.version).toBe(pkgVersion);
+
+    // 既存フィールドが従来どおり存在すること（回帰確認）。
+    expect(json).toHaveProperty('updatedAt');
+    expect(typeof json.updatedAt).toBe('string');
+    expect(json).toHaveProperty('terminals');
+    expect(json.terminals && typeof json.terminals).toBe('object');
+    expect(json).toHaveProperty('usage');
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── モバイルページ最下部の #app-version-footer に「VK Terminals v<version>」が
+//     表示され、.show が付いて可視になる ───
+test('モバイル: 最下部の #app-version-footer に VK Terminals v<version> が表示され可視になる', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    // /api/states が version を返せる状態になってからページを開く。
+    await waitForStatesWithVersion(port);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    // フッターがポーリング反映で .show 付与＝可視になるのを待つ。
+    const footer = page.locator('#app-version-footer');
+    await expect(footer).toBeVisible({ timeout: 15_000 });
+    await expect(footer).toHaveClass(/\bshow\b/, { timeout: 15_000 });
+
+    // 表示テキストが「VK Terminals v<package.json の version>」であること。
+    await expect(footer).toHaveText(`VK Terminals v${pkgVersion}`);
+
+    // 中央寄せの CSS（design-rules 観点の副次テキスト表現）が適用されていること。
+    await expect(footer).toHaveCSS('text-align', 'center');
+
+    // <footer> が list より後ろ（=最下部側）に配置されていること。
+    const listBottom = await page.locator('#list').evaluate((el) => el.getBoundingClientRect().bottom);
+    const footerTop = await footer.evaluate((el) => el.getBoundingClientRect().top);
+    expect(footerTop).toBeGreaterThanOrEqual(listBottom - 1);
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

モバイル版ページ（`renderer/mobile.html`、HTTP サーバー経由でスマートフォンに配信されるページ）の最下部に、アプリのバージョンを「VK Terminals vX.Y.Z」形式で表示するようにしました。デスクトップ版（設定ヘッダ）の表示形式に揃えています。

- `main.js`: `GET /api/states` のレスポンス JSON に `version`（`package.json` の version）を後方互換の additive フィールドとして追加。
- `renderer/mobile.html`: 最下部に `<footer id="app-version-footer">` を追加し、ポーリングレスポンスの `version` を `textContent` で描画（XSS 安全）。値が未取得・空のときは非表示にするフォールバックあり。スタイルは既存の副次テキスト（`var(--muted)` / 11px / 中央寄せ）に統一し、iPhone のホームインジケータに配慮して下端 padding を `max(18px, env(safe-area-inset-bottom))` に設定。
- `CHANGELOG.md`: 機能追加エントリを追記。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/135

@coderabbitai ignore

## テスト（確認手順）

前提: アプリを起動し、モバイルページ配信用の HTTP サーバー（`GET /`）にブラウザ（スマートフォン想定）でアクセスできる状態にする。

1. アプリを起動する。
   → HTTP API サーバーが起動する。
2. ブラウザで `http://127.0.0.1:<API_PORT>/`（モバイルページ）を開く。
   → ページが表示され、ポーリング（`/api/states`）が開始される。
3. ページを一番下までスクロールする。
   → 最下部に「VK Terminals v1.15.5」（= `package.json` の version）が、控えめな灰色・中央寄せで表示される。
4. `curl http://127.0.0.1:<API_PORT>/api/states` を実行する。
   → レスポンス JSON に `"version":"1.15.5"` が含まれ、既存の `terminals` / `usage` / `updatedAt` も従来どおり返る（後方互換）。

デグレ確認:
- 既存のターミナル一覧・使用量表示（usage）が従来どおり描画されること。
- `/api/states` の既存フィールドが欠落していないこと。

補足: バージョン表示部分は表示のみ・操作なしの副次テキストです。Before/After のスクリーンショットは e2e 工程（麗美）の動作確認レポートで確認します。

## テスト結果（実装者ローカル）

- `npm test`: 104 passed
- `npm run test:e2e`: 18 passed

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/365