### PR TITLE
[ 開発環境 ] Prettier を導入し renderer の CSS を統一フォーマット化

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+package-lock.json
+CHANGELOG.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 - [ 開発環境 ] モバイルプレビュー高さ縮小（#141）に伴い更新漏れしていた e2e テストの期待値を現行仕様（min-height 140px）に合わせて修正（[#145](https://github.com/vektor-inc/vk-terminals/issues/145)）
 - [ 開発環境 ] モバイル版の外部 CSS 化のデグレ（`/mobile.css` の 404 による無スタイル化）を検知する e2e 回帰テストを追加（[#152](https://github.com/vektor-inc/vk-terminals/issues/152)）
+- [ 開発環境 ] Prettier を導入し renderer の CSS を統一フォーマット化（`npm run format` / `format:check`）
 - [ その他 ] モバイル版のインライン CSS を外部ファイル（mobile.css）へ分離しメンテナンス性を向上（[#152](https://github.com/vektor-inc/vk-terminals/issues/152)）
+- [ その他 ] mobile.css をセクション別に整理し見出しコメントを付与してメンテナンス性を向上
 
 ## 1.17.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
       },
       "devDependencies": {
         "@electron/rebuild": "^3.6.0",
-        "@playwright/test": "^1.61.1"
+        "@playwright/test": "^1.61.1",
+        "prettier": "^3.9.5"
       },
       "engines": {
         "node": ">=20"
@@ -1820,6 +1821,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proc-log": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "start": "electron .",
     "test": "node --test tests/",
     "test:e2e": "playwright test",
+    "format": "prettier --write \"renderer/*.css\"",
+    "format:check": "prettier --check \"renderer/*.css\"",
     "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^3.6.0",
-    "@playwright/test": "^1.61.1"
+    "@playwright/test": "^1.61.1",
+    "prettier": "^3.9.5"
   }
 }

--- a/renderer/mobile.css
+++ b/renderer/mobile.css
@@ -1,3 +1,6 @@
+/* =============================================================================
+   デザイントークン
+   ========================================================================== */
 :root {
   --bg: #14171c;
   --card: #1d2127;
@@ -9,146 +12,584 @@
   --waiting: #f5a623;
   --accent: #2563eb;
 }
-* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
-html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
-  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Helvetica Neue", Arial, sans-serif; }
+
+/* =============================================================================
+   ベース / リセット
+   ========================================================================== */
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Hiragino Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+/* =============================================================================
+   ヘッダー
+   ========================================================================== */
 header {
-  position: sticky; top: 0; z-index: 5; background: rgba(20,23,28,0.92);
-  backdrop-filter: blur(8px); padding: 10px 14px; border-bottom: 1px solid var(--card-border);
-  display: flex; align-items: center; gap: 8px;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: rgba(20, 23, 28, 0.92);
+  backdrop-filter: blur(8px);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--card-border);
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
-header h1 { font-size: 15px; margin: 0; font-weight: 600; flex: 1; }
-header .meta { font-size: 11px; color: var(--muted); }
-#list { padding: 10px; display: flex; flex-direction: column; gap: 10px; }
-.card { background: var(--card); border: 1px solid var(--card-border); border-radius: 12px;
-  overflow: hidden; }
-.card-head { display: flex; flex-direction: column; align-items: stretch; gap: 6px; padding: 10px 12px;
-  min-height: 44px; cursor: pointer; user-select: none; -webkit-user-select: none; }
-.card-head-main { display: flex; align-items: center; gap: 8px; flex: 1 1 auto; min-width: 0; }
-.card-head-meta { display: flex; align-items: center; gap: 8px; flex: none; }
-.card-head-meta .chevron { margin-left: auto; }
-.card-head:active { background: #232830; }
-.chevron { flex: none; display: inline-flex; align-items: center; justify-content: center;
-  width: 32px; height: 32px; color: var(--fg); font-size: 16px; line-height: 1;
-  transition: transform 0.12s ease; }
-.card.collapsed .chevron { transform: rotate(-90deg); }
+header h1 {
+  font-size: 15px;
+  margin: 0;
+  font-weight: 600;
+  flex: 1;
+}
+header .meta {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+/* =============================================================================
+   リスト / カード枠
+   ========================================================================== */
+#list {
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.card {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.card.collapsed pre.lines,
+.card.collapsed .actions {
+  display: none;
+}
+
+/* =============================================================================
+   カードヘッダ（開閉トリガ）
+   ========================================================================== */
+.card-head {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 10px 12px;
+  min-height: 44px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.card-head-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.card-head-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+}
+.card-head-meta .chevron {
+  margin-left: auto;
+}
+.card-head:active {
+  background: #232830;
+}
+
+/* =============================================================================
+   シェブロン（開閉インジケータ）
+   ========================================================================== */
+.chevron {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: var(--fg);
+  font-size: 16px;
+  line-height: 1;
+  transition: transform 0.12s ease;
+}
+.card.collapsed .chevron {
+  transform: rotate(-90deg);
+}
 @media (prefers-reduced-motion: reduce) {
-  .chevron { transition: none; }
+  .chevron {
+    transition: none;
+  }
 }
-.dot { width: 10px; height: 10px; border-radius: 50%; flex: none; }
-.dot.idle { background: var(--idle); }
-.dot.running { background: var(--running); box-shadow: 0 0 0 3px rgba(59,130,246,0.18); }
-.dot.waiting { background: var(--waiting); box-shadow: 0 0 0 3px rgba(245,166,35,0.22);
-  animation: pulse 1.2s ease-in-out infinite; }
-@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
-.card-title { flex: 1; min-width: 0; }
-a.card-title { color: inherit; text-decoration: none; }
-.card-title .name { font-size: 13px; font-weight: 600; white-space: nowrap;
-  overflow: hidden; text-overflow: ellipsis; }
-.card-title.is-link .name { color: #58a6ff; text-decoration: underline;
-  text-underline-offset: 2px; cursor: pointer; }
-.card-title.is-link .name::after { content: " ↗"; font-size: 10px; opacity: 0.85; }
-.card-title .cwd { font-size: 11px; color: var(--muted); white-space: nowrap;
-  overflow: hidden; text-overflow: ellipsis; }
-.card-title:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; border-radius: 4px; }
-.badge { font-size: 10px; font-weight: 700; padding: 3px 7px; border-radius: 6px;
-  text-transform: uppercase; letter-spacing: 0.04em; flex: none; }
-.badge.idle { background: #2a2f37; color: #9aa3ae; }
-.badge.running { background: rgba(59,130,246,0.15); color: #7fb0ff; }
-.badge.waiting { background: rgba(245,166,35,0.18); color: #ffce7a; }
+
+/* =============================================================================
+   ステータスドット
+   ========================================================================== */
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: none;
+}
+.dot.idle {
+  background: var(--idle);
+}
+.dot.running {
+  background: var(--running);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
+}
+.dot.waiting {
+  background: var(--waiting);
+  box-shadow: 0 0 0 3px rgba(245, 166, 35, 0.22);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+/* =============================================================================
+   カードタイトル（名前 / cwd）
+   ========================================================================== */
+.card-title {
+  flex: 1;
+  min-width: 0;
+}
+a.card-title {
+  color: inherit;
+  text-decoration: none;
+}
+.card-title .name {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.card-title.is-link .name {
+  color: #58a6ff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.card-title.is-link .name::after {
+  content: ' ↗';
+  font-size: 10px;
+  opacity: 0.85;
+}
+.card-title .cwd {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.card-title:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* =============================================================================
+   ステータスバッジ
+   ========================================================================== */
+.badge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 3px 7px;
+  border-radius: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex: none;
+}
+.badge.idle {
+  background: #2a2f37;
+  color: #9aa3ae;
+}
+.badge.running {
+  background: rgba(59, 130, 246, 0.15);
+  color: #7fb0ff;
+}
+.badge.waiting {
+  background: rgba(245, 166, 35, 0.18);
+  color: #ffce7a;
+}
+
+/* =============================================================================
+   PR リンク（issue #53 / #137）
+   ========================================================================== */
 /* PR リンク（issue #53）。PC 版の [ PR ↗ ] バッジ（GitHub PR グリーン系）に寄せる。
    ヘッダ帯（暗背景 var(--card)）上に置くため、PC の濃緑ではなく明るい緑文字にする。
    .badge と同じ角丸・font-size に調和させつつ、タップ領域確保のため min-height 32px・
    padding 縦広めにして指で押しやすくする（ヘッダ自体は min-height 44px）。 */
-a.pr-link { display: none; align-items: center; gap: 4px; flex: none;
-  font-size: 10px; font-weight: 700; padding: 4px 8px; min-height: 32px; border-radius: 6px;
-  text-transform: uppercase; letter-spacing: 0.04em; text-decoration: none;
-  background: rgba(63,185,80,0.15); border: 1px solid rgba(63,185,80,0.3); color: #6fd58a; }
-a.pr-link.show { display: inline-flex; }
-a.pr-link:active { background: rgba(63,185,80,0.28); border-color: rgba(63,185,80,0.5); }
+a.pr-link {
+  display: none;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 4px 8px;
+  min-height: 32px;
+  border-radius: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  background: rgba(63, 185, 80, 0.15);
+  border: 1px solid rgba(63, 185, 80, 0.3);
+  color: #6fd58a;
+}
+a.pr-link.show {
+  display: inline-flex;
+}
+a.pr-link:active {
+  background: rgba(63, 185, 80, 0.28);
+  border-color: rgba(63, 185, 80, 0.5);
+}
 /* マージ済み PR リンク（issue #137）。ヘッダ帯 var(--card) #1d2127 上で
    #c8a8ff はコントラスト比 8.08:1、active の #d0b5ff は 9.03:1 で AA 4.5:1 を満たす。 */
-a.pr-link.merged { background: rgba(130,80,223,0.15); border-color: rgba(130,80,223,0.45); color: #c8a8ff; }
-a.pr-link.merged:active { background: rgba(130,80,223,0.28); border-color: rgba(200,168,255,0.62); color: #d0b5ff; }
-a.pr-link:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
-a.pr-link .pr-icon { font-size: 10px; opacity: 0.85; line-height: 1; flex: none; }
-.pane-order-controls { display: inline-flex; align-items: center; gap: 8px; flex: none; }
-.pane-order-button { display: inline-flex; align-items: center; justify-content: center;
+a.pr-link.merged {
+  background: rgba(130, 80, 223, 0.15);
+  border-color: rgba(130, 80, 223, 0.45);
+  color: #c8a8ff;
+}
+a.pr-link.merged:active {
+  background: rgba(130, 80, 223, 0.28);
+  border-color: rgba(200, 168, 255, 0.62);
+  color: #d0b5ff;
+}
+a.pr-link:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+a.pr-link .pr-icon {
+  font-size: 10px;
+  opacity: 0.85;
+  line-height: 1;
+  flex: none;
+}
+
+/* =============================================================================
+   ペイン並べ替えコントロール
+   ========================================================================== */
+.pane-order-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+}
+.pane-order-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   position: relative;
-  width: 32px; min-width: 32px; height: 32px; padding: 0; border-radius: 6px;
-  border: 1px solid #606c7c; background: #2f353e; color: var(--fg);
-  font-size: 12px; line-height: 1; font-weight: 700; cursor: pointer; }
-.pane-order-button::before { content: ""; position: absolute; inset: -6px; }
-.pane-order-button:active { background: #3a424d; }
-.pane-order-button:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
-.pane-order-button:disabled { color: var(--idle); border-color: var(--card-border);
-  background: #20242b; cursor: default; opacity: 0.62; }
-.pane-order-button:disabled:active { background: #20242b; }
-pre.lines { margin: 0; padding: 10px 12px; background: #0d0f13; color: #c8ccd2;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; line-height: 1.5;
-  white-space: pre-wrap; word-break: break-word; min-height: 140px; max-height: min(35vh, 364px); overflow-y: auto;
-  -webkit-overflow-scrolling: touch; overscroll-behavior: contain;
-  border-top: 1px solid var(--card-border); }
-.card.collapsed pre.lines, .card.collapsed .actions { display: none; }
-.actions { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 7px; }
-.row { display: flex; gap: 6px; flex-wrap: wrap; }
-button.k { flex: 1 1 auto; min-width: 44px; padding: 9px 6px; border-radius: 8px;
-  border: 1px solid var(--card-border); background: #262b33; color: var(--fg);
-  font-size: 13px; font-weight: 600; cursor: pointer; }
-button.k:active { background: #323843; }
-button.k.yes { border-color: #2f6b3f; color: #8fe0a6; }
-button.k.no  { border-color: #6b2f2f; color: #f0a3a3; }
-button.k.stop { border-color: #6b5a2f; color: #e8d08a; }
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid #606c7c;
+  background: #2f353e;
+  color: var(--fg);
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 700;
+  cursor: pointer;
+}
+.pane-order-button::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+}
+.pane-order-button:active {
+  background: #3a424d;
+}
+.pane-order-button:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+.pane-order-button:disabled {
+  color: var(--idle);
+  border-color: var(--card-border);
+  background: #20242b;
+  cursor: default;
+  opacity: 0.62;
+}
+.pane-order-button:disabled:active {
+  background: #20242b;
+}
+
+/* =============================================================================
+   ターミナル出力
+   ========================================================================== */
+pre.lines {
+  margin: 0;
+  padding: 10px 12px;
+  background: #0d0f13;
+  color: #c8ccd2;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 140px;
+  max-height: min(35vh, 364px);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  border-top: 1px solid var(--card-border);
+}
+
+/* =============================================================================
+   アクション（クイックボタン / 送信 / トグル）
+   ========================================================================== */
+.actions {
+  padding: 8px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+button.k {
+  flex: 1 1 auto;
+  min-width: 44px;
+  padding: 9px 6px;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+  background: #262b33;
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+button.k:active {
+  background: #323843;
+}
+button.k.yes {
+  border-color: #2f6b3f;
+  color: #8fe0a6;
+}
+button.k.no {
+  border-color: #6b2f2f;
+  color: #f0a3a3;
+}
+button.k.stop {
+  border-color: #6b5a2f;
+  color: #e8d08a;
+}
 /* ペイン終了（issue #100）。実行中プロセスを kill する不可逆操作なので、
    クイックボタン（アウトライン様式）と格を変えた「塗りの赤」にし、
    .actions 最下段に独立した全幅ボタンとして高頻度操作から分離する。 */
-.actions .danger-row { margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--card-border); }
-button.k.kill { flex: 1 1 100%; width: 100%; min-height: 44px;
-  background: #b03636; border-color: #b03636; color: #fff; font-weight: 700; }
-button.k.kill:active { background: #8f2a2a; border-color: #8f2a2a; }
-button.k.kill:focus-visible { outline: 2px solid #58a6ff; outline-offset: 2px; }
-.sendrow { display: flex; gap: 6px; }
-.sendrow input { flex: 1; padding: 9px 10px; border-radius: 8px; border: 1px solid var(--card-border);
-  background: #0d0f13; color: var(--fg); font-size: 14px; font-family: ui-monospace, Menlo, monospace; }
-.sendrow button { padding: 9px 14px; border-radius: 8px; border: none; background: var(--accent);
-  color: #fff; font-weight: 700; font-size: 14px; }
-.empty { color: var(--muted); text-align: center; padding: 40px 20px; font-size: 13px; }
-.nl-toggle { font-size: 11px; color: var(--muted); display: flex; align-items: center; gap: 5px;
-  padding: 2px; }
-#err { display: none; background: #4a1e1e; color: #ffb4b4; font-size: 12px; padding: 6px 12px; }
+.actions .danger-row {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--card-border);
+}
+button.k.kill {
+  flex: 1 1 100%;
+  width: 100%;
+  min-height: 44px;
+  background: #b03636;
+  border-color: #b03636;
+  color: #fff;
+  font-weight: 700;
+}
+button.k.kill:active {
+  background: #8f2a2a;
+  border-color: #8f2a2a;
+}
+button.k.kill:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 2px;
+}
+.sendrow {
+  display: flex;
+  gap: 6px;
+}
+.sendrow input {
+  flex: 1;
+  padding: 9px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+  background: #0d0f13;
+  color: var(--fg);
+  font-size: 14px;
+  font-family: ui-monospace, Menlo, monospace;
+}
+.sendrow button {
+  padding: 9px 14px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 14px;
+}
+.nl-toggle {
+  font-size: 11px;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px;
+}
+
+/* =============================================================================
+   空表示 / エラー
+   ========================================================================== */
+.empty {
+  color: var(--muted);
+  text-align: center;
+  padding: 40px 20px;
+  font-size: 13px;
+}
+#err {
+  display: none;
+  background: #4a1e1e;
+  color: #ffb4b4;
+  font-size: 12px;
+  padding: 6px 12px;
+}
+
+/* =============================================================================
+   トークン使用量カード（issue #69 / #73）
+   ========================================================================== */
 /* トークン使用量カード（issue #69）。data.usage があるときだけ #list の先頭に表示する。 */
-#usage-card { display: none; margin: 10px 10px 0; padding: 11px 13px; background: var(--card);
-  border: 1px solid var(--card-border); border-radius: 12px; }
-#usage-card.show { display: block; }
-#usage-card .u-line { font-size: 12px; color: var(--fg); font-weight: 600;
-  display: flex; align-items: center; gap: 6px; }
-#usage-card .u-line[hidden] { display: none; }
-#usage-card .u-line .u-bolt { font-size: 13px; }
-#usage-card .u-bar { margin-top: 6px; font-size: 12px; color: var(--muted);
-  font-family: ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 1px;
-  display: flex; align-items: center; gap: 8px; }
-#usage-card .u-bar[hidden] { display: none; }
-#usage-card .u-bar .u-marks { color: var(--running); letter-spacing: 2px; }
+#usage-card {
+  display: none;
+  margin: 10px 10px 0;
+  padding: 11px 13px;
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+}
+#usage-card.show {
+  display: block;
+}
+#usage-card .u-line {
+  font-size: 12px;
+  color: var(--fg);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+#usage-card .u-line[hidden] {
+  display: none;
+}
+#usage-card .u-line .u-bolt {
+  font-size: 13px;
+}
+#usage-card .u-bar {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  letter-spacing: 1px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+#usage-card .u-bar[hidden] {
+  display: none;
+}
+#usage-card .u-bar .u-marks {
+  color: var(--running);
+  letter-spacing: 2px;
+}
 /* ピーク比の意味をモバイルにだけ一度添える補足（UX-1）。 */
-#usage-card .u-note { margin-top: 4px; font-size: 10px; color: var(--muted); }
-#usage-card .u-note[hidden] { display: none; }
+#usage-card .u-note {
+  margin-top: 4px;
+  font-size: 10px;
+  color: var(--muted);
+}
+#usage-card .u-note[hidden] {
+  display: none;
+}
 /* 公式 usage API のセッション% / 週間% 2 バー表示（issue #73）。
    公式% のみ閾値カラー（〜70% 青 / 70〜90% アンバー / 90%〜 赤）。
    数値ラベルを必ず併記し、色だけに依存しない。トラックは PC 側と同じ #21262d。 */
-#usage-oauth[hidden] { display: none; }
-#usage-oauth .u-sec { margin-top: 10px; }
-#usage-oauth .u-sec:first-child { margin-top: 0; }
-#usage-oauth .u-sec[hidden] { display: none; }
-#usage-oauth .u-sec-head { display: flex; align-items: baseline; justify-content: space-between;
-  gap: 8px; font-size: 12px; font-weight: 600; color: var(--fg); }
-#usage-oauth .u-sec-head .u-pct { white-space: nowrap; }
-#usage-oauth .u-track { margin-top: 5px; height: 7px; border-radius: 4px;
-  background: #21262d; overflow: hidden; }
-#usage-oauth .u-fill { height: 100%; border-radius: 4px; background: #58a6ff; }
-#usage-oauth .u-fill.level-warn { background: #d29922; }
-#usage-oauth .u-fill.level-crit { background: #f85149; }
-#usage-oauth .u-reset { margin-top: 4px; font-size: 10px; color: var(--muted); }
-#app-version-footer { display: none; padding: 4px 12px;
-  padding-bottom: max(18px, env(safe-area-inset-bottom)); color: var(--muted);
-  font-size: 11px; line-height: 1.4; text-align: center; }
-#app-version-footer.show { display: block; }
+#usage-oauth[hidden] {
+  display: none;
+}
+#usage-oauth .u-sec {
+  margin-top: 10px;
+}
+#usage-oauth .u-sec:first-child {
+  margin-top: 0;
+}
+#usage-oauth .u-sec[hidden] {
+  display: none;
+}
+#usage-oauth .u-sec-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg);
+}
+#usage-oauth .u-sec-head .u-pct {
+  white-space: nowrap;
+}
+#usage-oauth .u-track {
+  margin-top: 5px;
+  height: 7px;
+  border-radius: 4px;
+  background: #21262d;
+  overflow: hidden;
+}
+#usage-oauth .u-fill {
+  height: 100%;
+  border-radius: 4px;
+  background: #58a6ff;
+}
+#usage-oauth .u-fill.level-warn {
+  background: #d29922;
+}
+#usage-oauth .u-fill.level-crit {
+  background: #f85149;
+}
+#usage-oauth .u-reset {
+  margin-top: 4px;
+  font-size: 10px;
+  color: var(--muted);
+}
+
+/* =============================================================================
+   バージョンフッター
+   ========================================================================== */
+#app-version-footer {
+  display: none;
+  padding: 4px 12px;
+  padding-bottom: max(18px, env(safe-area-inset-bottom));
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: center;
+}
+#app-version-footer.show {
+  display: block;
+}

--- a/renderer/style.css
+++ b/renderer/style.css
@@ -2,10 +2,11 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  --vktm--border-radius--md:5px;
+  --vktm--border-radius--md: 5px;
 }
 
-html, body {
+html,
+body {
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -100,7 +101,7 @@ html, body {
 }
 .titlebar-menu-btn.usage-alert-warn::after,
 .titlebar-menu-btn.usage-alert-crit::after {
-  content: "";
+  content: '';
   position: absolute;
   top: 3px;
   right: 3px;
@@ -109,8 +110,12 @@ html, body {
   border-radius: 50%;
   border: 1px solid #0d1117;
 }
-.titlebar-menu-btn.usage-alert-warn::after { background: #d29922; }
-.titlebar-menu-btn.usage-alert-crit::after { background: #f85149; }
+.titlebar-menu-btn.usage-alert-warn::after {
+  background: #d29922;
+}
+.titlebar-menu-btn.usage-alert-crit::after {
+  background: #f85149;
+}
 
 /* ─── 設定パネル（モーダル）──────────────────────────────────────────────────── */
 .settings-overlay {
@@ -164,7 +169,10 @@ html, body {
   height: 26px;
   border-radius: 5px;
 }
-.settings-close:hover { background: #21262d; color: #e6edf3; }
+.settings-close:hover {
+  background: #21262d;
+  color: #e6edf3;
+}
 
 /* モーダル（flex column・max-height 制限）内でビュー単位にスクロールさせる。
  * hidden 属性で非表示切替。 */
@@ -172,9 +180,13 @@ html, body {
   overflow-y: auto;
   min-height: 0;
 }
-.settings-view[hidden] { display: none; }
+.settings-view[hidden] {
+  display: none;
+}
 /* 使用状況ビュー表示中はフッター（保存/キャンセル）ごと隠す（読み取り専用）。 */
-.settings-footer[hidden] { display: none; }
+.settings-footer[hidden] {
+  display: none;
+}
 
 /* ─── 使用状況ビュー（issue #73）───────────────────────────────────────────────
  * バーの色はダークテーマの既存トークンを流用する。
@@ -185,7 +197,9 @@ html, body {
 .usage-section {
   margin-bottom: 18px;
 }
-.usage-section:last-child { margin-bottom: 6px; }
+.usage-section:last-child {
+  margin-bottom: 6px;
+}
 .usage-section-head {
   display: flex;
   align-items: baseline;
@@ -216,8 +230,12 @@ html, body {
   background: #58a6ff;
   transition: width 0.3s ease;
 }
-.usage-bar-fill.level-warn { background: #d29922; }
-.usage-bar-fill.level-crit { background: #f85149; }
+.usage-bar-fill.level-warn {
+  background: #d29922;
+}
+.usage-bar-fill.level-crit {
+  background: #f85149;
+}
 .usage-reset {
   margin-top: 5px;
   font-size: 11px;
@@ -251,7 +269,9 @@ html, body {
   font-size: 12px;
   word-break: break-all;
 }
-.settings-target code { color: #8b949e; }
+.settings-target code {
+  color: #8b949e;
+}
 .settings-empty {
   margin: 0;
   padding: 18px;
@@ -281,7 +301,9 @@ html, body {
   gap: 4px;
   margin-top: 14px;
 }
-.settings-row:first-of-type { margin-top: 2px; }
+.settings-row:first-of-type {
+  margin-top: 2px;
+}
 .settings-label {
   color: #c9d1d9;
   font-size: 13px;
@@ -300,9 +322,9 @@ html, body {
 .settings-error:empty {
   display: none;
 }
-.settings-row input[type="text"],
-.settings-row input[type="number"],
-.settings-row input[type="password"],
+.settings-row input[type='text'],
+.settings-row input[type='number'],
+.settings-row input[type='password'],
 .settings-row select,
 .settings-row textarea {
   width: 100%;
@@ -315,9 +337,9 @@ html, body {
   font-size: 13px;
   font-family: inherit;
 }
-.settings-row input[type="text"]::placeholder,
-.settings-row input[type="number"]::placeholder,
-.settings-row input[type="password"]::placeholder,
+.settings-row input[type='text']::placeholder,
+.settings-row input[type='number']::placeholder,
+.settings-row input[type='password']::placeholder,
 .settings-row textarea::placeholder {
   color: #8b949e;
   opacity: 1;
@@ -337,7 +359,7 @@ html, body {
 }
 /* pattern 検証エラー時の赤枠。focus 時の青枠より前に置き、同詳細度なら後勝ちの
    ソース順で focus（青）が勝つようにする（入力中は青、blur 後の未focusで赤）。 */
-.settings-row input[aria-invalid="true"] {
+.settings-row input[aria-invalid='true'] {
   border-color: #f85149;
 }
 .settings-row input:focus,
@@ -353,7 +375,9 @@ html, body {
   gap: 8px;
   cursor: pointer;
 }
-.settings-check input { -webkit-app-region: no-drag; }
+.settings-check input {
+  -webkit-app-region: no-drag;
+}
 .settings-pwd {
   display: flex;
   gap: 6px;
@@ -367,7 +391,9 @@ html, body {
   cursor: pointer;
   width: 34px;
 }
-.settings-reveal:hover { background: #30363d; }
+.settings-reveal:hover {
+  background: #30363d;
+}
 .settings-footer {
   display: flex;
   align-items: center;
@@ -380,8 +406,12 @@ html, body {
   font-size: 13px;
   color: #8b949e;
 }
-.settings-msg.ok { color: #3fb950; }
-.settings-msg.err { color: #f85149; }
+.settings-msg.ok {
+  color: #3fb950;
+}
+.settings-msg.err {
+  color: #f85149;
+}
 .settings-footer button {
   padding: 6px 14px;
   border-radius: 5px;
@@ -393,14 +423,18 @@ html, body {
   background: #21262d;
   color: #c9d1d9;
 }
-.settings-cancel:hover { background: #30363d; }
+.settings-cancel:hover {
+  background: #30363d;
+}
 .settings-save {
   background: #238636;
   border-color: #2ea043;
   color: #fff;
   font-weight: 600;
 }
-.settings-save:hover { background: #2ea043; }
+.settings-save:hover {
+  background: #2ea043;
+}
 
 /* ─── Root layout ──────────────────────────────────────────────────────────── */
 #root {
@@ -426,7 +460,9 @@ html, body {
   display: flex;
   flex-direction: column;
   transform: translateX(-100%);
-  transition: flex-basis 0.18s ease, transform 0.18s ease;
+  transition:
+    flex-basis 0.18s ease,
+    transform 0.18s ease;
   z-index: 900;
   background: #0d1117;
   color: #e6edf3;
@@ -667,7 +703,7 @@ body.resizing-sidebar .sidebar {
 }
 /* コンパクトカードでは幅が限られるため、idle 時のステータスバッジは
  * （グリッドのように幅を予約せず）畳んでタスク名の表示幅を優先する。 */
-.stash-item-head .pane-status[data-status="idle"] {
+.stash-item-head .pane-status[data-status='idle'] {
   display: none;
 }
 .stash-item .pane-task-title-pr {
@@ -784,7 +820,9 @@ body.resizing-sidebar .sidebar {
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
 .grid-empty-btn:hover {
   background: #2ea043;
@@ -840,7 +878,9 @@ body.resizing-sidebar .sidebar {
   min-height: 0;
   border: 1px solid #21262d;
   box-shadow: none;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
   overflow: hidden;
   border-radius: var(--vktm--border-radius--md);
 }
@@ -873,12 +913,19 @@ body.resizing-sidebar .sidebar {
 }
 
 @keyframes drop-flash {
-  0%   { border-color: #56d364; box-shadow: 0 0 0 4px rgba(86, 211, 100, 0.5); }
-  100% { border-color: #21262d; box-shadow: none; }
+  0% {
+    border-color: #56d364;
+    box-shadow: 0 0 0 4px rgba(86, 211, 100, 0.5);
+  }
+  100% {
+    border-color: #21262d;
+    box-shadow: none;
+  }
 }
 
 @keyframes waiting-pulse {
-  0%, 100% {
+  0%,
+  100% {
     border-color: #d29922;
     box-shadow: 0 0 0 0 rgba(210, 153, 34, 0);
   }
@@ -928,7 +975,9 @@ body.resizing-sidebar .sidebar {
   cursor: pointer;
   border-radius: 3px;
   /* リンクのフォーカスリングと色変化のみの transition。 */
-  transition: color 0.12s ease, text-decoration-color 0.12s ease;
+  transition:
+    color 0.12s ease,
+    text-decoration-color 0.12s ease;
 }
 
 /* PR ボタン同居時はタイトルが画面外に PR ボタンを押し出さないよう min-width: 0 を保証
@@ -1001,7 +1050,10 @@ body.resizing-sidebar .sidebar {
   color: #3fb950;
   text-decoration: none;
   cursor: pointer;
-  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
 }
 
 .pane-task-title-pr:hover {
@@ -1109,11 +1161,13 @@ body.resizing-sidebar .sidebar {
   margin-right: 6px;
   /* 最長ラベル「入力待ち」基準で min-width を予約（idle 時もレイアウトを保つ） */
   min-width: 6ch;
-  transition: color 0.15s, background 0.15s;
+  transition:
+    color 0.15s,
+    background 0.15s;
 }
 
 .pane-status::before {
-  content: "";
+  content: '';
   width: 6px;
   height: 6px;
   border-radius: 50%;
@@ -1121,20 +1175,20 @@ body.resizing-sidebar .sidebar {
   flex-shrink: 0;
 }
 
-.pane-status[data-status="idle"] {
+.pane-status[data-status='idle'] {
   /* visibility:hidden により (1) レイアウト幅維持 (2) フォーカス対象外
    * (3) aria-live 非発火 を同時に満たす。display:none だと cwd 位置がジッタする。 */
   visibility: hidden;
 }
 
-.pane-status[data-status="running"] {
+.pane-status[data-status='running'] {
   /* .pane.drag-over の緑（#3fb950）と同系統に揃え、衝突を回避 */
   color: #3fb950;
   background: rgba(63, 185, 80, 0.15);
   border: 1px solid rgba(63, 185, 80, 0.3);
 }
 
-.pane-status[data-status="waiting"] {
+.pane-status[data-status='waiting'] {
   color: #d29922;
   background: rgba(210, 153, 34, 0.15);
   border: 1px solid rgba(210, 153, 34, 0.3);
@@ -1143,8 +1197,13 @@ body.resizing-sidebar .sidebar {
 }
 
 @keyframes badge-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
 }
 
 /* ─── Auto-input badge ────────────────────────────────────────────────────── */
@@ -1158,8 +1217,12 @@ body.resizing-sidebar .sidebar {
 }
 
 @keyframes auto-input-flash {
-  0% { background: rgba(88, 166, 255, 0.4); }
-  100% { background: rgba(88, 166, 255, 0.15); }
+  0% {
+    background: rgba(88, 166, 255, 0.4);
+  }
+  100% {
+    background: rgba(88, 166, 255, 0.15);
+  }
 }
 
 .pane.auto-input {
@@ -1180,7 +1243,9 @@ body.resizing-sidebar .sidebar {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.12s, background 0.12s;
+  transition:
+    color 0.12s,
+    background 0.12s;
   -webkit-app-region: no-drag;
   flex-shrink: 0;
 }
@@ -1255,15 +1320,15 @@ body.file-dragging .pane {
  *   - ドラッグ元ペインは opacity:0.5 でうっすら見せる
  *   - ドロップ予定の半分（または1/2矩形）は #pane-drop-indicator を body 直下に
  *     position:fixed で出してアクセントカラーで塗りつぶす（pointer-events:none 必須） */
-.pane-task-title[draggable="true"] {
+.pane-task-title[draggable='true'] {
   cursor: grab;
 }
 
-.pane-task-title[draggable="true"]:active {
+.pane-task-title[draggable='true']:active {
   cursor: grabbing;
 }
 
-body.pane-dragging .pane-task-title[draggable="true"] {
+body.pane-dragging .pane-task-title[draggable='true'] {
   cursor: grabbing;
 }
 
@@ -1325,16 +1390,25 @@ body.pane-dragging * {
   user-select: none;
   font-weight: 600;
 }
-.agent-room-summary::-webkit-details-marker { display: none; }
-.agent-room-summary:hover { color: #c9d1d9; background: #161b22; }
+.agent-room-summary::-webkit-details-marker {
+  display: none;
+}
+.agent-room-summary:hover {
+  color: #c9d1d9;
+  background: #161b22;
+}
 .agent-room-summary::after {
   content: '▸';
   margin-left: auto;
   font-size: 10px;
   transition: transform 0.15s ease;
 }
-.agent-room[open] > .agent-room-summary::after { transform: rotate(90deg); }
-.agent-room-icon { font-size: 13px; }
+.agent-room[open] > .agent-room-summary::after {
+  transform: rotate(90deg);
+}
+.agent-room-icon {
+  font-size: 13px;
+}
 
 /* シーン本体。床（チェック模様）の上にゾーンを横並びにする。 */
 .agent-room-body {
@@ -1347,7 +1421,9 @@ body.pane-dragging * {
     linear-gradient(45deg, #161d2a 25%, transparent 25%, transparent 75%, #161d2a 75%),
     linear-gradient(45deg, #161d2a 25%, transparent 25%, transparent 75%, #161d2a 75%);
   background-size: 24px 24px;
-  background-position: 0 0, 12px 12px;
+  background-position:
+    0 0,
+    12px 12px;
 }
 
 .ar-stage {
@@ -1402,7 +1478,9 @@ body.pane-dragging * {
   background: repeating-linear-gradient(90deg, #6b4422 0 6px, #7a4f29 6px 12px);
   box-shadow: 0 2px 0 #4a2f17;
 }
-.ar-zone-table .ar-table-top .ar-zone-tag { bottom: -1px; }
+.ar-zone-table .ar-table-top .ar-zone-tag {
+  bottom: -1px;
+}
 
 /* 1 キャラ */
 .ar-char {
@@ -1443,7 +1521,10 @@ body.pane-dragging * {
   width: 18px;
   height: 18px;
 }
-.ar-coffee .ar-prop-svg { width: 18px; height: 18px; }
+.ar-coffee .ar-prop-svg {
+  width: 18px;
+  height: 18px;
+}
 /* 湯気 */
 .ar-coffee::before {
   content: '';
@@ -1465,7 +1546,10 @@ body.pane-dragging * {
   display: flex;
   justify-content: center;
 }
-.ar-desk .ar-prop-svg { width: 38px; height: 28px; }
+.ar-desk .ar-prop-svg {
+  width: 38px;
+  height: 28px;
+}
 
 /* 吹き出し（相談） */
 .ar-bubble {
@@ -1497,39 +1581,80 @@ body.pane-dragging * {
 
 /* ─── キャラの状態別アニメーション ─────────────────────────────────────────── */
 /* 待機: ゆっくり上下に揺れる */
-.ar-state-idle .ar-sprite-svg { animation: ar-bob 2.6s ease-in-out infinite; }
+.ar-state-idle .ar-sprite-svg {
+  animation: ar-bob 2.6s ease-in-out infinite;
+}
 /* 作業: 小刻みにタイピングするように細かく揺れる */
-.ar-state-working .ar-sprite-svg { animation: ar-type 0.5s steps(2, end) infinite; }
+.ar-state-working .ar-sprite-svg {
+  animation: ar-type 0.5s steps(2, end) infinite;
+}
 /* 相談: わずかに首を振る */
-.ar-state-consulting .ar-sprite-svg { animation: ar-nod 1.4s ease-in-out infinite; }
+.ar-state-consulting .ar-sprite-svg {
+  animation: ar-nod 1.4s ease-in-out infinite;
+}
 /* 離席: 薄く・グレースケール気味に */
-.ar-state-off { opacity: 0.35; filter: grayscale(0.8); }
+.ar-state-off {
+  opacity: 0.35;
+  filter: grayscale(0.8);
+}
 
 @keyframes ar-bob {
-  0%, 100% { transform: translateY(0); }
-  50%      { transform: translateY(-2px); }
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-2px);
+  }
 }
 @keyframes ar-type {
-  0%   { transform: translateY(0); }
-  100% { transform: translateY(-1px); }
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(-1px);
+  }
 }
 @keyframes ar-nod {
-  0%, 100% { transform: translateY(0) rotate(0deg); }
-  50%      { transform: translateY(-1px) rotate(-2deg); }
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-1px) rotate(-2deg);
+  }
 }
 @keyframes ar-steam {
-  0%   { opacity: 0;   transform: translateY(2px) scaleY(0.6); }
-  50%  { opacity: 0.7; transform: translateY(-1px) scaleY(1); }
-  100% { opacity: 0;   transform: translateY(-4px) scaleY(0.6); }
+  0% {
+    opacity: 0;
+    transform: translateY(2px) scaleY(0.6);
+  }
+  50% {
+    opacity: 0.7;
+    transform: translateY(-1px) scaleY(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-4px) scaleY(0.6);
+  }
 }
 @keyframes ar-bubble-pop {
-  0%, 100% { transform: translateX(-50%) translateY(0); opacity: 0.85; }
-  50%      { transform: translateX(-50%) translateY(-2px); opacity: 1; }
+  0%,
+  100% {
+    transform: translateX(-50%) translateY(0);
+    opacity: 0.85;
+  }
+  50% {
+    transform: translateX(-50%) translateY(-2px);
+    opacity: 1;
+  }
 }
 
 /* アニメーション抑制設定を尊重 */
 @media (prefers-reduced-motion: reduce) {
   .ar-sprite-svg,
   .ar-bubble,
-  .ar-coffee::before { animation: none !important; }
+  .ar-coffee::before {
+    animation: none !important;
+  }
 }


### PR DESCRIPTION
## 概要

CSS のフォーマット規約を明確にするため Prettier を導入し、`renderer/` 配下の CSS を統一フォーマットに整形します。あわせて mobile.css をセクション別に整理し見出しコメントを付与しました。

これまで CSS が「1ルール1行」に手で詰められており、1プロパティの変更でも行全体が差分になりレビューしづらい状態でした。Prettier 導入により今後は 1プロパティ1行の統一フォーマットが自動適用され、差分がプロパティ単位で追えるようになります。

### 変更内容

- `prettier@3.9.5` を devDependencies に追加
- `.prettierrc.json`（printWidth 100 / 2スペース / シングルクォート / セミコロンあり）・`.prettierignore` を追加
- npm scripts に `format`（整形）/ `format:check`（確認用）を追加
- `renderer/mobile.css` をセクション別（デザイントークン / ベース / ヘッダー / カード …）に整理し見出しコメントを付与
- `renderer/mobile.css` `renderer/style.css` を Prettier で 1プロパティ1行に整形

CSS ルール（値・セレクタ・詳細度）は一切変更しておらず、**描画結果・挙動は変更前と同一**です。

## 確認手順

1. ブランチを切り替えて依存をインストール
   ```
   git switch chore/prettier-css-format
   npm install
   ```
   → `prettier` が devDependencies に入る

2. フォーマットが統一されていることを確認
   ```
   npm run format:check
   ```
   → `All matched files use Prettier code style!` と表示される（差分なし）

3. ユニットテストが通ることを確認
   ```
   npm test
   ```
   → 110 tests / 0 fail

4. アプリを起動し、PC 版・モバイル版の表示が変更前と同じであることを確認
   ```
   npm start
   ```
   → カード・バッジ・ドット・PR リンク・使用量カード等の見た目が従来どおり。モバイルプレビューの最低高さ（min-height 140px）も維持

## スクリーンショット

本 PR は CSS の整形・セクション並べ替えのみで、出力される CSS ルールは同一（描画結果に変化なし）のため、[pull-request.md](https://github.com/vektor-inc/vk-terminals/blob/main/CHANGELOG.md) の「表示に影響がない場合は省略可」に従い Before/After スクリーンショットは省略します。

@coderabbitai ignore