### PR TITLE
[ デザイン不具合修正 ] モバイル版ターミナルカードの開閉インジケータを視認しやすいサイズ・色に調整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ デザイン不具合修正 ] モバイル版のターミナルカード開閉インジケータが小さく気づきにくい問題を、サイズと色の調整で視認しやすく修正（[#146](https://github.com/vektor-inc/vk-terminals/issues/146)）
+
 ## 1.16.0
 
 - [ 機能追加 ] モバイル版の最下部に VK Terminals のバージョンを表示（[#135](https://github.com/vektor-inc/vk-terminals/issues/135)）

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -36,7 +36,8 @@
   .card-head-meta { display: flex; align-items: center; gap: 8px; flex: none; }
   .card-head-meta .chevron { margin-left: auto; }
   .card-head:active { background: #232830; }
-  .chevron { flex: none; color: var(--muted); font-size: 13px; line-height: 1;
+  .chevron { flex: none; display: inline-flex; align-items: center; justify-content: center;
+    width: 32px; height: 32px; color: var(--fg); font-size: 16px; line-height: 1;
     transition: transform 0.12s ease; }
   .card.collapsed .chevron { transform: rotate(-90deg); }
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 概要

モバイル版（`renderer/mobile.html`）のターミナルカード開閉インジケータ `.chevron`（グリフ `▾`）が小さく淡い色のため、カードをタップして開閉できることに気づきにくい問題を修正します。

- `font-size`: 13px → 16px
- `color`: `var(--muted)`（#8b939e）→ `var(--fg)`（#e6e8eb）
- 外形のみ 32×32 の `inline-flex` 中央寄せに変更し、隣の操作ボタン `.pane-order-button`（32px）と視覚リズムを揃える

丸ボタン化・枠付けはしていません（`aria-hidden` の状態インジケータであり、独立した操作ボタンとの誤認を避けるため）。JS は無改変で、CSS 差し替えのみで完結します。折りたたみ回転（`.card.collapsed .chevron { transform: rotate(-90deg) }`）・右寄せ（`margin-left: auto`）・`prefers-reduced-motion` 配慮はそのまま維持しています。

## 変更方針の根拠

- 真因は「淡さ」ではなく「小ささ・視覚的軽さ（アフォーダンス不足）」。旧 `--muted` も card 帯上で約 5.2:1 で WCAG 2.1 AA の UI コンポーネント基準（3:1）は満たしていたため、色だけでなくサイズを上げるのが本質。
- `--fg` 化でコントラストは約 13:1（本文 4.5:1・UI 3:1 を大きく超過）。
- 詳細な設計判断は元 issue のコメントに記録済み。

## テスト（確認手順）

前提: `renderer/mobile.html`（モバイル版 Web ビュー）をスマートフォン、または PC ブラウザの開発者ツールでモバイル幅表示にして開く。ターミナルのペインが1つ以上表示されている状態にする。

**Before（修正前）**
1. モバイル版でターミナルカードのヘッダ右端を見る。
2. → 開閉インジケータ（`▾`）が 13px・淡いグレー（#8b939e）で小さく、カードがタップで開閉できることに気づきにくい。

**After（修正後）**
1. 同じくモバイル版でターミナルカードのヘッダ右端を見る。
2. → インジケータが 16px・明るい前景色（#e6e8eb）で、隣の並び替えボタンと同じ 32×32 の領域に中央表示され、視認しやすくなっている。
3. カードヘッダをタップする。
4. → xterm 出力が開閉し、`▾` が展開時は下向き・折りたたみ時は右向き（`rotate(-90deg)`）に切り替わる（従来どおりの挙動を維持）。
5. OS のモーション低減設定を有効にした状態でも開閉し、回転トランジションが無効化される（`prefers-reduced-motion` 維持）。

デグレ確認: ヘッダ帯の高さ（`min-height: 44px`）・バッジ・PR リンク・並び替えボタンの配置が崩れていないこと。カード横スクロールが発生しないこと。

### スクリーンショット（同一条件・幅390px・ダーク背景）

カードヘッダ右端の開閉インジケータ `▾` の視認性差。

| Before | After |
|---|---|
| ![before](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/issue-146/before.png?raw=true) | ![after](https://github.com/vektor-inc/review-assets/blob/main/vk-terminals/issue-146/after.png?raw=true) |

Before は `▾` が 13px・淡いグレー（#8b939e）で小さく埋もれ、After は 16px・明るい前景色（#e6e8eb）で隣の並び替えボタンと同じ 32×32 領域に表示され視認しやすい。

## 関連 issue

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/146

@coderabbitai ignore