### PR TITLE
[ デザイン不具合修正 ] サイドバー格納時とモバイル版でマージ済み PR ラベルが紫にならず緑のままになる不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [ 機能追加 ] モバイル版の最下部に VK Terminals のバージョンを表示（[#135](https://github.com/vektor-inc/vk-terminals/issues/135)）
+- [ デザイン不具合修正 ] サイドバー格納時とモバイル版でマージ済み PR ラベルが紫にならず緑のままになる不具合を修正（[#137](https://github.com/vektor-inc/vk-terminals/issues/137)）
 
 ## 1.15.5
 

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -818,7 +818,7 @@ function renderStashItem(id, idx, count) {
     + (!title && !taskPrUrl ? ' empty' : '')
     + (taskUrl ? ' has-link' : '')
     + (taskPrUrl ? ' has-pr' : '');
-  renderTaskTitleContent(titleEl, title, taskUrl, taskPrUrl);
+  renderTaskTitleContent(titleEl, title, taskUrl, taskPrUrl, !!t?.apiPrMerged);
   if (taskUrl) {
     titleEl.removeAttribute('title');
   } else {
@@ -889,7 +889,7 @@ function updateStashItem(paneId) {
     const title = getDisplayTitle(t);
     const url = getDisplayUrl(t);
     const prUrl = isSafeExternalUrl(t.apiPrUrl) ? t.apiPrUrl : '';
-    renderTaskTitleContent(titleEl, title, url, prUrl);
+    renderTaskTitleContent(titleEl, title, url, prUrl, !!t.apiPrMerged);
     if (url) {
       titleEl.removeAttribute('title');
     } else {

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -73,6 +73,10 @@
     background: rgba(63,185,80,0.15); border: 1px solid rgba(63,185,80,0.3); color: #6fd58a; }
   a.pr-link.show { display: inline-flex; }
   a.pr-link:active { background: rgba(63,185,80,0.28); border-color: rgba(63,185,80,0.5); }
+  /* マージ済み PR リンク（issue #137）。ヘッダ帯 var(--card) #1d2127 上で
+     #c8a8ff はコントラスト比 8.08:1、active の #d0b5ff は 9.03:1 で AA 4.5:1 を満たす。 */
+  a.pr-link.merged { background: rgba(130,80,223,0.15); border-color: rgba(130,80,223,0.45); color: #c8a8ff; }
+  a.pr-link.merged:active { background: rgba(130,80,223,0.28); border-color: rgba(200,168,255,0.62); color: #d0b5ff; }
   a.pr-link:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
   a.pr-link .pr-icon { font-size: 10px; opacity: 0.85; line-height: 1; flex: none; }
   .pane-order-controls { display: inline-flex; align-items: center; gap: 8px; flex: none; }
@@ -785,7 +789,7 @@ function ensureCard(termId) {
 
   cards[termId] = { root: root, pre: pre, name: name, cwd: cwd, dot: dot, badge: badge,
     title: title,
-    prLink: prLink, head: head, chevron: chevron, orderControls: orderControls, killBtn: killBtn,
+    prLink: prLink, prIcon: prIcon, head: head, chevron: chevron, orderControls: orderControls, killBtn: killBtn,
     moveUpBtn: moveUpBtn, moveDownBtn: moveDownBtn };
   // 復活時を含め、現在の collapsed 状態を初期反映
   syncCollapseUI(cards[termId], termId);
@@ -932,9 +936,13 @@ function render(data) {
     // PR リンク（issue #53）。安全な http(s) URL のときだけ href にセットして表示、
     // そうでなければ href を空にして非表示にする。
     if (isSafeHttpUrl(t.apiPrUrl)) {
+      var prMerged = t.apiPrMerged === true;
       c.prLink.href = t.apiPrUrl;
       c.prLink.title = t.apiPrUrl;
       c.prLink.classList.add("show");
+      c.prLink.classList.toggle("merged", prMerged);
+      c.prLink.setAttribute("aria-label", prMerged ? "マージ済みのプルリクエストを開く" : "プルリクエストを開く");
+      c.prIcon.textContent = prMerged ? "✓" : "↗";
       c.title.href = t.apiPrUrl;
       c.title.target = "_blank";
       c.title.rel = "noopener noreferrer";
@@ -944,6 +952,9 @@ function render(data) {
       c.prLink.removeAttribute("href");
       c.prLink.removeAttribute("title");
       c.prLink.classList.remove("show");
+      c.prLink.classList.remove("merged");
+      c.prLink.setAttribute("aria-label", "プルリクエストを開く");
+      c.prIcon.textContent = "↗";
       c.title.removeAttribute("href");
       c.title.removeAttribute("target");
       c.title.removeAttribute("rel");

--- a/tests/e2e/mobile-title-link.smoke.spec.js
+++ b/tests/e2e/mobile-title-link.smoke.spec.js
@@ -264,3 +264,86 @@ test('モバイル: apiPrUrl が javascript: の場合はタイトルがリン�
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   }
 });
+
+test('モバイル: マージ済み PR リンクは紫表示とチェックアイコンに切り替わり、通常状態へ戻る', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForTermId(port, '1');
+
+    const prUrl = `http://127.0.0.1:${port}/?pr=137`;
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    let injectedTerm = {
+      termId: '1',
+      status: 'idle',
+      displayTitle: 'PR #137 モバイル merged',
+      apiPrUrl: prUrl,
+      apiPrMerged: true,
+      lastLines: '',
+    };
+
+    // /api/states を差し替え、モバイル renderer に apiPrMerged: true を直接流す。
+    // POST /api/set-title と renderer の間の状態反映は既存テストで担保済みなので、
+    // ここでは mobile.html の render() が states の apiPrMerged を UI に反映するかへ絞る。
+    await page.route(`http://127.0.0.1:${port}/api/states`, async (route) => {
+      const injected = {
+        terminals: {
+          '1': injectedTerm,
+        },
+        updatedAt: Date.now(),
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(injected),
+      });
+    });
+
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    const card = page.locator('.card').first();
+    await expect(card).toContainText('PR #137 モバイル merged', { timeout: 15_000 });
+    const prLink = card.locator('a.pr-link');
+    await expect(prLink).toBeVisible();
+
+    // apiPrMerged: true のときは PC 版 PR バッジと同じ意味論（.merged + ✓ + 専用 aria-label）。
+    await expect(prLink).toHaveClass(/\bmerged\b/);
+    await expect(prLink).toHaveAttribute('aria-label', 'マージ済みのプルリクエストを開く');
+    await expect(prLink.locator('.pr-icon')).toHaveText('✓');
+
+    // 次の描画で未マージ／URL 無効になった場合、古い merged 表示が残らないことも確認する。
+    injectedTerm = {
+      termId: '1',
+      status: 'idle',
+      displayTitle: 'PR #137 モバイル normal',
+      apiPrUrl: prUrl,
+      apiPrMerged: false,
+      lastLines: '',
+    };
+    await page.evaluate(() => poll());
+
+    await expect(prLink).not.toHaveClass(/\bmerged\b/);
+    await expect(prLink).toHaveAttribute('aria-label', 'プルリクエストを開く');
+    await expect(prLink.locator('.pr-icon')).toHaveText('↗');
+
+    injectedTerm = {
+      termId: '1',
+      status: 'idle',
+      displayTitle: 'PR #137 モバイル hidden',
+      apiPrUrl: '',
+      apiPrMerged: true,
+      lastLines: '',
+    };
+    await page.evaluate(() => poll());
+
+    await expect(prLink).not.toHaveClass(/\bmerged\b/);
+    await expect(prLink).toHaveAttribute('aria-label', 'プルリクエストを開く');
+    await expect(prLink.locator('.pr-icon')).toHaveText('↗');
+  } finally {
+    await browser.close();
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/e2e/stash-header.smoke.spec.js
+++ b/tests/e2e/stash-header.smoke.spec.js
@@ -219,6 +219,43 @@ test('格納カードのヘッダーが2段（タイトル行/操作行）にな
   }
 });
 
+test('格納カード: マージ済み PR バッジは格納後も紫表示とチェックアイコンを維持する', async () => {
+  const port = await getFreePort();
+  const { app, win, tmpRoot } = await launchApp(port);
+  try {
+    await waitForTermId(port, '1', true);
+
+    const prUrl = 'https://github.com/vektor-inc/vk-terminals/pull/137';
+    const setTitleRes = await postJson(port, '/api/set-title', {
+      termId: '1',
+      title: 'PR #137 マージ済み stash 確認',
+      prUrl,
+      prMerged: true,
+    });
+    expect(setTitleRes.status).toBe(200);
+    expect(setTitleRes.body?.prMerged).toBe(true);
+
+    // グリッド側でマージ済み表示になったペインを、実操作でサイドバーへ格納する。
+    const paneDomId = 'pane-1';
+    const gridPane = win.locator(`.pane[data-id="${paneDomId}"]`);
+    await expect(gridPane.locator('.pane-task-title-pr')).toHaveClass(/\bmerged\b/);
+    await gridPane.locator('.btn-stash').click();
+
+    await ensureSidebarOpen(win);
+    const stashItem = win.locator(`.stash-item[data-id="${paneDomId}"]`);
+    await expect(stashItem).toBeVisible({ timeout: 10_000 });
+
+    // renderStashItem() が apiPrMerged を渡し忘れると、ここで緑の通常 PR バッジに戻る。
+    const prBadge = stashItem.locator('.stash-item-title-row .pane-task-title-pr');
+    await expect(prBadge).toHaveClass(/\bmerged\b/);
+    await expect(prBadge).toHaveAttribute('aria-label', 'マージ済みのプルリクエストを開く（外部ブラウザ）');
+    await expect(prBadge.locator('.pane-task-title-pr-icon')).toHaveText('✓');
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
 test('格納カード: ▲▼で並べ替えできる（デグレ確認）', async () => {
   const port = await getFreePort();
   const { app, win, tmpRoot } = await launchApp(port);


### PR DESCRIPTION
## 概要

ペインのタイトルバーに表示される PR リンクのラベルは、PR がマージ済みのとき紫（`.merged`：紫背景・境界＋`✓` アイコン＋「マージ済みの…」aria-label）、未マージのとき緑になる仕様です。ところが **サイドバー格納時（stash）** と **モバイル版（`mobile.html`）** では、マージ済みでも緑のまま紫に切り替わりませんでした。この不具合を修正します。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/137

## 原因

コード起因の不具合が 2 箇所ありました（いずれも修正前コードで再現する e2e を追加し red→green で実証済み）。

1. **サイドバー格納時（`renderer/app.js`）**: `renderStashItem` / `updateStashItem` が共通描画関数 `renderTaskTitleContent(el, title, url, prUrl, prMerged)` を **第5引数 `prMerged` を渡さず** に呼んでいたため、格納時は常に未マージ扱い（緑）になっていた。グリッド側は `!!t.apiPrMerged` を渡しており正常。
2. **モバイル版（`renderer/mobile.html`）**: `a.pr-link` に緑スタイルしか無く、`render()` が `apiPrMerged` を反映していなかった。

## 変更内容

- `renderer/app.js`: 格納時の 2 箇所の `renderTaskTitleContent(...)` 呼び出しに第5引数 `!!t.apiPrMerged` を追加。表示ロジックは PC グリッドと同じ `renderer/prBadge.js` の `getPrBadgePresentation()` を共有するため、色・アイコン・aria-label が一元的に一致する。
- `renderer/mobile.html`: `a.pr-link.merged`（および `:active`）の紫スタイルを追加し、`render()` で `apiPrMerged === true` のとき `merged` クラス・`✓` アイコン・「マージ済みのプルリクエストを開く」aria-label に切替、未マージ・URL 無効時は通常表示へリセット。暗ヘッダ `var(--card)`（#1d2127）上で文字 `#c8a8ff` = 8.08:1、`:active` の `#d0b5ff` = 9.03:1 と WCAG 2.1 AA（4.5:1）を満たす。
- `tests/e2e/stash-header.smoke.spec.js` / `tests/e2e/mobile-title-link.smoke.spec.js`: 再現＋回帰テストを追加。
- `CHANGELOG.md`: 追記。

## テスト（確認手順）

### 前提
- VK Terminals を起動し、いずれかのペインに対し `POST /api/set-title` で `prUrl` と `prMerged: true` を送る（マージ済み PR ラベルを表示させる）。

### Before（修正前の再現）
1. マージ済み表示（グリッドで紫の `PR ✓` ラベル）になったペインを、サイドバーへ格納（stash）する。
   → **格納カード内の PR ラベルが緑（`PR ↗`）に戻ってしまう**（バグ）。
2. モバイル版（ブラウザで `GET /`）を開き、同じマージ済みペインのカードを見る。
   → **PR リンクが緑のまま**（バグ）。

### After（修正後の確認）
1. 同じ手順でペインを格納する。
   → 格納カード内の PR ラベルが **紫（`PR ✓`）を維持** する。aria-label は「マージ済みのプルリクエストを開く（外部ブラウザ）」。
2. モバイル版のカードを見る。
   → PR リンクが **紫（`PR ✓`）** で表示される。aria-label は「マージ済みのプルリクエストを開く」。
3. デグレ確認: `prMerged` を送らない／`prUrl` を空にすると、格納・モバイルとも **緑（`PR ↗`）へ正しく戻る**。

### 自動テスト
- `node --test tests/`（ユニット 104 件 PASS）
- `npx playwright test`（e2e 22 件 PASS。追加した stash / mobile の merged 検証を含む）

> 視覚（実際の紫表示・コントラスト）の最終確認は、レビューの e2e/UI フェーズでブラウザ実機確認します。

## レビュー
- 🔒 セキュリティ（安藤）: PASS（新たな注入シンクなし・URL ガード維持）
- 🎨 UX（植草）: PASS（3チャンネルで状態表現・コントラスト AA クリア）

@coderabbitai ignore

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/366