### PR TITLE
[ 開発環境 ] モバイルプレビュー高さ縮小に伴う e2e 期待値の更新漏れを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 開発環境 ] モバイルプレビュー高さ縮小（#141）に伴い更新漏れしていた e2e テストの期待値を現行仕様（min-height 140px）に合わせて修正（[#145](https://github.com/vektor-inc/vk-terminals/issues/145)）
+
 ## 1.17.0
 
 - [ 機能追加 ] UI から開く新規ペインの初期ディレクトリと Claude Code 自動起動有無を設定できる項目を追加（[#143](https://github.com/vektor-inc/vk-terminals/issues/143)）

--- a/tests/e2e/mobile-preview-csi-redraw.smoke.spec.js
+++ b/tests/e2e/mobile-preview-csi-redraw.smoke.spec.js
@@ -161,7 +161,7 @@ test('モバイルプレビュー: CSI 位置指定再描画で直近の本文�
     const nonEmptyLineCount = text.split('\n').filter((l) => l.trim()).length;
     expect(nonEmptyLineCount).toBeGreaterThanOrEqual(5);
 
-    // (2) 最低高さ: 内容が短くてもプレビュー枠が約10行分（min-height: 140px）を確保する。
+    // (2) 最低高さ: 内容が短くてもプレビュー枠が約7行分（min-height: 140px）を確保する。
     const minHeightPx = await pre.evaluate((el) => parseFloat(getComputedStyle(el).minHeight));
     expect(minHeightPx).toBeGreaterThanOrEqual(130);
     // 実効の描画高さも約140px以上（短い内容で枠が潰れない）。

--- a/tests/e2e/mobile-preview-csi-redraw.smoke.spec.js
+++ b/tests/e2e/mobile-preview-csi-redraw.smoke.spec.js
@@ -161,12 +161,12 @@ test('モバイルプレビュー: CSI 位置指定再描画で直近の本文�
     const nonEmptyLineCount = text.split('\n').filter((l) => l.trim()).length;
     expect(nonEmptyLineCount).toBeGreaterThanOrEqual(5);
 
-    // (2) 最低高さ: 内容が短くてもプレビュー枠が約10行分（min-height: 200px）を確保する。
+    // (2) 最低高さ: 内容が短くてもプレビュー枠が約10行分（min-height: 140px）を確保する。
     const minHeightPx = await pre.evaluate((el) => parseFloat(getComputedStyle(el).minHeight));
-    expect(minHeightPx).toBeGreaterThanOrEqual(190);
-    // 実効の描画高さも約200px以上（短い内容で枠が潰れない）。
+    expect(minHeightPx).toBeGreaterThanOrEqual(130);
+    // 実効の描画高さも約140px以上（短い内容で枠が潰れない）。
     const clientHeightPx = await pre.evaluate((el) => el.clientHeight);
-    expect(clientHeightPx).toBeGreaterThanOrEqual(190);
+    expect(clientHeightPx).toBeGreaterThanOrEqual(130);
   } finally {
     await browser.close();
     if (app) await app.close();

--- a/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
+++ b/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
@@ -186,7 +186,7 @@ test('モバイルプレビュー: 末尾に罫線再描画が大量に溜まっ
     const minHeightPx = await pre.evaluate((el) => {
       return parseFloat(getComputedStyle(el).minHeight);
     });
-    expect(minHeightPx).toBeGreaterThanOrEqual(190);
+    expect(minHeightPx).toBeGreaterThanOrEqual(130);
 
     // (3) 長いコンテンツ注入時、初回描画でプレビューが最下部（最新）まで
     //     スクロールされている（scrollTop + clientHeight ≒ scrollHeight）。

--- a/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
+++ b/tests/e2e/mobile-preview-order-scroll.smoke.spec.js
@@ -182,7 +182,7 @@ test('モバイルプレビュー: 末尾に罫線再描画が大量に溜まっ
     expect(maxHeightPx).not.toBe(240);
     expect(maxHeightPx).toBeGreaterThan(240);
 
-    // (2.5) issue #132: 内容が短くても、約10行分の表示領域を確保する。
+    // (2.5) issue #132: 内容が短くても、約7行分の表示領域を確保する。
     const minHeightPx = await pre.evaluate((el) => {
       return parseFloat(getComputedStyle(el).minHeight);
     });


### PR DESCRIPTION
## 概要

モバイル版ペインプレビューの高さを縮小した #141（`renderer/mobile.html` の `min-height: 200px → 140px`）の際に、既存 e2e 2 ファイルの期待値（`>= 190`）が更新されておらず、`npm run test:e2e` で 2 件が FAIL したままになっていました。

**#144 とは無関係の既存テスト債務**です（base v1.16.0 時点で既に `min-height: 140px`）。現行仕様（140px）に合わせて期待値としきい値コメントを更新しました。テスト設定変更のため分類は `[ 開発環境 ]` です。

## 変更内容

- `tests/e2e/mobile-preview-csi-redraw.smoke.spec.js`
  - `minHeightPx` / `clientHeightPx` の期待値を `>= 190` → `>= 130`（実測 140px に対し約10px マージン）に更新
  - コメントの `min-height: 200px` → `min-height: 140px`、`約200px以上` → `約140px以上`、`約10行分` → `約7行分` に更新
- `tests/e2e/mobile-preview-order-scroll.smoke.spec.js`
  - `minHeightPx` の期待値を `>= 190` → `>= 130` に更新
  - コメントの `約10行分` → `約7行分` に更新
- `CHANGELOG.md`
  - `[ 開発環境 ]` エントリを1件追記

マジックナンバーの二重管理を避けるため、実際の `min-height` 値（140px）を基準にしたしきい値（`>= 130`）へ揃えています。

## テスト（確認手順）

### Before（修正前・base v1.16.0〜v1.17.0 時点）

1. リポジトリルートで `npm run test:e2e` を実行する
   → `tests/e2e/mobile-preview-csi-redraw.smoke.spec.js` と `tests/e2e/mobile-preview-order-scroll.smoke.spec.js` の計 2 件が `min-height >= 190` を期待して **FAIL** する（実測値は 140px のため）

### After（本 PR 適用後）

1. 本ブランチをチェックアウトする
2. リポジトリルートで対象 spec を実行する
   ```
   npm run test:e2e -- mobile-preview-csi-redraw.smoke mobile-preview-order-scroll.smoke
   ```
   → 2 spec（計 3 tests）が **PASS** する
3. 全体を実行しても回帰がないこと
   ```
   npm run test:e2e
   ```
   → 上記 2 ファイルが FAIL しなくなっていること

※ UI・表示の挙動自体は変更していません（テスト期待値とコメント、CHANGELOG のみの変更）。実装値 `renderer/mobile.html` の `min-height: 140px` は #141 で確定済みで本 PR では変更していないため、スクリーンショットは省略します。

関連 issue: https://github.com/vektor-inc/vk-terminals/issues/145
関連: #141（モバイルプレビュー高さ縮小）

@coderabbitai ignore

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/373