### PR TITLE
[ 機能追加 ] 新規ペインの初期ディレクトリと Claude 自動起動有無を設定できる項目を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [ 機能追加 ] モバイル版の最下部に VK Terminals のバージョンを表示（[#135](https://github.com/vektor-inc/vk-terminals/issues/135)）
 - [ 機能追加 ] 設定ダイアログのテキスト入力に形式チェックを追加し、`<owner>/<repo>` 等の不正な形式のまま保存されるのを防止（[#140](https://github.com/vektor-inc/vk-terminals/issues/140)）
+- [ 機能追加 ] UI から開く新規ペインの初期ディレクトリと Claude Code 自動起動有無を設定できる項目を追加（[#143](https://github.com/vektor-inc/vk-terminals/issues/143)）
 - [ 仕様変更 ] モバイル版のペインプレビュー表示領域の高さを約70%に縮小（[#139](https://github.com/vektor-inc/vk-terminals/issues/139)）
 - [ デザイン不具合修正 ] サイドバー格納時とモバイル版でマージ済み PR ラベルが紫にならず緑のままになる不具合を修正（[#137](https://github.com/vektor-inc/vk-terminals/issues/137)）
 

--- a/main.js
+++ b/main.js
@@ -500,12 +500,15 @@ app.on('before-quit', () => {
 // renderer がエージェントルーム（issue #58）の有効/無効を知るための設定取得。
 //   本来は config.json の `agentroom: true` のときだけ各ペイン下部にアコーディオンを
 //   表示するが、issue #70 でエージェントルーム（β）を一旦無効化するため、config.json の
-//   値によらず常に false を返す。復帰時は下記を
-//     const config = loadUserConfig();
-//     return { agentroom: config.agentroom === true };
-//   に戻せばよい。
+//   値によらず agentroom は常に false を返す。復帰時は agentroom の返却値だけ
+//   `config.agentroom === true` に戻せばよい。
 ipcMain.handle('app:get-config', () => {
-  return { agentroom: false };
+  const config = loadUserConfig();
+  return {
+    agentroom: false,
+    newPaneStartupDir: typeof config.newPaneStartupDir === 'string' ? config.newPaneStartupDir.trim() : '',
+    newPaneAutoLaunchClaude: config.newPaneAutoLaunchClaude === true,
+  };
 });
 
 // 使用状況の取得（issue #69 → #73 で公式 API 主・トランスクリプト従の統一構造に変更）。
@@ -541,7 +544,7 @@ function resolveOwnConfigTargetPath() {
 }
 
 // env 未指定（スタンドアロン起動）時に使う組み込みディスクリプタ。VK Terminals 自身の
-// config.json（apiHost / initialCommand / agentroom / additionalPanes）を GUI から編集できる。
+// config.json（apiHost / initialCommand / 新規ペイン設定 / agentroom / additionalPanes）を GUI から編集できる。
 function builtinSettingsDescriptor() {
   return {
     title: 'VK Terminals 設定',
@@ -552,7 +555,9 @@ function builtinSettingsDescriptor() {
         label: '基本',
         fields: [
           { key: 'apiHost',        label: 'API ホスト',            type: 'text',    help: '既定 127.0.0.1' },
-          { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: '1 ペイン目で claude 起動直後に自動実行させたいコマンドがあれば記入してください。' },
+          { key: 'newPaneStartupDir', label: '新規ペインを開く時の初期ディレクトリ', type: 'text', help: '値が保存されている場合、新規ペインを開いた時にそのディレクトリでターミナル（及び Claude）が起動します。' },
+          { key: 'newPaneAutoLaunchClaude', label: '新規ペイン（子ターミナル）を開く時に自動的に Claude Code を起動する', type: 'boolean', default: false, help: 'チェックが入っている場合、新規ペインを開いた時に自動的に Claude Code が起動します。オフの場合は素のターミナルで起動します。' },
+          { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: 'Claude Code で起動する設定の場合、最初のペインで Claude 起動直後に自動実行させたいコマンドがあれば記入してください。毎日最初に実行するコマンドの入力を省略するための機能です。' },
           // showUsage（issue #69）は opt-out（既定 ON）。default:true で「未設定 boolean が
           // 保存時に false になる」問題を避ける（settings:describe / settings:save が default 尊重）。
           { key: 'showUsage',      label: 'トークン使用量を表示',   type: 'boolean', default: true, help: 'Claude の利用状況（セッション% / 週間制限%）をサイドバーの「Claude使用量」・モバイルページに表示します。' },
@@ -743,7 +748,14 @@ ipcMain.handle('settings:save', (event, incoming) => {
 ipcMain.handle('terminal:create', (event, cwd, options = {}) => {
   const id = String(nextId++);
   const shell = process.env.SHELL || (process.platform === 'win32' ? (process.env.COMSPEC || 'powershell.exe') : '/bin/zsh');
-  const resolvedCwd = cwd || process.env.HOME || process.env.USERPROFILE || os.tmpdir();
+  let resolvedCwd = cwd || process.env.HOME || process.env.USERPROFILE || os.tmpdir();
+  try {
+    if (!fs.existsSync(resolvedCwd) || !fs.statSync(resolvedCwd).isDirectory()) {
+      resolvedCwd = process.env.HOME || process.env.USERPROFILE || os.tmpdir();
+    }
+  } catch (_e) {
+    resolvedCwd = process.env.HOME || process.env.USERPROFILE || os.tmpdir();
+  }
 
   // `options.noClaude` が明示指定されていればそれを優先、未指定なら CLI フラグの値を継承。
   // `noClaude` が true の場合、claude を自動起動せず素のシェルとして開く。

--- a/main.js
+++ b/main.js
@@ -555,7 +555,7 @@ function builtinSettingsDescriptor() {
         label: '基本',
         fields: [
           { key: 'apiHost',        label: 'API ホスト',            type: 'text',    help: '既定 127.0.0.1' },
-          { key: 'newPaneStartupDir', label: '新規ペインを開く時の初期ディレクトリ', type: 'text', help: '値が保存されている場合、新規ペインを開いた時にそのディレクトリでターミナル（及び Claude）が起動します。' },
+          { key: 'newPaneStartupDir', label: '新規ペインを開く時の初期ディレクトリ', type: 'text', placeholder: '/path/to/project', help: '新規ペインを開く時の作業ディレクトリを絶対パスで指定します。「Claude Code を自動起動する」設定が有効な場合は Claude もこのディレクトリで起動します。未入力の場合、または存在しないパスの場合はホームディレクトリで起動します。' },
           { key: 'newPaneAutoLaunchClaude', label: '新規ペイン（子ターミナル）を開く時に自動的に Claude Code を起動する', type: 'boolean', default: false, help: 'チェックが入っている場合、新規ペインを開いた時に自動的に Claude Code が起動します。オフの場合は素のターミナルで起動します。' },
           { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: 'Claude Code で起動する設定の場合、最初のペインで Claude 起動直後に自動実行させたいコマンドがあれば記入してください。毎日最初に実行するコマンドの入力を省略するための機能です。' },
           // showUsage（issue #69）は opt-out（既定 ON）。default:true で「未設定 boolean が

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -74,6 +74,10 @@ const RUNNING_INPUT_GUARD_MS = 200;
 // config.json の `agentroom: true` のときだけ各ペイン下部にアコーディオンを表示する。
 // 値は起動時に main プロセス（app:get-config）から取得する。
 let agentRoomEnabled = false;
+// 新規ペイン（＋ / 空グリッド「新規ペインを追加」）の既定挙動（issue #143）。
+// 値は起動時に main（app:get-config）から取得する。設定反映には再起動が必要（設定パネルの note 参照）。
+let newPaneStartupDir = '';
+let newPaneAutoLaunchClaude = false;
 // HTTP API（POST /api/agentroom）由来のルーム状態を、この TTL を超えたら「古い」と判断して
 // PTY 出力ベースのフォールバック表示に切り替える（ms）。
 const AGENTROOM_API_TTL_MS = 90000;
@@ -1612,7 +1616,7 @@ function renderEmptyGrid() {
   addBtn.className = 'grid-empty-btn';
   addBtn.textContent = '新規ペインを追加';
   addBtn.setAttribute('aria-label', '新規ペインを追加');
-  addBtn.addEventListener('click', () => { addPane(); });
+  addBtn.addEventListener('click', () => { addPane(newPaneStartupDir || null, { noClaude: !newPaneAutoLaunchClaude }); });
 
   const openBtn = document.createElement('button');
   openBtn.type = 'button';
@@ -1899,7 +1903,7 @@ function renderLeaf(node) {
   });
   header.querySelector('.btn-split').addEventListener('click', e => {
     e.stopPropagation();
-    splitPane(node.id, 'h');
+    splitPane(node.id, 'h', newPaneStartupDir || null, { noClaude: !newPaneAutoLaunchClaude });
   });
   header.querySelector('.btn-close').addEventListener('click', e => {
     e.stopPropagation();
@@ -2722,6 +2726,8 @@ async function initApp() {
   try {
     const cfg = await ipcRenderer.invoke('app:get-config');
     agentRoomEnabled = !!(cfg && cfg.agentroom);
+    newPaneStartupDir = (cfg && typeof cfg.newPaneStartupDir === 'string') ? cfg.newPaneStartupDir : '';
+    newPaneAutoLaunchClaude = !!(cfg && cfg.newPaneAutoLaunchClaude);
   } catch (_e) { /* 取得失敗時は無効のまま */ }
 
   // Dispose any existing terminals

--- a/tests/e2e/new-pane-startup.smoke.spec.js
+++ b/tests/e2e/new-pane-startup.smoke.spec.js
@@ -1,0 +1,234 @@
+const { test, expect, _electron } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// 空きポートを取得する（他の e2e と同様、API サーバ用の固定ポート衝突を避ける）。
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+// 指定した config で Electron アプリを起動する（--no-claude で claude 自動起動を抑止）。
+// tmpHome を HOME に割り当て、その下の .vk-terminals/config.json に設定を書き込む。
+// これにより settings:describe は組み込みディスクリプタ（VK Terminals 自身の設定）を返す。
+async function launchApp(port, config) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-newpane-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify(config), 'utf8');
+
+  // 親環境（vk-orchestrator 等）の VK_TERMINALS_SETTINGS が漏れ込むと外部ディスクリプタが
+  // 使われてしまうため、明示的に外して VK Terminals 自身の組み込みディスクリプタを使わせる。
+  const childEnv = {
+    ...process.env,
+    HOME: tmpHome,
+    USERPROFILE: tmpHome,
+    VK_TERMINALS_API_PORT: String(port),
+  };
+  delete childEnv.VK_TERMINALS_SETTINGS;
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: childEnv,
+  });
+  const win = await app.firstWindow();
+  return { app, win, tmpRoot, tmpHome };
+}
+
+// 最小構成の config。個別テストで必要なキーだけ上書きする。
+const BASE_CONFIG = { apiHost: '127.0.0.1', initialCommand: '', agentroom: false, additionalPanes: [] };
+
+test.describe('新規ペイン起動設定（issue #143 / PR #144）', () => {
+  // ── (1) 設定パネルに新規ペイン設定が表示される ──────────────────────────────
+  // 組み込みディスクリプタの描画順は apiHost=0 / newPaneStartupDir=1 /
+  // newPaneAutoLaunchClaude=2 / initialCommand=3。field id は描画順採番なので、
+  // 「API ホストの直下」に 2 項目が並ぶことを id の連番で担保する。
+  test('設定パネルに新規ペイン設定が API ホストの直下に表示される', async () => {
+    const port = await getFreePort();
+    const { app, win, tmpRoot } = await launchApp(port, BASE_CONFIG);
+    try {
+      await win.waitForSelector('#sidebar', { state: 'attached' });
+      // 設定モーダルを開く（組み込みディスクリプタで描画される）。
+      await win.evaluate(() => window.openSettingsModal());
+      await win.waitForSelector('.settings-modal', { state: 'visible' });
+      await win.waitForSelector('#set-field-1', { state: 'visible' });
+
+      // 直上が API ホスト（field-0）であること（＝「API ホストの直下」に並ぶ）。
+      await expect(win.locator('label[for="set-field-0"]')).toHaveText('API ホスト');
+
+      // (1) 新規ペイン初期ディレクトリ（text）: ラベル・placeholder・help を確認。
+      const dirInput = win.locator('#set-field-1');
+      await expect(dirInput).toBeVisible();
+      await expect(dirInput).toHaveAttribute('type', 'text');
+      await expect(dirInput).toHaveAttribute('placeholder', '/path/to/project');
+      await expect(win.locator('label[for="set-field-1"]'))
+        .toHaveText('新規ペインを開く時の初期ディレクトリ');
+      // help に「未入力／存在しないパスはホームで起動」の旨が含まれること。
+      await expect(win.locator('#set-field-1-help')).toContainText('ホームディレクトリで起動');
+
+      // (2) Claude 自動起動（boolean → checkbox）: ラベル・型・既定オフ・help を確認。
+      const claudeCheck = win.locator('#set-field-2');
+      await expect(claudeCheck).toBeVisible();
+      await expect(claudeCheck).toHaveAttribute('type', 'checkbox');
+      // boolean は <label class="settings-check"> 内の <span class="settings-label"> がラベル。
+      await expect(
+        win.locator('label.settings-check', { has: win.locator('#set-field-2') })
+          .locator('.settings-label')
+      ).toHaveText('新規ペイン（子ターミナル）を開く時に自動的に Claude Code を起動する');
+      // 既定 false（default:false）で未チェック表示。
+      await expect(claudeCheck).not.toBeChecked();
+      await expect(win.locator('#set-field-2-help')).toContainText('素のターミナル');
+
+      // (3) その下に初期コマンド（field-3）が続く（＝2 項目が API ホストと初期コマンドの間に入る）。
+      await expect(win.locator('label[for="set-field-3"]')).toHaveText('初期コマンド');
+    } finally {
+      await app.close();
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  // ── (2) terminal:create の cwd 解決（PR で追加した実在チェック） ──────────────
+  test('terminal:create は実在ディレクトリを使い、不正パスは HOME にフォールバックする', async () => {
+    const port = await getFreePort();
+    const { app, win, tmpRoot, tmpHome } = await launchApp(port, BASE_CONFIG);
+    // 実在する一時ディレクトリ（cwd として渡す）。
+    const existDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-exist-'));
+    try {
+      await win.waitForSelector('#sidebar', { state: 'attached' });
+
+      // (A) 実在ディレクトリを渡すと、resolvedCwd はそのパスのまま返る。
+      const okCwd = await win.evaluate(async (dir) => {
+        const { ipcRenderer } = require('electron');
+        const r = await ipcRenderer.invoke('terminal:create', dir, { noClaude: true });
+        return r && r.cwd;
+      }, existDir);
+      expect(okCwd).toBe(existDir);
+
+      // (B) 存在しないパスを渡すと HOME(tmpHome) にフォールバックし、起動は失敗しない。
+      const fbCwd = await win.evaluate(async (badPath) => {
+        const { ipcRenderer } = require('electron');
+        const r = await ipcRenderer.invoke('terminal:create', badPath, { noClaude: true });
+        return r && r.cwd;
+      }, path.join(existDir, 'no', 'such', 'dir-xyz'));
+      expect(fbCwd).toBe(tmpHome);
+    } finally {
+      await app.close();
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+      fs.rmSync(existDir, { recursive: true, force: true });
+    }
+  });
+
+  // ── (3) ＋ボタンが config を反映する（自動起動オフ → noClaude:true） ───────────
+  test('ヘッダの＋ボタンは newPaneStartupDir と noClaude:true(自動起動オフ) を渡す', async () => {
+    const port = await getFreePort();
+    const startupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-startup-'));
+    const { app, win, tmpRoot } = await launchApp(port, {
+      ...BASE_CONFIG,
+      newPaneStartupDir: startupDir,
+      newPaneAutoLaunchClaude: false,
+    });
+    try {
+      await win.waitForSelector('#sidebar', { state: 'attached' });
+      // 起動時に生成される既定ペインのヘッダ＋ボタンを待つ。
+      await win.waitForSelector('.pane-header .btn-split', { state: 'visible' });
+
+      // ipcRenderer.invoke を包んで terminal:create の引数を記録（元処理には委譲）。
+      await win.evaluate(() => {
+        const { ipcRenderer } = require('electron');
+        window.__termCreateCalls = [];
+        const orig = ipcRenderer.invoke.bind(ipcRenderer);
+        ipcRenderer.invoke = (channel, ...args) => {
+          if (channel === 'terminal:create') {
+            window.__termCreateCalls.push({ cwd: args[0], options: args[1] });
+          }
+          return orig(channel, ...args);
+        };
+      });
+
+      // ＋ボタン → addPane(newPaneStartupDir, { noClaude: !newPaneAutoLaunchClaude })
+      await win.locator('.pane-header .btn-split').first().click();
+
+      await expect
+        .poll(async () => await win.evaluate(() => window.__termCreateCalls.length))
+        .toBeGreaterThan(0);
+
+      const call = await win.evaluate(
+        () => window.__termCreateCalls[window.__termCreateCalls.length - 1]
+      );
+      // 設定した初期ディレクトリが渡る。
+      expect(call.cwd).toBe(startupDir);
+      // 自動起動オフ → noClaude:true（素のターミナル）。
+      expect(call.options && call.options.noClaude).toBe(true);
+    } finally {
+      await app.close();
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+      fs.rmSync(startupDir, { recursive: true, force: true });
+    }
+  });
+
+  // ── (4) ＋ボタンが config を反映する（自動起動オン → noClaude:false） ──────────
+  // claude 実バイナリの起動を避けるため、terminal:create はスタブ応答にして記録のみ行う
+  // （他チャンネルは元処理へ委譲）。noClaude の値がトグルに正しく連動することを確認する。
+  test('ヘッダの＋ボタンは noClaude:false(自動起動オン) を渡す', async () => {
+    const port = await getFreePort();
+    const startupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-startup-on-'));
+    const { app, win, tmpRoot } = await launchApp(port, {
+      ...BASE_CONFIG,
+      newPaneStartupDir: startupDir,
+      newPaneAutoLaunchClaude: true,
+    });
+    try {
+      await win.waitForSelector('#sidebar', { state: 'attached' });
+      await win.waitForSelector('.pane-header .btn-split', { state: 'visible' });
+
+      await win.evaluate(() => {
+        const { ipcRenderer } = require('electron');
+        window.__termCreateCalls = [];
+        let n = 1000;
+        const orig = ipcRenderer.invoke.bind(ipcRenderer);
+        ipcRenderer.invoke = (channel, ...args) => {
+          if (channel === 'terminal:create') {
+            window.__termCreateCalls.push({ cwd: args[0], options: args[1] });
+            // claude を起こさないようスタブ応答（PTY を実生成しない）。
+            return Promise.resolve({ id: 'spy-' + (n++), cwd: args[0] || '' });
+          }
+          return orig(channel, ...args);
+        };
+      });
+
+      await win.locator('.pane-header .btn-split').first().click();
+
+      await expect
+        .poll(async () => await win.evaluate(() => window.__termCreateCalls.length))
+        .toBeGreaterThan(0);
+
+      const call = await win.evaluate(
+        () => window.__termCreateCalls[window.__termCreateCalls.length - 1]
+      );
+      expect(call.cwd).toBe(startupDir);
+      // 自動起動オン → noClaude:false（claude 起動）。
+      expect(call.options && call.options.noClaude).toBe(false);
+    } finally {
+      await app.close();
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+      fs.rmSync(startupDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 概要

新しいペイン（子ターミナル）を開く時の挙動を設定パネルから制御できるようにしました。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/143

## 変更内容

設定パネル（`main.js` の `builtinSettingsDescriptor()`）に以下を追加・変更しました。

- **「新規ペインを開く時の初期ディレクトリ」**（config `newPaneStartupDir` / text）を「API ホスト」の直下に追加。値が保存されている場合、UI から開く新規ペインをそのディレクトリで起動します。未入力・存在しないパスの場合はホームディレクトリにフォールバックします。
- **「新規ペイン（子ターミナル）を開く時に自動的に Claude Code を起動する」**（config `newPaneAutoLaunchClaude` / boolean・既定 false）を追加。オンで新規ペインが Claude 起動、オフ（既定）で素のターミナルで起動します。
- **「初期コマンド」の説明文**を、Claude 起動設定との関係がわかる文面に更新。

### 挙動のスコープ

- 上記2設定が効くのは **UI から開く新規ペイン**（ペインヘッダの ＋ ボタン・空グリッドの「新規ペインを追加」）のみです。
- **最初のペイン**は従来どおり Claude を自動起動します（挙動不変）。
- **API 経由の新規ペイン**（`POST /api/new-pane`）は呼び出し側の `noClaude` 指定を優先し、この既定は適用しません（挙動不変）。
- `terminal:create` に cwd の実在チェックを追加し、存在しないディレクトリ指定時のペイン起動失敗を防止しました。

## テスト（確認手順）

### 前提
- `npm start` で VK Terminals を起動できること。設定は `config.json`（`~/.vk-terminals/config.json` または リポジトリ直下）に保存されます。

### 確認1: 既定挙動（素のターミナル）
1. 設定を未変更（または `newPaneAutoLaunchClaude` オフ）のまま起動する。
2. ペインヘッダの **＋ ボタン** を押して新規ペインを開く。
   → 新規ペインが **素のターミナル**（Claude が自動起動しない）で開くこと。
3. 最初のペインは従来どおり Claude が自動起動していること（挙動が変わっていないこと）。

### 確認2: Claude 自動起動 ON
1. 設定パネルを開き、**「新規ペイン（子ターミナル）を開く時に自動的に Claude Code を起動する」にチェック** して保存 → アプリを再起動する。
2. ＋ ボタンで新規ペインを開く。
   → 新規ペインで **Claude Code が自動起動** すること。

### 確認3: 初期ディレクトリ
1. 設定パネルの **「新規ペインを開く時の初期ディレクトリ」** に実在する絶対パス（例: 任意のプロジェクトフォルダ）を入力して保存 → 再起動する。
2. ＋ ボタンで新規ペインを開く。
   → 新規ペインが **指定したディレクトリ** で開くこと（プロンプトの cwd 表示で確認）。
3. 存在しないパスを入力して保存 → 再起動 → 新規ペインを開く。
   → クラッシュせず **ホームディレクトリ** で開くこと（フォールバック）。

### 確認4: 設定パネルの文言
1. 設定パネルを開く。
   → 「API ホスト」の直下に「新規ペインを開く時の初期ディレクトリ」→「新規ペイン（子ターミナル）を開く時に自動的に Claude Code を起動する」→「初期コマンド」の順で並び、各説明文が表示されること。

### 自動テスト
- `npm test`（`node --test tests/`）が **110 件すべて PASS**。

## スクリーンショット

設定パネルへのフォーム項目追加（text 入力・チェックボックス）ですが、Electron アプリの GUI 起動を伴うため本 PR では静止画は省略し、上記「確認4」で表示要点を記載しています。ブラウザ動作確認は e2e 担当（麗美）レビューで実施します。

## レビュー状況

- 🔒 安藤（セキュリティ）: PASS（`newPaneStartupDir` は pty の cwd にのみ渡りシェル解釈されず、インジェクション経路なし）
- 🎨 植草（UX）: 指摘に対応済み（初期ディレクトリ説明文の省略時挙動明記・Claude 起動断定の解消・絶対パス案内/placeholder 追加）

@coderabbitai ignore

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/369