### PR TITLE
[ 機能追加 ] 環境変数でデスクトップ／モバイルのヘッダーのアプリ名を上書きできる機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [ 機能追加 ] 呼び出し元が環境変数 `VK_TERMINALS_APP_TITLE` を渡すと、デスクトップとモバイル双方のヘッダー／タイトルのアプリ名を任意の名称に上書きできる機能を追加（未指定時は従来どおり `VK Terminals`）
+
 ## 1.17.1
 
 - [ 開発環境 ] モバイルプレビュー高さ縮小（#141）に伴い更新漏れしていた e2e テストの期待値を現行仕様（min-height 140px）に合わせて修正（[#145](https://github.com/vektor-inc/vk-terminals/issues/145)）

--- a/main.js
+++ b/main.js
@@ -49,6 +49,13 @@ const API_PORT = (() => {
 const DATA_DIR = path.join(os.homedir(), '.vk-terminals');
 const STATE_FILE = path.join(DATA_DIR, 'states.json');
 const LOG_PREFIX = '[vk-terminals]';
+// ウィンドウタイトルバーおよびヘッダーに表示するアプリ名。既定は 'VK Terminals'。
+// 呼び出し側（例: vk-orchestrator）が env VK_TERMINALS_APP_TITLE を渡すと、その名称
+// （例: 'VK Orchestrator'）を表示する。renderer には app:get-config 経由で伝える。
+const APP_TITLE = (() => {
+  const t = process.env.VK_TERMINALS_APP_TITLE;
+  return typeof t === 'string' && t.trim() ? t.trim() : 'VK Terminals';
+})();
 // /api/send で「本文 + 末尾 Enter」を 1 リクエストで受け取ったとき、本文と Enter を
 // 分割して送るまでの待機時間（ms）。本文と \r を 1 回の write でまとめて流すと、
 // Claude Code の TUI がペースト（複数行入力）扱いして末尾 \r を入力欄の改行として
@@ -468,7 +475,7 @@ function createWindow() {
     titleBarStyle: 'hiddenInset',
     trafficLightPosition: { x: 16, y: 12 },
     backgroundColor: '#0d1117',
-    title: 'VK Terminals',
+    title: APP_TITLE,
   });
 
   win.webContents.on('did-finish-load', () => {
@@ -506,6 +513,7 @@ ipcMain.handle('app:get-config', () => {
   const config = loadUserConfig();
   return {
     agentroom: false,
+    appTitle: APP_TITLE,
     newPaneStartupDir: typeof config.newPaneStartupDir === 'string' ? config.newPaneStartupDir.trim() : '',
     newPaneAutoLaunchClaude: config.newPaneAutoLaunchClaude === true,
   };
@@ -556,7 +564,7 @@ function builtinSettingsDescriptor() {
         fields: [
           { key: 'apiHost',        label: 'API ホスト',            type: 'text',    help: '既定 127.0.0.1' },
           { key: 'newPaneStartupDir', label: '新規ペインを開く時の初期ディレクトリ', type: 'text', placeholder: '/path/to/project', help: '新規ペインを開く時の作業ディレクトリを絶対パスで指定します。「Claude Code を自動起動する」設定が有効な場合は Claude もこのディレクトリで起動します。未入力の場合、または存在しないパスの場合はホームディレクトリで起動します。' },
-          { key: 'newPaneAutoLaunchClaude', label: '新規ペイン（子ターミナル）を開く時に自動的に Claude Code を起動する', type: 'boolean', default: false, help: 'チェックが入っている場合、新規ペインを開いた時に自動的に Claude Code が起動します。オフの場合は素のターミナルで起動します。' },
+          { key: 'newPaneAutoLaunchClaude', label: 'Claude Code を自動的に起動する', type: 'boolean', default: false, help: 'チェックが入っている場合、新規ペインを開いた時に自動的に Claude Code が起動します。オフの場合は素のターミナルで起動します。' },
           { key: 'initialCommand', label: '初期コマンド',          type: 'text',    help: 'Claude Code で起動する設定の場合、最初のペインで Claude 起動直後に自動実行させたいコマンドがあれば記入してください。毎日最初に実行するコマンドの入力を省略するための機能です。' },
           // showUsage（issue #69）は opt-out（既定 ON）。default:true で「未設定 boolean が
           // 保存時に false になる」問題を避ける（settings:describe / settings:save が default 尊重）。
@@ -1077,6 +1085,7 @@ function startHttpApi() {
             terminals: cachedStates,
             usage,
             version: require('./package.json').version,
+            appTitle: APP_TITLE,
           }));
         });
       return;

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -2728,6 +2728,13 @@ async function initApp() {
     agentRoomEnabled = !!(cfg && cfg.agentroom);
     newPaneStartupDir = (cfg && typeof cfg.newPaneStartupDir === 'string') ? cfg.newPaneStartupDir : '';
     newPaneAutoLaunchClaude = !!(cfg && cfg.newPaneAutoLaunchClaude);
+    // ヘッダー／タブのアプリ名。呼び出し側（例: vk-orchestrator）が env で上書きすると
+    // main が app:get-config で伝えてくる。未指定時は index.html の既定 'VK Terminals'。
+    if (cfg && typeof cfg.appTitle === 'string' && cfg.appTitle.trim()) {
+      const titleEl = document.querySelector('.app-title');
+      if (titleEl) titleEl.textContent = cfg.appTitle.trim();
+      document.title = cfg.appTitle.trim();
+    }
   } catch (_e) { /* 取得失敗時は無効のまま */ }
 
   // Dispose any existing terminals

--- a/renderer/mobile.html
+++ b/renderer/mobile.html
@@ -650,6 +650,18 @@ function ensureCard(termId) {
 // 文字列は textContent で入れるので XSS 面も安全。
 var usageCard = document.getElementById("usage-card");
 var appVersionFooter = document.getElementById("app-version-footer");
+var appTitleHeading = document.querySelector("header h1");
+
+// ヘッダー／タブ／フッターに表示するアプリ名。呼び出し元が env VK_TERMINALS_APP_TITLE を
+// 渡すと main が /api/states の appTitle で伝えてくる。未指定時は既定の "VK Terminals"。
+var appTitle = "VK Terminals";
+
+function renderAppTitle(title) {
+  var t = typeof title === "string" ? title.trim() : "";
+  appTitle = t || "VK Terminals";
+  if (appTitleHeading) appTitleHeading.textContent = appTitle;
+  document.title = appTitle + " - Remote";
+}
 
 function renderAppVersion(version) {
   if (!appVersionFooter) return;
@@ -659,7 +671,7 @@ function renderAppVersion(version) {
     appVersionFooter.classList.remove("show");
     return;
   }
-  appVersionFooter.textContent = "VK Terminals v" + v;
+  appVersionFooter.textContent = appTitle + " v" + v;
   appVersionFooter.classList.add("show");
 }
 
@@ -752,6 +764,7 @@ function renderUsage(usage) {
 }
 
 function render(data) {
+  renderAppTitle(data.appTitle);
   renderAppVersion(data.version);
   renderUsage(data.usage);
   var terms = data.terminals || {};

--- a/tests/e2e/app-title-override.smoke.spec.js
+++ b/tests/e2e/app-title-override.smoke.spec.js
@@ -1,0 +1,122 @@
+const { test, expect, _electron, chromium } = require('@playwright/test');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+// 環境変数 VK_TERMINALS_APP_TITLE によるアプリ名上書きの end-to-end 確認。
+//   - デスクトップ（renderer/index.html）のヘッダー .app-title が上書き名になる。
+//   - GET /api/states のレスポンス JSON に appTitle（= 上書き名）が含まれる。
+//   - モバイルページ（renderer/mobile.html）の <h1> とバージョンフッターが上書き名になる。
+// 呼び出し元（例: vk-orchestrator）が 'VK Orchestrator' を渡すユースケースの回帰を守る。
+
+const OVERRIDE_TITLE = 'VK Orchestrator';
+const repoRoot = path.resolve(__dirname, '..', '..');
+const pkgVersion = require(path.join(repoRoot, 'package.json')).version;
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : null;
+      server.close((err) => {
+        if (err) { reject(err); return; }
+        if (!port) { reject(new Error('failed to allocate a free port')); return; }
+        resolve(port);
+      });
+    });
+  });
+}
+
+// /api/states が appTitle を返し始めるまで短くリトライして待つ。
+async function waitForStatesWithAppTitle(port, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastJson = null;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/states`);
+      if (res.status === 200) {
+        const json = await res.json();
+        lastJson = json;
+        if (typeof json.appTitle === 'string' && json.appTitle) return json;
+      }
+    } catch (_e) {
+      // 起動前の fetch 失敗は同じループで吸収する。
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`/api/states did not return appTitle in time. last json: ${JSON.stringify(lastJson)}`);
+}
+
+// 一時 HOME を用意し、VK_TERMINALS_APP_TITLE を付与して Electron を起動する。
+async function launchApp(port) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-terminals-e2e-title-'));
+  const tmpHome = path.join(tmpRoot, 'home');
+  const configDir = path.join(tmpHome, '.vk-terminals');
+  const configPath = path.join(configDir, 'config.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    apiHost: '127.0.0.1',
+    initialCommand: '',
+    agentroom: false,
+    additionalPanes: [],
+  }), 'utf8');
+
+  const app = await _electron.launch({
+    args: ['.', '--no-claude'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: tmpHome,
+      USERPROFILE: tmpHome,
+      VK_TERMINALS_API_PORT: String(port),
+      VK_TERMINALS_APP_TITLE: OVERRIDE_TITLE,
+    },
+  });
+  await app.firstWindow();
+  return { app, tmpRoot };
+}
+
+// ─── デスクトップのヘッダー .app-title が上書き名になり、/api/states にも反映される ───
+test('デスクトップ: VK_TERMINALS_APP_TITLE でヘッダーと /api/states の appTitle が上書きされる', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  try {
+    const json = await waitForStatesWithAppTitle(port);
+    expect(json.appTitle).toBe(OVERRIDE_TITLE);
+
+    const win = await app.firstWindow();
+    const titleEl = win.locator('.app-title');
+    await expect(titleEl).toHaveText(OVERRIDE_TITLE, { timeout: 15_000 });
+  } finally {
+    await app.close().catch(() => {});
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── モバイルページの <h1> とバージョンフッターが上書き名になる ───
+test('モバイル: <h1> とフッターが VK_TERMINALS_APP_TITLE の上書き名になる', async () => {
+  const port = await getFreePort();
+  const { app, tmpRoot } = await launchApp(port);
+  const browser = await chromium.launch();
+  try {
+    await waitForStatesWithAppTitle(port);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    const heading = page.locator('header h1');
+    await expect(heading).toHaveText(OVERRIDE_TITLE, { timeout: 15_000 });
+
+    const footer = page.locator('#app-version-footer');
+    await expect(footer).toBeVisible({ timeout: 15_000 });
+    await expect(footer).toHaveText(`${OVERRIDE_TITLE} v${pkgVersion}`, { timeout: 15_000 });
+  } finally {
+    await browser.close().catch(() => {});
+    await app.close().catch(() => {});
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

呼び出し元（例: VK Orchestrator）が環境変数 `VK_TERMINALS_APP_TITLE` を渡すと、VK Terminals のヘッダー／タイトル表記を任意の名称（例: `VK Orchestrator`）に上書きできるようにしました。未指定時は従来どおり `VK Terminals` を表示します。

### 変更内容

- `main.js`
  - `VK_TERMINALS_APP_TITLE` を読む `APP_TITLE` 定数を追加（未指定・空文字なら `VK Terminals`）
  - ウィンドウの `title` を `APP_TITLE` に
  - `app:get-config`（デスクトップ renderer 用）と `/api/states`（モバイル用）のレスポンスに `appTitle` を追加
- `renderer/app.js`（デスクトップ）
  - 起動時に `app:get-config` の `appTitle` を受け取り、ヘッダーの `.app-title` と `document.title` を更新
- `renderer/mobile.html`（モバイル）
  - `/api/states` の `appTitle` を受け取り、`<h1>`・`document.title`・バージョンフッターの接頭辞を更新
- `tests/e2e/app-title-override.smoke.spec.js`
  - 上書き名がデスクトップヘッダー・`/api/states`・モバイル `<h1>`／フッターに反映されることを検証する smoke テストを追加

## 確認手順

### 上書きされること（After）

1. 環境変数を付けて起動する
   ```bash
   VK_TERMINALS_APP_TITLE="VK Orchestrator" npm start
   ```
2. デスクトップウィンドウ左上のヘッダー表記を確認する
   → `VK Orchestrator` と表示される
3. 別端末で `curl -s http://127.0.0.1:13847/api/states | grep -o '"appTitle":"[^"]*"'` を実行する
   → `"appTitle":"VK Orchestrator"` が返る
4. スマホ等から `http://<ホスト>:13847/` を開く
   → ヘッダー `<h1>` とページ最下部フッターが `VK Orchestrator`（フッターは `VK Orchestrator v<version>`）になる

### 既定挙動（デグレ確認）

1. 環境変数なしで `npm start`
   → ヘッダー・タイトル・モバイル表記がすべて従来どおり `VK Terminals`
2. e2e smoke テスト
   ```bash
   npx playwright test tests/e2e/app-title-override.smoke.spec.js tests/e2e/mobile-app-version.smoke.spec.js
   ```
   → いずれも green

## 備考

VK Orchestrator 側で GUI 起動時に `VK_TERMINALS_APP_TITLE=VK Orchestrator` を付与する変更を別 PR（vektor-inc/vk-orchestrator）で行います。実機反映には本リポジトリのリリース後、orchestrator 側の依存タグ更新が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 環境変数 `VK_TERMINALS_APP_TITLE` で、デスクトップ・モバイルのアプリ名やタイトルを任意に変更できるようになりました。
  * 未指定または空の場合は、従来どおり「VK Terminals」が表示されます。
* **改善**
  * 設定パネルの自動起動項目のラベルを、より分かりやすい表現に変更しました。
* **テスト**
  * アプリ名の上書きが各画面に正しく反映されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->