### PR TITLE
[ 仕様変更 ] モバイル版のペインプレビュー表示領域の高さを約70%に縮小

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [ 機能追加 ] モバイル版の最下部に VK Terminals のバージョンを表示（[#135](https://github.com/vektor-inc/vk-terminals/issues/135)）
+- [ 仕様変更 ] モバイル版のペインプレビュー表示領域の高さを約70%に縮小（[#139](https://github.com/vektor-inc/vk-terminals/issues/139)）
 - [ デザイン不具合修正 ] サイドバー格納時とモバイル版でマージ済み PR ラベルが紫にならず緑のままになる不具合を修正（[#137](https://github.com/vektor-inc/vk-terminals/issues/137)）
 
 ## 1.15.5

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -93,7 +93,7 @@
   .pane-order-button:disabled:active { background: #20242b; }
   pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; line-height: 1.5;
-    white-space: pre-wrap; word-break: break-word; min-height: 200px; max-height: min(50vh, 520px); overflow-y: auto;
+    white-space: pre-wrap; word-break: break-word; min-height: 140px; max-height: min(35vh, 364px); overflow-y: auto;
     -webkit-overflow-scrolling: touch; overscroll-behavior: contain;
     border-top: 1px solid var(--card-border); }
   .card.collapsed pre.lines, .card.collapsed .actions { display: none; }


### PR DESCRIPTION
## 概要

モバイル版（`renderer/mobile.html`）のペインプレビュー（ターミナル出力）表示領域 `pre.lines` の高さを、現状の約70%に縮小します。1画面あたりに表示されるペイン数を増やし、複数ペインの一覧性を高めることが目的です。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/139

## 変更内容

`renderer/mobile.html` の `pre.lines`（モバイル版のペイン出力表示エリア）の高さを一律約70%に縮小:

| プロパティ | 変更前 | 変更後 |
|---|---|---|
| `min-height` | `200px` | `140px` |
| `max-height` | `min(50vh, 520px)` | `min(35vh, 364px)` |

- いずれも変更前の 70%（200→140 / 520→364 / 50vh→35vh）で、比率を統一。
- `overflow-y: auto` 等のスクロール挙動・折り畳み挙動・タッチ領域は変更なし。
- ロジック（JS）・DOM 構造には一切変更なし。純粋な CSS 寸法変更。

## テスト（確認手順）

前提: モバイルページ（`mobile.html`）にアクセスできる状態にする（README のモバイルページ節参照）。実行中のペインが1つ以上ある状態が望ましい。

1. スマートフォン（または開発者ツールのモバイル表示）でモバイルページを開く。
2. 任意のペインカードを展開し、ターミナル出力表示エリア（`pre.lines`）の高さを確認する。
   → 出力が少ないカードでも表示エリアの最低高さが **約140px**（約6〜7行分）に収まる。以前（200px）より縦に短くなっている。
3. 出力が多いカードを展開する。
   → 表示エリアの最大高さが **画面高の35%または364pxのいずれか小さい方**に収まり、それを超える出力はエリア内スクロールで閲覧できる。以前（50vh / 520px）より縦に短くなっている。
4. 複数ペインがある状態で一覧を確認する。
   → 1画面に収まるペイン数が以前より増え、一覧性が向上している。
5. デグレ確認: カードの折り畳み（chevron タップ）で表示エリアが非表示になること、末尾追従スクロール（新着出力で最下部に追従）が従来どおり動作すること。

### スクリーンショット

Before / After のモバイル実機表示は、後続の e2e/UI 動作確認（麗美）で取得・添付します。

@coderabbitai ignore

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/368