### PR TITLE
[ 仕様変更 ] モバイル版のペイン上下入れ替えアイコンを ▲▼ から ↑↓ に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [ 仕様変更 ] モバイル版のペイン上下入れ替えアイコンを ▲▼ から ↑↓ に変更（[#148](https://github.com/vektor-inc/vk-terminals/issues/148)）
 - [ デザイン不具合修正 ] モバイル版のターミナルカード開閉インジケータが小さく気づきにくい問題を、サイズと色の調整で視認しやすく修正（[#146](https://github.com/vektor-inc/vk-terminals/issues/146)）
 
 ## 1.16.0

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -791,13 +791,13 @@ function renderPaneStash() {
 
 // xterm 表示トグル（― ボタン）のグリフ / ラベルを開閉状態から返す。
 // aria-expanded に加えて視覚グリフも切り替える（表示中=下向き▾ / 非表示=右向き▸）。
-// 並べ替えの ▲▼ とは向き（縦↔横起点）で区別する。
+// 並べ替えの ↑↓ とは向き（縦↔横起点）で区別する。
 function stashToggleGlyph(open) { return open ? '▾' : '▸'; }
 function stashToggleLabel(open) { return open ? 'ターミナルを隠す' : 'ターミナルを表示'; }
 
 // 格納ペイン 1 件分（コンパクトカード）を生成する。
 //   - タイトル行: タスク名 / タイトルリンク / PR リンク
-//   - 操作行: 状態バッジ + アクション（▲ ▼ 表示トグル(▸/▾) →(復帰) ✕）
+//   - 操作行: 状態バッジ + アクション（↑ ↓ 表示トグル(▸/▾) →(復帰) ✕）
 //   - cwd 行
 //   - term-container（xterm。既定は非表示、― で開閉）
 function renderStashItem(id, idx, count) {
@@ -836,8 +836,8 @@ function renderStashItem(id, idx, count) {
   head.innerHTML = `
     <span class="pane-badge pane-status" data-status="${escAttr(status)}" role="status" aria-live="polite"${statusAriaLabel ? ` aria-label="${escAttr(statusAriaLabel)}"` : ''}>${escText(statusLabel)}</span>
     <div class="stash-item-actions">
-      <button class="btn btn-stash-up" title="上へ移動" aria-label="上へ移動">▲</button>
-      <button class="btn btn-stash-down" title="下へ移動" aria-label="下へ移動">▼</button>
+      <button class="btn btn-stash-up" title="上へ移動" aria-label="上へ移動">↑</button>
+      <button class="btn btn-stash-down" title="下へ移動" aria-label="下へ移動">↓</button>
       <button class="btn btn-stash-toggle" title="${escAttr(stashToggleLabel(xtermOpen))}" aria-label="${escAttr(stashToggleLabel(xtermOpen))}" aria-expanded="${xtermOpen ? 'true' : 'false'}">${escText(stashToggleGlyph(xtermOpen))}</button>
       <span class="stash-actions-sep" aria-hidden="true"></span>
       <button class="btn btn-stash-restore" title="グリッドへ戻す" aria-label="グリッドへ戻す">→</button>

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -711,11 +711,11 @@ function ensureCard(termId) {
   var orderControls = document.createElement("span"); orderControls.className = "pane-order-controls";
   var moveUpBtn = document.createElement("button");
   moveUpBtn.type = "button"; moveUpBtn.className = "pane-order-button";
-  moveUpBtn.textContent = "▲"; moveUpBtn.setAttribute("aria-label", "1つ上へ移動");
+  moveUpBtn.textContent = "↑"; moveUpBtn.setAttribute("aria-label", "1つ上へ移動");
   moveUpBtn.addEventListener("click", function() { movePane(termId, -1); });
   var moveDownBtn = document.createElement("button");
   moveDownBtn.type = "button"; moveDownBtn.className = "pane-order-button";
-  moveDownBtn.textContent = "▼"; moveDownBtn.setAttribute("aria-label", "1つ下へ移動");
+  moveDownBtn.textContent = "↓"; moveDownBtn.setAttribute("aria-label", "1つ下へ移動");
   moveDownBtn.addEventListener("click", function() { movePane(termId, 1); });
   orderControls.appendChild(moveUpBtn); orderControls.appendChild(moveDownBtn);
   var chevron = document.createElement("span"); chevron.className = "chevron";

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -721,7 +721,7 @@ body.resizing-sidebar .sidebar {
   display: block;
 }
 
-/* 格納/復帰（←→）と並べ替え（◀▶ / ▲▼）を視覚的に分ける区切り線。 */
+/* 格納/復帰（←→）と並べ替え（◀▶ / ↑↓）を視覚的に分ける区切り線。 */
 .pane-actions-sep,
 .stash-actions-sep {
   width: 1px;

--- a/tests/e2e/stash-header.smoke.spec.js
+++ b/tests/e2e/stash-header.smoke.spec.js
@@ -10,7 +10,7 @@ const path = require('path');
 //   - 格納カードのヘッダーが2段になっているか（タイトル行と操作行が別要素か）
 //   - prUrl 設定時に PR バッジが出るか
 //   - url 設定時にタイトルがリンク化されるか
-//   - 既存の操作ボタン（▲▼／xterm開閉／グリッドへ戻す／閉じる）が機能するか（デグレ確認）
+//   - 既存の操作ボタン（↑↓／xterm開閉／グリッドへ戻す／閉じる）が機能するか（デグレ確認）
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 
@@ -256,7 +256,7 @@ test('格納カード: マージ済み PR バッジは格納後も紫表示と�
   }
 });
 
-test('格納カード: ▲▼で並べ替えできる（デグレ確認）', async () => {
+test('格納カード: ↑↓で並べ替えできる（デグレ確認）', async () => {
   const port = await getFreePort();
   const { app, win, tmpRoot } = await launchApp(port);
   try {


### PR DESCRIPTION
## 概要

モバイル版のペイン上下入れ替えボタンのアイコンが三角形（`▲` / `▼`）で、隣のカード開閉トグル（`▾` chevron）と混同されやすい問題を解消するため、矢印（`↑` / `↓`）に変更しました。

- 対象:
  - `renderer/mobile.html`（スマホ向けモバイルページ本体）の並べ替えボタン `moveUpBtn` / `moveDownBtn`（本 issue の一次対象）
  - `renderer/app.js` `renderStashItem()`（Electron デスクトップのサイドバー格納ペイン）の `btn-stash-up` / `btn-stash-down`（同一の誤認が起き得るため一貫性の観点で同時対応）
- 変更は **視覚グリフのみ**。`title` / `aria-label`（「上へ移動」「下へ移動」「1つ上へ移動」「1つ下へ移動」）・クラスセレクタ・イベントハンドラ・並べ替えロジックは一切変更していません。
- カード開閉トグル（`chevron` = `▾` / stash の `▸` `▾`）は変更対象外です（これと並べ替えボタンを別グリフにするのが目的）。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/148

## 変更内容

| ファイル | 変更 |
|---|---|
| `renderer/mobile.html` | 並べ替えボタン `▲`→`↑`、`▼`→`↓` |
| `renderer/app.js` | 格納ペイン並べ替えボタン `▲`→`↑`、`▼`→`↓`、関連コメント追随 |
| `renderer/style.css` | 実装と乖離していた説明コメントの `▲▼`→`↑↓` |
| `tests/e2e/stash-header.smoke.spec.js` | 説明コメント・test 名の `▲▼`→`↑↓`（セレクタ・ロジックは不変） |
| `CHANGELOG.md` | 未リリース領域にエントリ追記 |

## テスト（確認手順）

### モバイル版（`renderer/mobile.html`）
1. モバイルページを開き、ペインを2つ以上表示する。
2. 各カードのヘッダー右側の並べ替えボタンを確認する。
   → **Before**: `▲` / `▼`（三角形）で、隣の開閉インジケータ `▾` と紛らわしい。
   → **After**: `↑` / `↓`（矢印）で、開閉トグルと視覚的に区別できる。
3. `↑` / `↓` をタップし、ペインの並び順が上下に入れ替わることを確認する（デグレ確認）。
   → 並べ替え動作・localStorage への順序保存は従来どおり機能する。

### デスクトップ（サイドバー格納ペイン / `renderer/app.js`）
1. ペインをサイドバーに格納し、格納カードの操作行を確認する。
   → **Before**: `▲` / `▼`。 **After**: `↑` / `↓`。
2. `↑` / `↓` で格納ペインの並び順が入れ替わることを確認する（デグレ確認）。

### 自動テスト
- `npm test`（ユニット）: PASS。
- e2e の `stash-header.smoke.spec.js`（並べ替えデグレ確認）: PASS。
- ※ `mobile-preview-csi-redraw.smoke.spec.js` の min-height 期待値（190px）で2件失敗しますが、これは #139（プレビュー高さを約70%＝140pxに縮小）でテスト期待値が未更新の**既存の失敗**であり、本 PR の変更（グリフ・コメントのみ）とは無関係です（別 issue 対応が望ましい）。

@coderabbitai ignore

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/371