### PR TITLE
[ 機能追加 ] 設定ダイアログのテキスト入力に owner/repo 等の形式チェックを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [ 機能追加 ] モバイル版の最下部に VK Terminals のバージョンを表示（[#135](https://github.com/vektor-inc/vk-terminals/issues/135)）
+- [ 機能追加 ] 設定ダイアログのテキスト入力に形式チェックを追加し、`<owner>/<repo>` 等の不正な形式のまま保存されるのを防止（[#140](https://github.com/vektor-inc/vk-terminals/issues/140)）
 - [ デザイン不具合修正 ] サイドバー格納時とモバイル版でマージ済み PR ラベルが紫にならず緑のままになる不具合を修正（[#137](https://github.com/vektor-inc/vk-terminals/issues/137)）
 
 ## 1.15.5

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -8,6 +8,7 @@ const { AGENT_ORDER, buildScene, resolveAgentStatesFromOutput } = require('./age
 const { matchesWaiting, nextWaitingState } = require('./waitingState');
 const { deriveStatus } = require('./statusState');
 const { getPrBadgePresentation } = require('./prBadge');
+const { isPatternValid } = require('./settingsValidation');
 
 // ─── xterm.css の注入 ─────────────────────────────────────────────────────────
 // xterm.css は index.html の相対パス <link> ではなく、Node のモジュール解決
@@ -2473,7 +2474,8 @@ function setupUsageBadge() {
 // "a.b" と "a_b" のような別キーがサニタイズ後に衝突しうるため、キー由来にしない）。
 function renderSettingsField(f, value, id) {
   const label = escText(f.label || f.key);
-  const help = f.help ? `<span class="settings-help">${escText(f.help)}</span>` : '';
+  // help には id を振り、text/number 分岐で input の aria-describedby から参照する。
+  const help = f.help ? `<span class="settings-help" id="${escAttr(id + '-help')}">${escText(f.help)}</span>` : '';
 
   if (f.type === 'boolean') {
     return `<div class="settings-row settings-row-check">
@@ -2528,9 +2530,14 @@ function renderSettingsField(f, value, id) {
 
   const inputType = f.type === 'number' ? 'number' : 'text';
   const ph = f.placeholder ? ` placeholder="${escAttr(f.placeholder)}"` : '';
+  // pattern 検証のエラー行と aria 関連付け。help があれば help id と error id を
+  // スペース区切りで両方指す（無ければ error id のみ）。
+  const errorId = escAttr(id + '-error');
+  const describedBy = escAttr(f.help ? `${id}-help ${id}-error` : `${id}-error`);
   return `<div class="settings-row">
     <label class="settings-label" for="${id}">${label}</label>${help}
-    <input type="${inputType}" id="${id}" value="${strVal}"${ph} spellcheck="false">
+    <input type="${inputType}" id="${id}" value="${strVal}"${ph} spellcheck="false" aria-describedby="${describedBy}">
+    <span class="settings-error" id="${errorId}" role="alert"></span>
   </div>`;
 }
 
@@ -2620,7 +2627,70 @@ async function openSettingsModal() {
     });
   });
 
+  // ─── pattern 検証（issue #140） ──────────────────────────────────────────────
+  // 検証対象は field.pattern（正規表現文字列）を持つフィールドのみ。type ではなく
+  // pattern の有無で判定することで、text/number など type を問わず汎用的に扱う。
+  const validatable = entries.filter(
+    ({ field }) => typeof field.pattern === 'string' && field.pattern !== ''
+  );
+
+  // 1 フィールドの検証結果を DOM に反映する。valid かどうかを返す。
+  // - valid: aria-invalid を外し、エラー文をクリア（赤枠も CSS 側で解除される）。
+  // - invalid: aria-invalid="true" を付与し、invalidMessage（無ければ汎用文）を表示。
+  //   invalidMessage は textContent で流し込むため HTML として解釈されない（XSS 安全）。
+  const applyFieldValidity = (field, id) => {
+    const input = modal.querySelector('#' + id);
+    const errEl = modal.querySelector('#' + id + '-error');
+    if (!input) return true;
+    const valid = isPatternValid(field.pattern, input.value);
+    if (valid) {
+      input.removeAttribute('aria-invalid');
+      if (errEl) errEl.textContent = '';
+    } else {
+      input.setAttribute('aria-invalid', 'true');
+      if (errEl) errEl.textContent = field.invalidMessage || '入力形式が正しくありません';
+    }
+    return valid;
+  };
+
+  // エラー表示を一旦消す（保存時の再判定前リセットに使う）。
+  const clearFieldValidity = (field, id) => {
+    const input = modal.querySelector('#' + id);
+    const errEl = modal.querySelector('#' + id + '-error');
+    if (input) input.removeAttribute('aria-invalid');
+    if (errEl) errEl.textContent = '';
+  };
+
+  // "優しく遅らせ、素早く許す": 打鍵中は警告せず blur で初回検証。エラーが付いた後だけ
+  // input イベントで再検証し、valid になれば即解除する。
+  for (const { field, id } of validatable) {
+    const input = modal.querySelector('#' + id);
+    if (!input) continue;
+    input.addEventListener('blur', () => { applyFieldValidity(field, id); });
+    input.addEventListener('input', () => {
+      if (input.getAttribute('aria-invalid') === 'true') applyFieldValidity(field, id);
+    });
+  }
+
   modal.querySelector('.settings-save').addEventListener('click', async () => {
+    // 保存前の検証ゲート: 全エラー表示を一旦クリアしてから対象を一括再判定する。
+    for (const { field, id } of validatable) clearFieldValidity(field, id);
+    let firstInvalid = null;
+    for (const { field, id } of validatable) {
+      const valid = applyFieldValidity(field, id);
+      if (!valid && !firstInvalid) firstInvalid = modal.querySelector('#' + id);
+    }
+    // 1 つでも不一致なら settings:save を呼ばず中断し、最初の不正欄へフォーカスする。
+    if (firstInvalid) {
+      msg.textContent = '入力内容に問題があります';
+      msg.className = 'settings-msg err';
+      firstInvalid.focus();
+      if (typeof firstInvalid.scrollIntoView === 'function') {
+        firstInvalid.scrollIntoView({ block: 'nearest' });
+      }
+      return;
+    }
+
     const out = {};
     for (const { field, id } of entries) {
       const input = modal.querySelector('#' + id);

--- a/renderer/settingsValidation.js
+++ b/renderer/settingsValidation.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// 設定ダイアログのテキスト系フィールドを pattern（正規表現文字列）で検証する純粋関数。
+// descriptor 側（vk-orchestrator）が text フィールドに付与する `pattern` を GUI 側で
+// 消費し、保存前に形式チェックする。DOM に依存しないためユニットテストしやすい。
+//
+// 判定方針:
+//   - pattern が無い（文字列でない/空文字）フィールドは常に valid（後方互換）。
+//   - 値は trim してから検証する。反映先（保存処理側）が trim 済みの値を見るため、
+//     生値のまま検証すると前後空白のせいで実際の反映結果と食い違う。
+//   - trim 後が空文字なら valid 扱い（空欄は許容。必須チェックは本関数の責務外）。
+//   - pattern が壊れた正規表現でも保存不能にしない（fail-open）。生成に失敗したら
+//     警告だけ出して valid として扱う。
+//
+// @param {string} pattern  検証に使う正規表現文字列（descriptor 由来）。
+// @param {*} rawValue      入力欄の生値（通常は input.value）。
+// @return {boolean}        検証を通れば true。
+function isPatternValid(pattern, rawValue) {
+  // pattern を持たないフィールドは検証対象外。
+  if (typeof pattern !== 'string' || pattern === '') return true;
+
+  // 反映先が trim 済みの値を見るため、検証も trim 後の値で行う。
+  const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+
+  // 空欄は許容（打鍵前・未入力を弾かない）。
+  if (value === '') return true;
+
+  let re;
+  try {
+    re = new RegExp(pattern);
+  } catch (_e) {
+    // 壊れた pattern で保存不能にならないよう valid 扱い（fail-open）。
+    // 環境によっては console が無いこともあるため存在チェックしてから警告する。
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[settings] 不正な pattern のため検証をスキップしました:', pattern);
+    }
+    return true;
+  }
+
+  return re.test(value);
+}
+
+module.exports = {
+  isPatternValid,
+};

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -292,6 +292,14 @@ html, body {
   color: #8b949e;
   font-size: 12px;
 }
+.settings-error {
+  color: #f85149;
+  font-size: 12px;
+}
+/* 空のエラー行は余白を作らないよう非表示にする（flex gap の影響も避ける）。 */
+.settings-error:empty {
+  display: none;
+}
 .settings-row input[type="text"],
 .settings-row input[type="number"],
 .settings-row input[type="password"],
@@ -326,6 +334,11 @@ html, body {
 .settings-row textarea {
   resize: vertical;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+/* pattern 検証エラー時の赤枠。focus 時の青枠より前に置き、同詳細度なら後勝ちの
+   ソース順で focus（青）が勝つようにする（入力中は青、blur 後の未focusで赤）。 */
+.settings-row input[aria-invalid="true"] {
+  border-color: #f85149;
 }
 .settings-row input:focus,
 .settings-row select:focus,

--- a/tests/e2e/settings-pattern-validation.smoke.spec.js
+++ b/tests/e2e/settings-pattern-validation.smoke.spec.js
@@ -1,0 +1,232 @@
+const { test, expect, _electron } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// 空きポートを取得する（他の e2e と同様、API サーバ用に固定ポート衝突を避ける）。
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+// Electron アプリを起動する（--no-claude でターミナル起動を抑止）。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-settings-pattern-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+    },
+  });
+  const win = await app.firstWindow();
+  return { app, win, tmpRoot };
+}
+
+// renderer の ipcRenderer.invoke を差し替え、pattern 付き descriptor を返させる。
+// app.js は `const { ipcRenderer } = require('electron')` で同一のモジュールオブジェクトを
+// 参照しているため、そのオブジェクトの invoke を上書きすれば openSettingsModal 内の
+// 呼び出しにも効く。settings:save は成功を返しつつ payload を window に記録する。
+async function installMockDescriptor(win) {
+  await win.evaluate(() => {
+    const { ipcRenderer } = require('electron');
+    // <owner>/<repo> 形式（親 vk-orchestrator が付与する pattern の代表例）。
+    const REPO_PATTERN = '^[^/\\s]+/[^/\\s]+$';
+    const desc = {
+      available: true,
+      title: 'テスト設定',
+      note: '',
+      targetPath: '/tmp/mock-settings.json',
+      appVersion: '0.0.0-test',
+      groups: [{
+        label: 'テストグループ',
+        fields: [
+          {
+            key: 'repo',
+            label: 'レビュー用アセットリポジトリ',
+            type: 'text',
+            help: 'owner/repo 形式で入力してください',
+            placeholder: 'vektor-inc/task-queue',
+            pattern: REPO_PATTERN,
+            invalidMessage: 'owner/repo の形式で入力してください（例: vektor-inc/task-queue）',
+          },
+          {
+            // pattern を持たない従来フィールド（後方互換の確認用）。
+            key: 'legacy',
+            label: '従来フィールド',
+            type: 'text',
+            help: '検証なし',
+          },
+        ],
+      }],
+      values: { repo: '', legacy: '' },
+    };
+    window.__savedPayloads = [];
+    ipcRenderer.invoke = (channel, payload) => {
+      if (channel === 'settings:describe') return Promise.resolve(desc);
+      if (channel === 'settings:save') {
+        window.__savedPayloads.push(payload);
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(null);
+    };
+  });
+}
+
+// フィールド id は描画順採番（repo=0, legacy=1）。
+const REPO_ID = '#set-field-0';
+const REPO_ERR = '#set-field-0-error';
+const LEGACY_ID = '#set-field-1';
+const INVALID_MSG = 'owner/repo の形式で入力してください（例: vektor-inc/task-queue）';
+
+test.describe.serial('設定ダイアログの pattern 形式チェック（issue #140）', () => {
+  let app;
+  let win;
+  let tmpRoot;
+
+  test.beforeAll(async () => {
+    const port = await getFreePort();
+    ({ app, win, tmpRoot } = await launchApp(port));
+    await win.waitForSelector('#sidebar', { state: 'attached' });
+  });
+
+  test.afterAll(async () => {
+    if (app) await app.close();
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  // 各テストの前にモックを入れ直し、設定モーダルを開き直す（DOM を毎回まっさらに）。
+  test.beforeEach(async () => {
+    await installMockDescriptor(win);
+    await win.evaluate(() => window.openSettingsModal());
+    await win.waitForSelector('.settings-modal', { state: 'visible' });
+    await win.waitForSelector(REPO_ID, { state: 'visible' });
+  });
+
+  // 各テストの後に Escape でモーダルを閉じる（次テストで再オープンできるように）。
+  test.afterEach(async () => {
+    await win.keyboard.press('Escape');
+    await win.waitForSelector('.settings-modal', { state: 'detached' }).catch(() => {});
+  });
+
+  test('1 & 6: 不正形式を blur すると赤枠＋エラー文＋aria が付く', async () => {
+    // 初期状態: 空エラー行は display:none（余白を作らない）。
+    await expect(win.locator(REPO_ERR)).toBeHidden();
+
+    // 不正形式を入力して blur。
+    await win.locator(REPO_ID).fill('foobar');
+    await win.locator(REPO_ID).blur();
+
+    // aria-invalid="true"（赤枠の CSS トリガ）が付く。
+    await expect(win.locator(REPO_ID)).toHaveAttribute('aria-invalid', 'true');
+    // 直下にエラー行が role="alert" で invalidMessage を表示。
+    const err = win.locator(REPO_ERR);
+    await expect(err).toBeVisible();
+    await expect(err).toHaveText(INVALID_MSG);
+    await expect(err).toHaveAttribute('role', 'alert');
+    // aria-describedby が help と error の両方を関連付けている。
+    await expect(win.locator(REPO_ID)).toHaveAttribute(
+      'aria-describedby', 'set-field-0-help set-field-0-error'
+    );
+    // 赤枠が実際に適用されているか（computed border-color を確認）。
+    const borderColor = await win.locator(REPO_ID).evaluate(
+      (el) => getComputedStyle(el).borderTopColor
+    );
+    // #f85149 = rgb(248, 81, 73)
+    expect(borderColor).toBe('rgb(248, 81, 73)');
+  });
+
+  test('2: 不正なまま保存すると保存されず、総括メッセージ＋最初の不正欄へフォーカス', async () => {
+    await win.locator(REPO_ID).fill('foobar');
+    await win.locator('.settings-save').click();
+
+    // settings:save は呼ばれない（保存中断）。
+    const saved = await win.evaluate(() => window.__savedPayloads.length);
+    expect(saved).toBe(0);
+    // フッターに総括メッセージ。
+    await expect(win.locator('.settings-msg')).toHaveText('入力内容に問題があります');
+    await expect(win.locator('.settings-msg')).toHaveClass(/err/);
+    // 最初の不正欄にフォーカスが移動。
+    const focusedId = await win.evaluate(() => document.activeElement && document.activeElement.id);
+    expect(focusedId).toBe('set-field-0');
+    // 保存押下で検証されたため赤枠＋エラー文も出ている。
+    await expect(win.locator(REPO_ID)).toHaveAttribute('aria-invalid', 'true');
+    await expect(win.locator(REPO_ERR)).toHaveText(INVALID_MSG);
+  });
+
+  test('3: 正しい形式に直すと入力中に即解除され、保存が通る', async () => {
+    // まず不正にして blur でエラーを付ける。
+    await win.locator(REPO_ID).fill('foobar');
+    await win.locator(REPO_ID).blur();
+    await expect(win.locator(REPO_ID)).toHaveAttribute('aria-invalid', 'true');
+
+    // 正しい形式に打ち直す（fill は input イベントを発火 → 即再検証で解除）。
+    await win.locator(REPO_ID).fill('vektor-inc/vk-terminals');
+    // 赤枠（aria-invalid）が外れ、エラー文が消える。
+    await expect(win.locator(REPO_ID)).not.toHaveAttribute('aria-invalid', 'true');
+    await expect(win.locator(REPO_ERR)).toBeHidden();
+
+    // 保存が通る。
+    await win.locator('.settings-save').click();
+    await expect(win.locator('.settings-msg')).toHaveText('保存しました');
+    const payload = await win.evaluate(() => window.__savedPayloads[window.__savedPayloads.length - 1]);
+    expect(payload.repo).toBe('vektor-inc/vk-terminals');
+  });
+
+  test('4: 空欄は警告されず保存できる（空欄許容）', async () => {
+    // repo を空欄のまま blur しても警告されない。
+    await win.locator(REPO_ID).fill('');
+    await win.locator(REPO_ID).blur();
+    await expect(win.locator(REPO_ID)).not.toHaveAttribute('aria-invalid', 'true');
+    await expect(win.locator(REPO_ERR)).toBeHidden();
+
+    // 保存が通る。
+    await win.locator('.settings-save').click();
+    await expect(win.locator('.settings-msg')).toHaveText('保存しました');
+    const payload = await win.evaluate(() => window.__savedPayloads[window.__savedPayloads.length - 1]);
+    expect(payload.repo).toBe('');
+  });
+
+  test('5: pattern を持たない従来フィールドは無検証（後方互換）', async () => {
+    // 従来フィールドに、repo pattern には合わない任意の値を入れて blur。
+    await win.locator(LEGACY_ID).fill('foobar-not-a-repo');
+    await win.locator(LEGACY_ID).blur();
+    // 検証対象外なので aria-invalid は付かない。
+    await expect(win.locator(LEGACY_ID)).not.toHaveAttribute('aria-invalid', 'true');
+    await expect(win.locator('#set-field-1-error')).toBeHidden();
+
+    // repo は空欄のまま（valid）なので保存が通り、legacy 値もそのまま保存される。
+    await win.locator('.settings-save').click();
+    await expect(win.locator('.settings-msg')).toHaveText('保存しました');
+    const payload = await win.evaluate(() => window.__savedPayloads[window.__savedPayloads.length - 1]);
+    expect(payload.legacy).toBe('foobar-not-a-repo');
+  });
+});

--- a/tests/settingsValidation.test.js
+++ b/tests/settingsValidation.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isPatternValid } = require('../renderer/settingsValidation');
+
+// <owner>/<repo> 形式を要求する代表的な pattern。
+const REPO_PATTERN = '^[^/\\s]+/[^/\\s]+$';
+
+test('isPatternValid: pattern 未指定は常に valid（後方互換）', () => {
+  assert.equal(isPatternValid(undefined, 'anything'), true);
+  assert.equal(isPatternValid(null, 'anything'), true);
+  assert.equal(isPatternValid('', 'anything'), true);
+});
+
+test('isPatternValid: trim 後が空なら valid（空欄許容）', () => {
+  assert.equal(isPatternValid(REPO_PATTERN, ''), true);
+  assert.equal(isPatternValid(REPO_PATTERN, '   '), true);
+  assert.equal(isPatternValid(REPO_PATTERN, undefined), true);
+});
+
+test('isPatternValid: pattern に一致する値は valid', () => {
+  assert.equal(isPatternValid(REPO_PATTERN, 'vektor-inc/vk-terminals'), true);
+});
+
+test('isPatternValid: pattern に一致しない値は invalid', () => {
+  assert.equal(isPatternValid(REPO_PATTERN, 'vk-terminals'), false);
+  assert.equal(isPatternValid(REPO_PATTERN, 'a/b/c'), false);
+});
+
+test('isPatternValid: 検証は trim 後の値で行う（前後空白は無視）', () => {
+  // 生値には前後空白があるが、trim 後 'vektor-inc/vk-terminals' は一致する。
+  assert.equal(isPatternValid(REPO_PATTERN, '  vektor-inc/vk-terminals  '), true);
+});
+
+test('isPatternValid: 壊れた pattern は fail-open で valid 扱い', () => {
+  // 不正な正規表現（未閉じの括弧）でも保存不能にしない。
+  assert.equal(isPatternValid('([', 'anything'), true);
+});


### PR DESCRIPTION
## 概要

設定モーダル（設定ダイアログ）の `text` 型フィールドは、`number`/`json`/`select` と異なり保存時のバリデーション・エラー表示を持たず、`<owner>/<repo>` のような厳密な形式を要求する項目に不正形式を入力しても「保存できたように見えて、実際は反映先で無言に弾かれる」状態（silent-drop）になっていました。

本 PR で、descriptor フィールドが持つ `pattern`（文字列）/ `invalidMessage` を GUI 側で消費し、保存時に形式チェックして不正なら保存を弾き、その場にエラーを表示するようにします。descriptor 側（`pattern`/`invalidMessage` の提供・受理条件の単一ソース化）は親 issue の vk-orchestrator 側 PR で対応します。

## 変更内容

- `renderer/settingsValidation.js`（新規）: 純粋関数 `isPatternValid(pattern, rawValue)` を追加（DOM 非依存で単体テスト可能）。`pattern` 未指定は常に valid（後方互換）／`trim()` 後の値で検証／`trim()` 後が空なら valid（空欄許容）／`new RegExp` を try/catch で生成し、壊れた `pattern` は `console.warn` のみで valid 扱い（fail-open）。
- `renderer/app.js`:
  - `renderSettingsField()` の text/number 分岐に、input 直下のエラー行 `<span class="settings-error" role="alert">` を追加。input に `aria-describedby`（help + error）と、help 要素に id を付与してスクリーンリーダーへ関連付け。
  - 保存ハンドラ: `pattern` を持つフィールドのみ対象に、保存押下時に **`input.value.trim()`** で一括検証。1つでも不一致なら保存を中断し、フッターに総括メッセージ、最初の不正欄へ `focus()` + `scrollIntoView`。
  - 検証タイミング: blur で初回検証（空欄は警告しない）、エラー付与後は input イベントで再検証し valid になれば即解除（"優しく遅らせ、素早く許す"）。
- `renderer/style.css`: `.settings-error`（既存 err 赤 `#f85149`・help と同じ 12px）、`.settings-error:empty { display:none }`、`input[aria-invalid="true"]` の赤枠を追加（focus 時の青は既存ルールがソース順で勝つ）。
- `tests/settingsValidation.test.js`（新規）: `isPatternValid` の 6 ケース。

## テスト（確認手順）

**前提**: descriptor 側（vk-orchestrator）で text フィールドに `pattern`（例 `^[^/\s]+/[^/\s]+$`）と `invalidMessage` を付けた状態のビルドで確認します（親 PR とのマージ後、または手元で descriptor に一時的に付与）。

1. VK Terminals を起動し、設定モーダルを開く。
   → `pattern` 付きフィールド（例「レビュー用アセットリポジトリ」）に、入力欄の下にエラー表示用の余白が無い（空エラー行は非表示）ことを確認。
2. 当該欄に不正形式（例 `foobar`）を入力し、別の欄へ移動（blur）する。
   → 入力欄が赤枠になり、直下に `invalidMessage`（例「owner/repo の形式で入力してください（例: vektor-inc/task-queue）」）が赤字で表示される。
3. そのまま「保存」を押す。
   → 保存されず、フッターに「入力内容に問題があります」が表示され、最初の不正欄にフォーカスが移動する。
4. 正しい形式（例 `vektor-inc/vk-terminals`）に打ち直す。
   → 入力中に赤枠・エラー文が即座に消える。再度「保存」で保存が通る。
5. 当該欄を空欄にして保存する。
   → 警告されず保存できる（空欄許容）。
6. `pattern` を持たない従来フィールドに任意の値を入れて保存する。
   → 従来どおり無検証で保存できる（後方互換）。

**アクセシビリティ**: 不正時に input へ `aria-invalid="true"`、エラー行は `role="alert"`、`aria-describedby` で help + error を関連付け。色のみに依存せずテキストでもエラーを提示。

**自動テスト**: `node --test tests/` で全 110 件 pass（既存 104 + 新規 6）。

## デグレ確認

- `pattern` 未提供のフィールドは従来どおり無検証（旧 descriptor + 新 GUI でも挙動不変）。
- boolean / json / select / password の各フィールド描画・保存に影響がないこと。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/140
親 issue: https://github.com/vektor-inc/vk-orchestrator/issues/89

@coderabbitai ignore
